### PR TITLE
validator: split validation issues from operation errors

### DIFF
--- a/src/proto.rs
+++ b/src/proto.rs
@@ -422,7 +422,7 @@ pub mod mainchain {
     impl From<crate::types::WithdrawalBundleEvent> for (SidechainNumber, WithdrawalBundleEvent) {
         fn from(event: crate::types::WithdrawalBundleEvent) -> Self {
             let crate::types::WithdrawalBundleEvent {
-                sidechain_id,
+                sidechain_number,
                 m6id,
                 kind,
             } = event;
@@ -431,7 +431,7 @@ pub mod mainchain {
                 m6id: Some(ConsensusHex::encode(&m6id)),
                 withdrawal_bundle_event_type,
             };
-            (sidechain_id, event)
+            (sidechain_number, event)
         }
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -97,7 +97,7 @@ pub enum WithdrawalBundleEventKind {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct WithdrawalBundleEvent {
-    pub sidechain_id: SidechainNumber,
+    pub sidechain_number: SidechainNumber,
     pub m6id: Hash256,
     pub kind: WithdrawalBundleEventKind,
 }


### PR DESCRIPTION
Alternative to #55 and #54 

Invalid MX messages are "okay" - in that they shoudln't crash our chain
sync progress. We therefore separate them from operational errors, such
as writing/reading to/from the database and other issues that IS in fact
things that should take us down.

Some of these message are just fine to ignore, whereas some of them
should result in blocl invalidation. This comes later!
