### PR TITLE
validator: include original heed error in TryGet

### DIFF
--- a/src/validator/dbs/util.rs
+++ b/src/validator/dbs/util.rs
@@ -176,8 +176,9 @@ pub mod db_error {
 
     #[derive(Debug, Error)]
     #[error(
-        "Failed to read from db `{db_name}` at `{db_path}` ({})",
-        display_key_bytes(.key_bytes)
+        "Failed to read from db `{db_name}` at `{db_path}` ({}): {}",
+        display_key_bytes(.key_bytes),
+        .source
     )]
     pub struct TryGet {
         pub(super) db_name: &'static str,


### PR DESCRIPTION
This makes the error more scrutable. 

Currently when I try GetBlockHeaderInfo I get this: 

```json
{
   "code": "unknown",
   "message": "Failed to read from db `block_hash_to_header` at `././bip300301_enforcer/signet.mdb` (key: `200000000000000021755015219a84cb8548aeffe5b067899da7ceac37cd250bedb6a6ee29030000`): error while decoding: io error: unexpected end of file"
}
```