### PR TITLE
wallet: remove mempool + deposits tables, fetch raw mempool in block construction

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -87,7 +87,7 @@ impl IntoStatus for miette::Report {
         }
 
         tracing::warn!("Unable to convert miette::Report to a meaningful tonic::Status: {self:?}");
-        tonic::Status::new(tonic::Code::Unknown, self.to_string())
+        tonic::Status::new(tonic::Code::Unknown, format!("{self:#}"))
     }
 }
 

--- a/src/validator/task/mod.rs
+++ b/src/validator/task/mod.rs
@@ -364,7 +364,6 @@ fn handle_m5_m6(
         total_value: new_total_value,
         previous_total_value: old_total_value,
     };
-    dbg!(&treasury_utxo);
 
     let mut res = None;
     // M6


### PR DESCRIPTION
The two tables `deposits` and `mempool` were used to fetch pending
sidechain deposits that should be included in newly generated blocks.
These tables were never written to, and therefore sidechain deposits
didn't get included either.

Instead of keeping these tables in sync with the raw mempool, we fetch
this with RPC inside the block construction process.

With this branch I was able to make a sidechain deposit on my local regtest. Note that I was **not** able to do a second sidechain deposit. This is because the second sidechain deposit requires us to spend the previous ctip, and the wallet fails to sign this. This is not new behavior, but rather a bug (I believe) in how we add the foreign UTXO when constructing the deposit transaction. I think this would be best handled in a different PR. 