### PR TITLE
multi: implement create_deposit_transaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
    password=password
    signetblocktime=60
    signetchallenge=00141f61d57873d70d28bd28b3c9f9d6bf818b5a0d6a
+   acceptnonstdtxn=1 # Important! Otherwise Core rejects OP_DRIVECHAIN TXs
 
    # this can also be set to a different address, as long
    # as you set the CLI arg for bip300301_enforcer
@@ -35,7 +36,7 @@ $ cargo run -- --help
 # Adjust these parameters to match your local Bitcoin
 # Core instance
 $ cargo run -- \
-  --node-rpc-port=38332 \
+  --node-rpc-addr-=localhost:38332 \
   --node-rpc-user=user \
   --node-rpc-pass=password \
   --node-zmq-addr-sequence=tcp://0.0.0.0:29000

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -1,0 +1,44 @@
+use bdk::bitcoin::consensus::Decodable;
+
+pub fn bdk_block_hash_to_bitcoin_block_hash(hash: bdk::bitcoin::BlockHash) -> bitcoin::BlockHash {
+    use bdk::bitcoin::hashes::Hash as _;
+    let bytes = hash.as_byte_array().to_vec();
+
+    use bitcoin::hashes::sha256d::Hash;
+    use bitcoin::hashes::Hash as _;
+    let hash: bitcoin::hashes::sha256d::Hash = Hash::from_slice(&bytes).unwrap();
+
+    bitcoin::BlockHash::from_raw_hash(hash)
+}
+
+pub fn bitcoin_tx_to_bdk_tx(
+    tx: bitcoin::Transaction,
+) -> Result<bdk::bitcoin::Transaction, bdk::bitcoin::consensus::encode::Error> {
+    let tx_bytes = bitcoin::consensus::serialize(&tx);
+
+    let decoded = bdk::bitcoin::Transaction::consensus_decode(&mut tx_bytes.as_slice())?;
+
+    Ok(decoded)
+}
+
+pub fn bdk_txid_to_bitcoin_txid(txid: bdk::bitcoin::Txid) -> bitcoin::Txid {
+    use bdk::bitcoin::hashes::Hash as _;
+    let bytes = txid.to_byte_array();
+
+    use bitcoin::hashes::sha256d::Hash;
+    use bitcoin::hashes::Hash as _;
+    let hash: bitcoin::hashes::sha256d::Hash = Hash::from_byte_array(bytes);
+
+    bitcoin::Txid::from_raw_hash(hash)
+}
+
+pub fn bitcoin_txid_to_bdk_txid(txid: bitcoin::Txid) -> bdk::bitcoin::Txid {
+    use bitcoin::hashes::Hash as _;
+    let bytes = txid.to_byte_array();
+
+    use bdk::bitcoin::hashes::sha256d::Hash;
+    use bdk::bitcoin::hashes::Hash as _;
+    let hash: bdk::bitcoin::hashes::sha256d::Hash = Hash::from_byte_array(bytes);
+
+    bdk::bitcoin::Txid::from_raw_hash(hash)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use tower_http::trace::{DefaultOnFailure, DefaultOnResponse, TraceLayer};
 use tracing_subscriber::{filter as tracing_filter, layer::SubscriberExt};
 
 mod cli;
+mod convert;
 mod messages;
 mod proto;
 mod rpc_client;

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -1,10 +1,11 @@
+use bitcoin::script::{Instruction, Instructions};
 use bitcoin::{
     hashes::{sha256d, Hash},
     opcodes::{
         all::{OP_NOP5, OP_PUSHBYTES_1, OP_RETURN},
         OP_TRUE,
     },
-    script::{Instruction, Instructions, PushBytesBuf},
+    script::PushBytesBuf,
     Amount, Opcode, Script, ScriptBuf, Transaction, TxOut,
 };
 use byteorder::{ByteOrder, LittleEndian};
@@ -226,6 +227,24 @@ pub fn parse_op_drivechain(input: &[u8]) -> IResult<&[u8], SidechainNumber> {
     let sidechain_number = sidechain_number[0];
     tag(&[OP_TRUE.to_u8()])(input)?;
     Ok((input, SidechainNumber::from(sidechain_number)))
+}
+
+pub fn create_m5_deposit_output(
+    sidechain_number: SidechainNumber,
+    old_ctip_amount: Amount,
+    deposit_amount: Amount,
+) -> TxOut {
+    let script_pubkey = ScriptBuf::from_bytes(vec![
+        OP_DRIVECHAIN.to_u8(),
+        OP_PUSHBYTES_1.to_u8(),
+        sidechain_number.into(),
+        OP_TRUE.to_u8(),
+    ]);
+    TxOut {
+        script_pubkey,
+        // All deposits INCREASE the amount locked in the OP_DRIVECHAIN output.
+        value: old_ctip_amount + deposit_amount,
+    }
 }
 
 fn parse_m1_propose_sidechain(input: &[u8]) -> IResult<&[u8], CoinbaseMessage> {

--- a/src/validator/mod.rs
+++ b/src/validator/mod.rs
@@ -182,7 +182,9 @@ impl Validator {
         Ok(sequence_number)
     }
 
-    pub fn get_ctip(
+    /// Returns `Some` with the Ctip for the given sidechain number. `None`
+    /// if there's no Ctip for the given sidechain number.
+    pub fn try_get_ctip(
         &self,
         sidechain_number: SidechainNumber,
     ) -> Result<Option<Ctip>, miette::Report> {

--- a/src/wallet/error.rs
+++ b/src/wallet/error.rs
@@ -118,3 +118,8 @@ pub struct BitcoinCoreRPC {
 #[error("failed to consensus encode block")]
 #[diagnostic(code(encode_block_error))]
 pub struct EncodeBlock(#[from] pub bitcoin::io::Error);
+
+#[derive(Debug, Diagnostic, Error)]
+#[error("BDK wallet error: {0}")]
+#[diagnostic(code(bdk_wallet_error))]
+pub struct WalletError(#[from] pub bdk::Error);


### PR DESCRIPTION
~This is currently not working.~

~I'm not sure how to add the previous Ctip to the OP_DRIVECHAIN TX. I'm using `add_foreign_utxo`, but don't know how to obtain the `psbt_input` and `satisfaction_weight` values to pass in as parameters to that method. ~

~I'm able to create a transaction, but having some issues with both broadcasting as well as adding the previous Ctip for the sidechain.~

Update: was able to broadcast the TX, with help from @CryptAxe . Was missing the `acceptnonstdtxn` parameter for my local Core node. Updated the README.

Example of a created transaction: 

```
01000000000101516a86d7e375cd3295288eaed9b691734e5a218e7e02c99fff6e8196977b84b40100000000feffffff030000000000000000086a06666f6f626172d20400000000000004b4010051a114f505000000001600144d5107fd06c1935a71774c597e75f559def104c502473044022064fedbef71712c56a49449c61e84d97d80dd29501aa1ac8cac3ac8d6ecca4be9022015bf7c74b97463a10ddca461cc7155208a351b4f9a0a47e6fb153ac4bc46a479012103355f95c00c42a6f5211336d22b8a34e121b9bbdf79f0e9e8cab5479835e59f5b6b860000
```

This decodes to: 

```
{
  "txid": "e384460220fd04348d2b74488710d2f3ffd772332aa3be9662f62a18f80f9aaf",
  "hash": "ed8449eb824f6f9629a9a4567faefde782140cc9c7aae8a8e6eda00af3052747",
  "version": 1,
  "size": 221,
  "vsize": 140,
  "weight": 557,
  "locktime": 34411,
  "vin": [
    {
      "txid": "b4847b9796816eff9fc9027e8e215a4e7391b6d9ae8e289532cd75e3d7866a51",
      "vout": 1,
      "scriptSig": {
        "asm": "",
        "hex": ""
      },
      "txinwitness": [
        "3044022064fedbef71712c56a49449c61e84d97d80dd29501aa1ac8cac3ac8d6ecca4be9022015bf7c74b97463a10ddca461cc7155208a351b4f9a0a47e6fb153ac4bc46a47901",
        "03355f95c00c42a6f5211336d22b8a34e121b9bbdf79f0e9e8cab5479835e59f5b"
      ],
      "sequence": 4294967294
    }
  ],
  "vout": [
    {
      "value": 0.00000000,
      "n": 0,
      "scriptPubKey": {
        "asm": "OP_RETURN 666f6f626172",
        "desc": "raw(6a06666f6f626172)#jpksrptg",
        "hex": "6a06666f6f626172",
        "type": "nulldata"
      }
    },
    {
      "value": 0.00001234,
      "n": 1,
      "scriptPubKey": {
        "asm": "OP_NOP5 0 1",
        "desc": "raw(b4010051)#zv47nv5u",
        "hex": "b4010051",
        "type": "nonstandard"
      }
    },
    {
      "value": 0.99947681,
      "n": 2,
      "scriptPubKey": {
        "asm": "0 4d5107fd06c1935a71774c597e75f559def104c5",
        "desc": "addr(tb1qf4gs0lgxcxf45uthf3vhua04t800zpx9genuwr)#3gxj5n9e",
        "hex": "00144d5107fd06c1935a71774c597e75f559def104c5",
        "address": "tb1qf4gs0lgxcxf45uthf3vhua04t800zpx9genuwr",
        "type": "witness_v0_keyhash"
      }
    }
  ]
}

```


