### PR TITLE
validator: add function + test for creating sidechain proposal

### DIFF
--- a/.github/workflows/check_lint_build_release.yaml
+++ b/.github/workflows/check_lint_build_release.yaml
@@ -1,6 +1,6 @@
 on: [pull_request, push]
 
-name: Check, Lint, Build, Release
+name: Check, Lint, Test, Build, Release
 
 env:
   CARGO_TERM_COLOR: always
@@ -36,7 +36,7 @@ jobs:
       - name: Clippy
         run: cargo clippy --all-targets --all-features
 
-  build-release:
+  test-build-release:
     strategy:
       fail-fast: false
       matrix:
@@ -56,7 +56,7 @@ jobs:
             binary-suffix: .exe
             rustflags: "-C linker=/usr/bin/x86_64-w64-mingw32-gcc"
 
-    name: Build, Release (${{ matrix.name }})
+    name: Test, Build, Release (${{ matrix.name }})
     runs-on: ${{ matrix.os }}
     needs: [check-lint]
     permissions:
@@ -81,6 +81,9 @@ jobs:
       - name: Install mingw-w64
         run: sudo apt install mingw-w64
         if: ${{ matrix.name == 'x86_64-pc-windows-gnu' }}
+
+      - name: Test
+        run: cargo test --all-targets --all-features
 
       - name: Build
         run: cargo build --release --target ${{ matrix.name }}
@@ -118,7 +121,7 @@ jobs:
   upload-releases-to-releases-drivechain-info:
     name: Upload releases to releases.drivechain.info
     runs-on: ubuntu-latest
-    needs: [build-release]
+    needs: [test-build-release]
     if: github.ref == 'refs/heads/master'
     steps:
       - name: Download artifacts

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use tower_http::trace::{DefaultOnFailure, DefaultOnResponse, TraceLayer};
 use tracing_subscriber::{filter as tracing_filter, layer::SubscriberExt};
 
 mod cli;
+mod messages;
 mod proto;
 mod rpc_client;
 mod server;


### PR DESCRIPTION
This partially implements the solution sketched out here: https://github.com/LayerTwo-Labs/cusf_sidechain_proto/pull/5#discussion_r1793646099

After https://github.com/LayerTwo-Labs/cusf_sidechain_proto/pull/5 is landed, the idea is to add an endpoint that exposes this functionality. 

~One issue: this is not behaving precisely as expected... I'm unsure if this is due do a bug in one of the upstream bip300 libraries, or due to me misunderstanding things. See https://github.com/LayerTwo-Labs/bip300301_enforcer/pull/28/files#diff-a8412c4f5f378292029d100f76c5941c636af5cc429f504e82a636f1946fc3d2R1026-R1030~

The above was a misunderstanding on my part! Cleared up after talking with @Ash-L2L in private. 