### PR TITLE
server: comments, error response for get_ctip, input validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Requirements
 
-1. Bitcoin Core running in regtest mode at `localhost:18443` using cookie auth
+1. Bitcoin Core
+1. Rust
 
 # Getting started
 
@@ -10,8 +11,16 @@ Building/running:
 # Compiles the project
 $ cargo build
 
+# See available options
+$ cargo run -- --help
+
 # Starts the gRPC server at localhost:50001
-$ cargo run
+# Adjust these parameters to match your local Bitcoin
+# Core instance
+$ cargo run -- cargo run -- \
+  --node-rpc-port=38332 \
+  --node-rpc-user=user \
+  --node-rpc-password=password
 
 # You should now be able to fetch data from the server!
 $ buf curl  --schema 'https://github.com/LayerTwo-Labs/bip300301_enforcer_proto.git' \
@@ -20,4 +29,17 @@ $ buf curl  --schema 'https://github.com/LayerTwo-Labs/bip300301_enforcer_proto.
 {
   "height": 2
 }
+```
+
+# Working with the proto files
+
+Code is generated with [protox](https://github.com/andrewhickman/protox), and
+happens automatically as part of the build process.
+
+Files are linted with [protolint](https://github.com/yoheimuta/protolint).
+
+To lint the files, run:
+
+```bash
+$ protolint lint --fix proto/validator/v1/validator.proto
 ```

--- a/proto/validator/v1/validator.proto
+++ b/proto/validator/v1/validator.proto
@@ -1,45 +1,41 @@
 syntax = "proto3";
 package validator.v1;
 
+import "google/protobuf/wrappers.proto";
+
 service ValidatorService {
   rpc ConnectBlock(ConnectBlockRequest) returns (ConnectBlockResponse);
   rpc DisconnectBlock(DisconnectBlockRequest) returns (DisconnectBlockResponse);
   rpc GetCoinbasePSBT(GetCoinbasePSBTRequest) returns (GetCoinbasePSBTResponse);
   rpc GetDeposits(GetDepositsRequest) returns (GetDepositsResponse);
 
-  rpc GetSidechainProposals(GetSidechainProposalsRequest)
-      returns (GetSidechainProposalsResponse);
+  rpc GetSidechainProposals(GetSidechainProposalsRequest) 
+    returns (GetSidechainProposalsResponse);
 
   rpc GetSidechains(GetSidechainsRequest) returns (GetSidechainsResponse);
 
+  // Fetch the chain tip (ctip) for a specific sidechain.
   rpc GetCtip(GetCtipRequest) returns (GetCtipResponse);
 
-  rpc GetMainBlockHeight(GetMainBlockHeightRequest)
-      returns (GetMainBlockHeightResponse);
+  rpc GetMainBlockHeight(GetMainBlockHeightRequest) 
+    returns (GetMainBlockHeightResponse);
 
   rpc GetMainChainTip(GetMainChainTipRequest) returns (GetMainChainTipResponse);
-
   /*
-    rpc ListSidechainProposals(ListSidechainProposalsRequest) returns
-    (ListSidechainProposalsResponse); rpc
-    ListActiveSidechains(ListActiveSidechainsRequest) returns
-    (ListActiveSidechainsResponse);
 
-    rpc ListProposedWithdrawalBundleIds(ListProposedWithdrawalBundleIdsRequest)
-    returns (ListProposedWithdrawalBundleIdsResponse); rpc
-    ListFailedWithdrawalBundleIds(ListFailedWithdrawalBundleIdsRequest) returns
-    (ListFailedWithdrawalBundleIdsResponse); rpc
-    ListSuccededWithdrawalBundleIds(ListSuccededWithdrawalBundleIdsRequest)
-    returns (ListSuccededWithdrawalBundleIdsResponse);
+     rpc ListProposedWithdrawalBundleIds(ListProposedWithdrawalBundleIdsRequest)
+     returns (ListProposedWithdrawalBundleIdsResponse); rpc
+     ListFailedWithdrawalBundleIds(ListFailedWithdrawalBundleIdsRequest) returns
+     (ListFailedWithdrawalBundleIdsResponse); rpc
+     ListSuccededWithdrawalBundleIds(ListSuccededWithdrawalBundleIdsRequest)
+     returns (ListSuccededWithdrawalBundleIdsResponse);
 
-    rpc GetWithdrawalBundle(GetWithdrawalBundleRequest) returns
-    (GetWithdrawalBundleResponse);
+     rpc GetWithdrawalBundle(GetWithdrawalBundleRequest) returns
+     (GetWithdrawalBundleResponse);
 
-    rpc ListDeposits(ListDepositsRequest) returns (ListDepositsResponse);
-
-    rpc IsBlockValid(IsBlockValidRequest) returns (IsBlockValidResponse);
-    rpc IsTransactionValid(IsTransactionValidRequest) returns
-    (IsTransactionValidResponse);
+     rpc IsBlockValid(IsBlockValidRequest) returns (IsBlockValidResponse);
+     rpc IsTransactionValid(IsTransactionValidRequest) returns
+     (IsTransactionValidResponse);
   */
 }
 
@@ -90,10 +86,10 @@ message GetCoinbasePSBTRequest {
   repeated AckSidechain ack_sidechains = 2;
   repeated ProposeBundle propose_bundles = 3;
   AckBundles ack_bundles = 4;
-};
+}
 message GetCoinbasePSBTResponse {
   bytes psbt = 1;
-};
+}
 
 enum AckBundlesTag {
   ACK_BUNDLES_TAG_UNSPECIFIED = 0;
@@ -137,7 +133,10 @@ message Deposit {
 }
 
 message GetCtipRequest {
-  uint32 sidechain_number = 1;
+  // Sidechain number to fetch chain tip for. This argument is in fact
+  // NOT optional! It is marked as such to clearly differentiate it
+  // from passing in 0, which is a valid sidechain number.
+  google.protobuf.UInt32Value sidechain_number = 1;
 }
 
 message GetCtipResponse {


### PR DESCRIPTION
1. Clarify what the `GetCtip` endpoint does through a comment in the proto file
2. Proper error handling in `GetCtip`: 
    1. Return an error if the sidechain is not found
    2. Make the sidechain number request field optional. This is to differentiate _not_ passing a number from _passing 0_. The former is invalid, and we indicate this with a proper error message
3. Update the README with more context for devving