### PR TITLE
multi: use RPC-based blockchain backend on regtest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,14 +315,14 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 [[package]]
 name = "bdk"
 version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fc1fc1a92e0943bfbcd6eb7d32c1b2a79f2f1357eb1e2eee9d7f36d6d7ca44a"
+source = "git+https://github.com/torkelrogstad/bdk?branch=2024-10-30-rpc-patch#4b3c803dd17d76c168333684fae52b51376f6fae"
 dependencies = [
  "ahash 0.7.8",
  "async-trait",
  "bdk-macros",
  "bip39",
  "bitcoin 0.30.2",
+ "core-rpc",
  "electrum-client",
  "getrandom",
  "js-sys",
@@ -750,6 +750,32 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "core-rpc"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d77079e1b71c2778d6e1daf191adadcd4ff5ec3ccad8298a79061d865b235b"
+dependencies = [
+ "bitcoin-private",
+ "core-rpc-json",
+ "jsonrpc",
+ "log",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "core-rpc-json"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581898ed9a83f31c64731b1d8ca2dfffcfec14edf1635afacd5234cddbde3a41"
+dependencies = [
+ "bitcoin 0.30.2",
+ "bitcoin-private",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -1731,6 +1757,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonrpc"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd8d6b3f301ba426b30feca834a2a18d48d5b54e5065496b5c1b05537bee3639"
+dependencies = [
+ "base64 0.13.1",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,11 @@ tonic-build = "0.12.3"
 [dependencies]
 anyhow = "1.0.89"
 async-broadcast = "0.7.1"
-bdk = { version = "0.29.0", features = ["all-keys", "sqlite"] }
+bdk = { version = "0.29.0", features = [
+    "all-keys",
+    "sqlite",
+    "rpc",
+], git = "https://github.com/torkelrogstad/bdk", branch = "2024-10-30-rpc-patch" }
 bincode = "1.3.3"
 bitcoin = "0.32.3"
 blake3 = "1.5.4"

--- a/src/main.rs
+++ b/src/main.rs
@@ -200,11 +200,12 @@ async fn main() -> Result<()> {
     let wallet: Option<Arc<wallet::Wallet>> = if cli.enable_wallet {
         let wallet = Wallet::new(
             &wallet_data_dir,
+            &cli.node_rpc_opts,
             &cli.wallet_opts,
             mainchain_client,
             validator.clone(),
         )
-        .map_err(|e| miette!("failed to create wallet: {:?}", e))
+        .map_err(|e| miette!("failed to create wallet: {:#}", e))
         .await?;
         Some(Arc::new(wallet))
     } else {

--- a/src/wallet/blockchain.rs
+++ b/src/wallet/blockchain.rs
@@ -1,0 +1,141 @@
+use std::{cell::RefCell, collections::HashSet};
+
+use bdk::{
+    self,
+    bitcoin::{Network, Transaction, Txid},
+    blockchain::{
+        rpc::RpcBlockchainFactory, BlockchainFactory as _, ElectrumBlockchain, Progress,
+        RpcBlockchain,
+    },
+    database::BatchDatabase,
+    electrum_client::ConfigBuilder,
+};
+use miette::{miette, IntoDiagnostic as _, Result};
+
+use crate::{
+    cli::{NodeRpcConfig, WalletConfig},
+    rpc_client,
+};
+
+// Wrapper for different blockchain backends, that allow the wallet to dynamically
+// choose one at run-time.
+pub(crate) enum Type {
+    Electrum(ElectrumBlockchain),
+    Rpc(RpcBlockchain),
+}
+
+impl Type {
+    pub(crate) fn new<T: BatchDatabase>(
+        network: Network,
+        node_config: &NodeRpcConfig,
+        wallet_config: &WalletConfig,
+        wallet: &bdk::Wallet<T>,
+    ) -> Result<Self> {
+        if network == Network::Regtest {
+            tracing::debug!("Creating RPC blockchain client");
+
+            let factory = RpcBlockchainFactory {
+                url: node_config.addr.to_string(),
+                auth: rpc_client::create_auth(node_config)?,
+                network,
+                wallet_name_prefix: None,
+                sync_params: None,
+                default_skip_blocks: 0,
+            };
+
+            let blockchain = factory.build_for_wallet(wallet, None).into_diagnostic()?;
+
+            return Ok(Type::Rpc(blockchain));
+        }
+
+        let electrum_url = format!(
+            "{}:{}",
+            wallet_config.electrum_host, wallet_config.electrum_port
+        );
+
+        tracing::debug!("Creating electrum blockchain client: {electrum_url}");
+
+        // Apply a reasonably short timeout to prevent the wallet from hanging
+        let timeout = 5;
+        let config = ConfigBuilder::new().timeout(Some(timeout)).build();
+
+        let electrum_client = bdk::electrum_client::Client::from_config(&electrum_url, config)
+            .map_err(|err| miette!("failed to create electrum client: {err:#}"))?;
+
+        Ok(Type::Electrum(ElectrumBlockchain::from(electrum_client)))
+    }
+}
+
+impl bdk::blockchain::Blockchain for Type {
+    fn get_capabilities(&self) -> HashSet<bdk::blockchain::Capability> {
+        match self {
+            Type::Electrum(b) => b.get_capabilities(),
+            Type::Rpc(b) => b.get_capabilities(),
+        }
+    }
+
+    fn broadcast(&self, tx: &bdk::bitcoin::Transaction) -> Result<(), bdk::Error> {
+        match self {
+            Type::Electrum(b) => b.broadcast(tx),
+            Type::Rpc(b) => b.broadcast(tx),
+        }
+    }
+
+    fn estimate_fee(&self, target: usize) -> Result<bdk::FeeRate, bdk::Error> {
+        match self {
+            Type::Electrum(b) => b.estimate_fee(target),
+            Type::Rpc(b) => b.estimate_fee(target),
+        }
+    }
+}
+
+impl bdk::blockchain::GetBlockHash for Type {
+    fn get_block_hash(&self, height: u64) -> Result<bdk::bitcoin::BlockHash, bdk::Error> {
+        match self {
+            Type::Electrum(b) => b.get_block_hash(height),
+            Type::Rpc(b) => b.get_block_hash(height),
+        }
+    }
+}
+
+impl bdk::blockchain::GetTx for Type {
+    fn get_tx(&self, txid: &Txid) -> Result<Option<Transaction>, bdk::Error> {
+        match self {
+            Type::Electrum(b) => b.get_tx(txid),
+            Type::Rpc(b) => b.get_tx(txid),
+        }
+    }
+}
+
+impl bdk::blockchain::GetHeight for Type {
+    fn get_height(&self) -> Result<u32, bdk::Error> {
+        match self {
+            Type::Electrum(b) => b.get_height(),
+            Type::Rpc(b) => b.get_height(),
+        }
+    }
+}
+
+impl bdk::blockchain::WalletSync for Type {
+    fn wallet_setup<D: BatchDatabase>(
+        &self,
+        database: &RefCell<D>,
+        progress_update: Box<dyn Progress>,
+    ) -> Result<(), bdk::Error> {
+        match self {
+            Type::Electrum(b) => b.wallet_setup(database, progress_update),
+            Type::Rpc(b) => b.wallet_setup(database, progress_update),
+        }
+    }
+
+    fn wallet_sync<D: BatchDatabase>(
+        &self,
+        database: &RefCell<D>,
+        progress_update: Box<dyn Progress>,
+    ) -> Result<(), bdk::Error> {
+        match self {
+            Type::Electrum(b) => b.wallet_sync(database, progress_update),
+            Type::Rpc(b) => b.wallet_sync(database, progress_update),
+        }
+    }
+}


### PR DESCRIPTION
The PR relies on this bdk-patch: https://github.com/torkelrogstad/bdk/commit/4b3c803dd17d76c168333684fae52b51376f6fae