### PR TITLE
server/wallet: dont decode op_return_message

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -1002,12 +1002,6 @@ impl WalletService for Arc<crate::wallet::Wallet> {
             .transpose()
             .map_err(|err: crate::proto::Error| err.into_status())?;
 
-        let op_return_message = op_return_message
-            .map(|op_return_message| {
-                op_return_message.decode_tonic::<SendTransactionRequest, _>("op_return_message")
-            })
-            .transpose()?;
-
         let txid = self
             .send_wallet_transaction(destinations_validated, fee_policy, op_return_message)
             .await


### PR DESCRIPTION
See https://github.com/LayerTwo-Labs/cusf_sidechain_proto/pull/28 for motivation and why this is necessary.