### PR TITLE
config: add RPC user+password, rework cookie auth

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,17 +1,28 @@
-use std::{
-    net::{Ipv4Addr, SocketAddr, SocketAddrV4},
-    path::PathBuf,
-};
+use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 
 use clap::Parser;
 
 #[derive(Parser)]
-pub struct Cli {
-    #[arg(default_value_t = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 18_443)), long)]
-    pub node_rpc_addr: SocketAddr,
+pub struct Config {
+    #[arg(default_value = "localhost", long)]
+    pub node_rpc_host: String,
 
-    #[arg(default_value = "../data/bitcoin", long)]
-    pub node_rpc_datadir: PathBuf,
+    #[arg(default_value = "18443", long)]
+    pub node_rpc_port: u16,
+
+    /// Path to Bitcoin Core cookie. Cannot be set together with user + password.
+    #[arg(long)]
+    pub node_rpc_cookie_path: Option<String>,
+
+    /// RPC user for Bitcoin Core. Implies also setting password.
+    /// Cannot be set together with cookie path.
+    #[arg(long)]
+    pub node_rpc_user: Option<String>,
+
+    /// RPC password for Bitcoin Core. Implies also setting user. Cannot
+    /// be set together with cookie path.
+    #[arg(long)]
+    pub node_rpc_password: Option<String>,
 
     #[arg(default_value_t = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 50_051)), long)]
     pub serve_rpc_addr: SocketAddr,

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,18 +48,19 @@ async fn run_server(bip300: Bip300, addr: SocketAddr) -> Result<()> {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let cli = cli::Cli::parse();
+    let cli = cli::Config::parse();
+    let serve_rpc_addr = cli.serve_rpc_addr;
 
     let bip300 = Bip300::new(Path::new("./"))?;
 
     let task = bip300
-        .run(&cli.node_rpc_datadir, cli.node_rpc_addr)
+        .run(cli)
         .map(|res| res.into_diagnostic())
         .map_err(|err| miette!("unable to initialize bip300 handler: {}", err))
         .unwrap_or_else(|err| eprintln!("{err:#}"));
 
     //let ((), ()) = future::try_join(task.map(Ok), run_server(bip300, addr)).await?;
-    match future::select(task, run_server(bip300, cli.serve_rpc_addr).boxed()).await {
+    match future::select(task, run_server(bip300, serve_rpc_addr).boxed()).await {
         Either::Left(((), server_task)) => {
             // continue to run server task
             server_task.await


### PR DESCRIPTION
1. Adds support for username + password when creating the Core RPC client
2. Removes the data dir parameter, and instead adds a parameter that takes in the cookie path directly. This removes the hardcoded 'regtest' network, as a byproduct. 