### PR TITLE
multi: verify connection to mainchain, "start" wallet

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,5 @@
 # rust build artifacts
 target
+
+# git submodule
+cusf_sidechain_proto

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,7 +2,7 @@ use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 
 use clap::Parser;
 
-#[derive(Parser)]
+#[derive(Parser, Clone)]
 pub struct Config {
     #[arg(default_value = "localhost", long)]
     pub node_rpc_host: String,
@@ -26,4 +26,7 @@ pub struct Config {
 
     #[arg(default_value_t = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 50_051)), long)]
     pub serve_rpc_addr: SocketAddr,
+
+    #[arg(long)]
+    pub enable_wallet: bool,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use std::{net::SocketAddr, path::Path};
+use std::{net::SocketAddr, path::Path, sync::Arc};
 
 mod cli;
 mod gen;
@@ -8,15 +8,16 @@ mod validator;
 mod wallet;
 
 use clap::Parser;
-use futures::{
-    future::{self, Either},
-    FutureExt, TryFutureExt,
-};
+
+use futures::{future::select_all, TryFutureExt};
 use gen::validator::validator_service_server::ValidatorServiceServer;
 use miette::{miette, IntoDiagnostic, Result};
+
 use server::Validator;
+
 use tonic::transport::Server;
 use ureq_jsonrpc::Client;
+use wallet::Wallet;
 
 fn _create_client(main_datadir: &Path) -> Result<Client> {
     let auth = std::fs::read_to_string(main_datadir.join("regtest/.cookie")).into_diagnostic()?;
@@ -38,12 +39,12 @@ fn _create_client(main_datadir: &Path) -> Result<Client> {
     })
 }
 
-async fn run_server(bip300: Validator, addr: SocketAddr) -> Result<()> {
+async fn run_server(bip300: &Validator, addr: SocketAddr) -> Result<()> {
     println!("Listening for gRPC on {addr}");
     Server::builder()
-        .add_service(ValidatorServiceServer::new(bip300))
+        .add_service(ValidatorServiceServer::new(bip300.clone()))
         .serve(addr)
-        .map(|res| res.into_diagnostic())
+        .map_err(|err| miette!("error in validator server: {err:#}"))
         .await
 }
 
@@ -52,20 +53,83 @@ async fn main() -> Result<()> {
     let cli = cli::Config::parse();
     let serve_rpc_addr = cli.serve_rpc_addr;
 
-    let bip300 = Validator::new(Path::new("./"))?;
+    let enabled_wallet = cli.enable_wallet;
 
-    let task = bip300
-        .run(cli)
-        .map(|res| res.into_diagnostic())
-        .map_err(|err| miette!("unable to initialize bip300 handler: {}", err))
-        .unwrap_or_else(|err| eprintln!("{err:#}"));
-
-    //let ((), ()) = future::try_join(task.map(Ok), run_server(bip300, addr)).await?;
-    match future::select(task, run_server(bip300, serve_rpc_addr).boxed()).await {
-        Either::Left(((), server_task)) => {
-            // continue to run server task
-            server_task.await
+    let validator = match Validator::new(Path::new("./")) {
+        Ok(validator) => Arc::new(validator),
+        Err(err) => {
+            return Err(err);
         }
-        Either::Right((res, _task)) => res,
+    };
+
+    // Takes in data from the blockchain and updates the validator state
+    let run_validator_task = tokio::spawn({
+        let validator = Arc::clone(&validator);
+        async move { validator.run(&cli).await }
+    });
+
+    let mut tasks: Vec<tokio::task::JoinHandle<Result<(), miette::Error>>> = Vec::new();
+    tasks.push(run_validator_task);
+
+    let run_validator_server_task = tokio::spawn({
+        let validator = Arc::clone(&validator);
+        async move { run_server(&validator, serve_rpc_addr).await }
+    });
+    tasks.push(run_validator_server_task);
+
+    // "Start" the wallet. We're going to add a server here, and run this in a spawned task.
+    // That requires a bit more:
+    // 1. Proper configuration for connecting the wallet to the blockchain
+    // 2. A server for the wallet
+    //
+    // The point here is to prove that we can conditionally start a task.
+    if enabled_wallet {
+        let validator = Arc::clone(&validator);
+        let wallet = Wallet::new(Path::new("./wallet-db"), &validator)
+            .map_err(|e| miette!("failed to create wallet: {:?}", e))
+            .await?;
+
+        let run_wallet_task = tokio::spawn({
+            async move {
+                // this prints the wallet balance
+                // TODO: take the print statements ouf of the wallet, and into a return value
+                wallet
+                    .get_balance()
+                    .map_err(|e| miette!("failed to get wallet balance: {:?}", e))?;
+                Ok(())
+            }
+        });
+
+        tasks.push(run_wallet_task);
     }
+
+    // Wait for the first error or for all tasks to complete
+    let result = select_all(tasks.into_iter().map(|t| {
+        Box::pin(async move {
+            t.await
+                .unwrap_or_else(|e| Err(miette!("Task panicked: {}", e)))
+        })
+    }))
+    .await;
+
+    // Check if there was an error
+    if let (Err(e), _, _) = result {
+        return Err(e);
+    }
+    Ok(())
+
+    /*
+    match try_join_all(tasks.into_iter()).await {
+        Ok(_) => {
+            println!("Validator: tasks completed");
+            Ok(())
+        }
+        Err(err) => {
+            return Err(miette!("unable to run tasks: {err:#}"));
+        }
+        hm => {
+            println!("hm: {:?}", hm);
+            Ok(())
+        }
+    }*/
 }


### PR DESCRIPTION
1. Refactor the way we start tasks. Exit the entire application if any of the tasks fail
2. Verify we're able to connect to the mainchain on startup, with a short-timeout JSON-RPC request. 
3. Add a CLI option `--enable-wallet` for "starting" the wallet. Right now we just instantiate it, and verify that we're able to wire things correctly together. Note: you'll most likely **not** be able to do this, as the wallet has hard coded paths to an Electrum server that needs to be running. If you see "failed to create wallet:   × Connection refused (os error 61)", that means its "working". 