### PR TITLE
Include M3/M4 messages in mined blocks, handle Deposits and Withdrawals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,7 +250,7 @@ dependencies = [
  "pin-project-lite",
  "rustversion",
  "serde",
- "sync_wrapper 1.0.1",
+ "sync_wrapper 1.0.2",
  "tower 0.5.1",
  "tower-layer",
  "tower-service",
@@ -271,7 +271,7 @@ dependencies = [
  "mime",
  "pin-project-lite",
  "rustversion",
- "sync_wrapper 1.0.1",
+ "sync_wrapper 1.0.2",
  "tower-layer",
  "tower-service",
 ]
@@ -1969,9 +1969,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a73e9fe3c49d7afb2ace819fa181a287ce54a0983eda4e0eb05c22f82ffe534"
+checksum = "540654e97a3f4470a492cd30ff187bc95d89557a903a2bbf112e2fae98104ef2"
 
 [[package]]
 name = "jni"
@@ -2684,9 +2684,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.89"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
+checksum = "307e3004becf10f5a6e0d59d20f3cd28231b0e0827a96cd3e0ce6d14bc1e4bb3"
 dependencies = [
  "unicode-ident",
 ]
@@ -3010,7 +3010,7 @@ dependencies = [
  "rustls-webpki",
  "security-framework",
  "security-framework-sys",
- "webpki-roots 0.26.6",
+ "webpki-roots 0.26.7",
  "winapi",
 ]
 
@@ -3361,9 +3361,9 @@ checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "syn"
-version = "2.0.87"
+version = "2.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
+checksum = "44d46482f1c1c87acd84dea20c1bf5ebff4c757009ed6bf19cfd36fb10e92c4e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3378,9 +3378,9 @@ checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "sync_wrapper"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "synchronoise"
@@ -4002,9 +4002,9 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.6"
+version = "0.26.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841c67bff177718f1d4dfefde8d8f0e78f9b6589319ba88312f567fc5841a958"
+checksum = "5d642ff16b7e79272ae451b7322067cdc17cadf68c23264be9d94a32319efe7e"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,9 +46,9 @@ dependencies = [
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.18"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
+checksum = "45862d1c77f2228b9e10bc609d5bc203d86ebc9b87ad8d5d5167a6c9abf739d9"
 
 [[package]]
 name = "android-tzdata"
@@ -67,9 +67,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.17"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23a1e53f0f5d86382dafe1cf314783b2044280f406e7e1506368220ad11b1338"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -116,9 +116,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.92"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f37166d7d48a0284b99dd824694c26119c700b53bf0d1540cdb147dbdaaf13"
+checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
 
 [[package]]
 name = "arrayref"
@@ -204,9 +204,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd82dba44d209fddb11c190e0a94b78651f95299598e472215667417a03ff1d"
+checksum = "fe7c2840b66236045acd2607d5866e274380afd87ef99d6226e961e2cb47df45"
 dependencies = [
  "aws-lc-sys",
  "mirai-annotations",
@@ -216,9 +216,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df7a4168111d7eb622a31b214057b8509c0a7e1794f44c546d742330dc793972"
+checksum = "ad3a619a9de81e1d7de1f1186dcba4506ed661a0e483d84410fdef0ee87b2f96"
 dependencies = [
  "bindgen",
  "cc",
@@ -231,9 +231,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.7.7"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "504e3947307ac8326a5437504c517c4b56716c9d98fac0028c2acc7ca47d70ae"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -668,9 +668,9 @@ checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
 
 [[package]]
 name = "cc"
-version = "1.1.34"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b9470d453346108f93a59222a9a1a5724db32d0a4727b7ab7ace4b4d822dc9"
+checksum = "fd9de9f2205d5ef3fd67e685b0df337994ddd4495e2a28d185500d0e1edfea47"
 dependencies = [
  "jobserver",
  "libc",
@@ -724,9 +724,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.20"
+version = "4.5.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8"
+checksum = "fb3b4b9e5a7c7514dfa52869339ee98b3156b0bfb4e8a77c4ff4babb64b1604f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -734,9 +734,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.20"
+version = "4.5.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19bc80abd44e4bed93ca373a0704ccbd1b710dc5749406201bb018272808dc54"
+checksum = "b17a95aa67cc7b5ebd32aa5370189aa0d79069ef1c64ce893bd30fb24bff20ec"
 dependencies = [
  "anstream",
  "anstyle",
@@ -758,9 +758,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
+checksum = "afb84c814227b90d6895e01398aee0d8033c00e7466aca416fb6a8e0eb19d8a7"
 
 [[package]]
 name = "cmake"
@@ -826,9 +826,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
+checksum = "0ca741a962e1b0bff6d724a1a0958b686406e853bb14061f218562e1896f95e6"
 dependencies = [
  "libc",
 ]
@@ -1193,9 +1193,9 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
+checksum = "486f806e73c5707928240ddc295403b1b93c96a02038563881c4a2fd84b81ac4"
 
 [[package]]
 name = "fatality"
@@ -1453,9 +1453,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
+checksum = "ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1498,9 +1498,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
 
 [[package]]
 name = "hashlink"
@@ -1678,9 +1678,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbbff0a806a4728c99295b254c8838933b5b082d75e3cb70c8dab21fdfbcfa9a"
+checksum = "97818827ef4f364230e16705d4706e2897df2bb60617d6ca15d598025a3c481f"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1933,7 +1933,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.0",
+ "hashbrown 0.15.1",
  "serde",
 ]
 
@@ -1969,9 +1969,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+checksum = "7a73e9fe3c49d7afb2ace819fa181a287ce54a0983eda4e0eb05c22f82ffe534"
 
 [[package]]
 name = "jni"
@@ -2168,9 +2168,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.161"
+version = "0.2.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
+checksum = "433bfe06b8c75da9b2e3fbea6e5329ff87748f0b144ef75306e674c3f6f7c13f"
 
 [[package]]
 name = "libloading"
@@ -2840,7 +2840,7 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.8",
+ "regex-automata 0.4.9",
  "regex-syntax 0.8.5",
 ]
 
@@ -2855,9 +2855,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2938,9 +2938,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.38"
+version = "0.38.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa260229e6538e52293eeb577aabd09945a09d6d9cc0fc550ed7529056c2e32a"
+checksum = "d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
@@ -2951,9 +2951,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.16"
+version = "0.23.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eee87ff5d9b36712a58574e12e9f0ea80f915a5b0ac518d322b24a465617925e"
+checksum = "7f1a745511c54ba6d4465e8d5dfbd81b45791756de28d4981af70d6dca128f1e"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -3055,9 +3055,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01227be5826fa0690321a2ba6c5cd57a19cf3f6a09e76973b58e61de6ab9d1c1"
+checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
 dependencies = [
  "windows-sys 0.59.0",
 ]
@@ -3105,9 +3105,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea4a292869320c0272d7bc55a5a6aafaff59b4f63404a003887b679a2e05b4b6"
+checksum = "fa39c7303dc58b5543c94d22c1766b0d31f2ee58306363ea622b10bbc075eaa2"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3127,18 +3127,18 @@ checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
 
 [[package]]
 name = "serde"
-version = "1.0.214"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55c3193aca71c12ad7890f1785d2b73e1b9f63a0bbc353c08ef26fe03fc56b5"
+checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.214"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766"
+checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3147,9 +3147,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.132"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
+checksum = "c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377"
 dependencies = [
  "itoa",
  "memchr",
@@ -3404,9 +3404,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.13.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
+checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -3438,18 +3438,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.67"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3c6efbfc763e64eb85c11c25320f0737cb7364c4b6336db90aa9ebe27a0bbd"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.67"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b607164372e89797d78b8e23a6d67d5d1038c1c65efd52e1389ef8b77caba2a6"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3524,9 +3524,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.41.0"
+version = "1.41.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145f3413504347a2be84393cc8a7d2fb4d863b375909ea59f2158261aa258bbb"
+checksum = "22cfb5bee7a6a52939ca9224d6ac897bb669134078daa8735560897f69de4d33"
 dependencies = [
  "backtrace",
  "bytes",
@@ -3697,9 +3697,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8437150ab6bbc8c5f0f519e3d5ed4aa883a83dd4cdd3d1b21f9482936046cb97"
+checksum = "403fa3b783d4b626a8ad51d766ab03cb6d2dbfc46b1c5d4448395e6628dc9697"
 dependencies = [
  "bitflags 2.6.0",
  "bytes",
@@ -3799,9 +3799,9 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 
 [[package]]
 name = "unicode-linebreak"

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -3,11 +3,11 @@ use bitcoin::script::{Instruction, Instructions};
 use bitcoin::{
     hashes::{sha256d, Hash},
     opcodes::{
-        all::{OP_NOP5, OP_PUSHBYTES_1, OP_RETURN},
+        all::{OP_PUSHBYTES_1, OP_RETURN},
         OP_TRUE,
     },
     script::PushBytesBuf,
-    Amount, Opcode, Script, ScriptBuf, Transaction, TxOut,
+    Amount, Script, ScriptBuf, Transaction, TxOut,
 };
 use byteorder::{ByteOrder, LittleEndian};
 use nom::{
@@ -21,9 +21,8 @@ use thiserror::Error;
 
 use crate::types::{
     M6id, SidechainDeclaration, SidechainDescription, SidechainNumber, SidechainProposal,
+    OP_DRIVECHAIN,
 };
-
-pub const OP_DRIVECHAIN: Opcode = OP_NOP5;
 
 pub struct CoinbaseBuilder {
     messages: Vec<CoinbaseMessage>,
@@ -69,14 +68,10 @@ impl CoinbaseBuilder {
         self
     }
 
-    pub fn propose_bundle(
-        mut self,
-        sidechain_number: SidechainNumber,
-        bundle_hash: &[u8; 32],
-    ) -> Self {
+    pub fn propose_bundle(mut self, sidechain_number: SidechainNumber, m6id: M6id) -> Self {
         let message = CoinbaseMessage::M3ProposeBundle {
             sidechain_number,
-            bundle_txid: *bundle_hash,
+            bundle_txid: m6id.0.to_byte_array(),
         };
         self.messages.push(message);
         self

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -1,3 +1,5 @@
+use std::collections::{hash_map, HashMap};
+
 use bitcoin::amount::CheckedSum;
 use bitcoin::script::{Instruction, Instructions};
 use bitcoin::{
@@ -10,6 +12,7 @@ use bitcoin::{
     Amount, Script, ScriptBuf, Transaction, TxOut,
 };
 use byteorder::{ByteOrder, LittleEndian};
+use miette::Diagnostic;
 use nom::{
     branch::alt,
     bytes::complete::{tag, take},
@@ -24,13 +27,472 @@ use crate::types::{
     OP_DRIVECHAIN,
 };
 
-pub struct CoinbaseBuilder {
+#[derive(Debug)]
+pub struct M1ProposeSidechain {
+    pub sidechain_number: SidechainNumber,
+    pub description: SidechainDescription,
+}
+
+impl M1ProposeSidechain {
+    pub const TAG: [u8; 4] = [0xD5, 0xE0, 0xC4, 0xAF];
+
+    fn parse(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, sidechain_number) = take(1usize)(input)?;
+        let sidechain_number = sidechain_number[0];
+        let (input, description) = rest(input)?;
+        let description = description.to_vec().into();
+        let message = Self {
+            sidechain_number: SidechainNumber::from(sidechain_number),
+            description,
+        };
+        Ok((input, message))
+    }
+}
+
+impl TryFrom<M1ProposeSidechain> for ScriptBuf {
+    type Error = bitcoin::script::PushBytesError;
+
+    fn try_from(m1: M1ProposeSidechain) -> Result<Self, Self::Error> {
+        let M1ProposeSidechain {
+            sidechain_number,
+            description,
+        } = m1;
+        let message = [
+            &M1ProposeSidechain::TAG[..],
+            &[sidechain_number.into()],
+            &description.0,
+        ]
+        .concat();
+        let data = PushBytesBuf::try_from(message)?;
+        Ok(ScriptBuf::new_op_return(&data))
+    }
+}
+
+#[derive(Debug)]
+pub struct M2AckSidechain {
+    pub sidechain_number: SidechainNumber,
+    pub description_hash: sha256d::Hash,
+}
+
+impl M2AckSidechain {
+    pub const TAG: [u8; 4] = [0xD6, 0xE1, 0xC5, 0xDF];
+
+    fn parse(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, sidechain_number) = take(1usize)(input)?;
+        let sidechain_number = sidechain_number[0];
+        let (input, description_hash) = take(32usize)(input)?;
+        let description_hash: [u8; 32] = description_hash.try_into().unwrap();
+        let message = Self {
+            sidechain_number: SidechainNumber::from(sidechain_number),
+            description_hash: sha256d::Hash::from_byte_array(description_hash),
+        };
+        Ok((input, message))
+    }
+}
+
+impl TryFrom<M2AckSidechain> for ScriptBuf {
+    type Error = bitcoin::script::PushBytesError;
+
+    fn try_from(m2: M2AckSidechain) -> Result<Self, Self::Error> {
+        let M2AckSidechain {
+            sidechain_number,
+            description_hash,
+        } = m2;
+        let message = [
+            &M2AckSidechain::TAG[..],
+            &[sidechain_number.into()],
+            description_hash.as_byte_array(),
+        ]
+        .concat();
+        let data = PushBytesBuf::try_from(message)?;
+        Ok(ScriptBuf::new_op_return(&data))
+    }
+}
+
+#[derive(Debug)]
+pub struct M3ProposeBundle {
+    pub sidechain_number: SidechainNumber,
+    pub bundle_txid: [u8; 32],
+}
+
+impl M3ProposeBundle {
+    pub const TAG: [u8; 4] = [0xD4, 0x5A, 0xA9, 0x43];
+
+    fn parse(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, sidechain_number) = take(1usize)(input)?;
+        let sidechain_number = sidechain_number[0];
+        let (input, bundle_txid) = take(32usize)(input)?;
+        let bundle_txid: [u8; 32] = bundle_txid.try_into().unwrap();
+        let message = Self {
+            sidechain_number: SidechainNumber::from(sidechain_number),
+            bundle_txid,
+        };
+        Ok((input, message))
+    }
+}
+
+impl TryFrom<M3ProposeBundle> for ScriptBuf {
+    type Error = bitcoin::script::PushBytesError;
+
+    fn try_from(m3: M3ProposeBundle) -> Result<Self, Self::Error> {
+        let M3ProposeBundle {
+            sidechain_number,
+            bundle_txid,
+        } = m3;
+        let message = [
+            &M3ProposeBundle::TAG[..],
+            &[sidechain_number.into()],
+            &bundle_txid,
+        ]
+        .concat();
+        let data = PushBytesBuf::try_from(message)?;
+        Ok(ScriptBuf::new_op_return(&data))
+    }
+}
+
+#[derive(Debug)]
+pub enum M4AckBundles {
+    RepeatPrevious,
+    OneByte { upvotes: Vec<u8> },
+    TwoBytes { upvotes: Vec<u16> },
+    LeadingBy50,
+}
+
+impl M4AckBundles {
+    pub const TAG: [u8; 4] = [0xD7, 0x7D, 0x17, 0x76];
+
+    pub const ABSTAIN_ONE_BYTE: u8 = 0xFF;
+    pub const ABSTAIN_TWO_BYTES: u16 = 0xFFFF;
+    pub const ALARM_ONE_BYTE: u8 = 0xFE;
+    pub const ALARM_TWO_BYTES: u16 = 0xFFFE;
+    const REPEAT_PREVIOUS_TAG: [u8; 1] = [0x00];
+    const ONE_BYTE_TAG: [u8; 1] = [0x01];
+    const TWO_BYTES_TAG: [u8; 1] = [0x02];
+    const LEADING_BY_50_TAG: [u8; 1] = [0x03];
+
+    fn tag(&self) -> [u8; 1] {
+        match self {
+            Self::RepeatPrevious => Self::REPEAT_PREVIOUS_TAG,
+            Self::OneByte { .. } => Self::ONE_BYTE_TAG,
+            Self::TwoBytes { .. } => Self::TWO_BYTES_TAG,
+            Self::LeadingBy50 { .. } => Self::LEADING_BY_50_TAG,
+        }
+    }
+
+    fn parse(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, m4_tag) = alt((
+            tag(Self::REPEAT_PREVIOUS_TAG),
+            tag(Self::ONE_BYTE_TAG),
+            tag(Self::TWO_BYTES_TAG),
+            tag(Self::LEADING_BY_50_TAG),
+        ))(input)?;
+
+        if m4_tag == Self::REPEAT_PREVIOUS_TAG {
+            let message = M4AckBundles::RepeatPrevious;
+            return Ok((input, message));
+        } else if m4_tag == Self::ONE_BYTE_TAG {
+            let (input, upvotes) = rest(input)?;
+            let upvotes = upvotes.to_vec();
+            let message = M4AckBundles::OneByte { upvotes };
+            return Ok((input, message));
+        } else if m4_tag == Self::TWO_BYTES_TAG {
+            let (input, upvotes) = many0(take(2usize))(input)?;
+            let upvotes: Vec<u16> = upvotes.into_iter().map(LittleEndian::read_u16).collect();
+            let message = M4AckBundles::TwoBytes { upvotes };
+            return Ok((input, message));
+        } else if m4_tag == Self::LEADING_BY_50_TAG {
+            let message = M4AckBundles::LeadingBy50;
+            return Ok((input, message));
+        }
+        fail(input)
+    }
+}
+
+impl TryFrom<M4AckBundles> for ScriptBuf {
+    type Error = bitcoin::script::PushBytesError;
+
+    fn try_from(m4: M4AckBundles) -> Result<Self, Self::Error> {
+        let tag = m4.tag();
+        let upvotes = match m4 {
+            M4AckBundles::OneByte { upvotes } => upvotes,
+            M4AckBundles::TwoBytes { upvotes } => upvotes
+                .into_iter()
+                .flat_map(|upvote| upvote.to_le_bytes())
+                .collect(),
+            _ => vec![],
+        };
+        let message = [&M4AckBundles::TAG[..], &tag, &upvotes].concat();
+        let data = PushBytesBuf::try_from(message)?;
+        Ok(ScriptBuf::new_op_return(&data))
+    }
+}
+
+#[derive(Debug)]
+pub struct M7BmmAccept {
+    pub sidechain_number: SidechainNumber,
+    pub sidechain_block_hash: [u8; 32],
+}
+
+impl M7BmmAccept {
+    pub const TAG: [u8; 4] = [0xD1, 0x61, 0x73, 0x68];
+
+    fn parse(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, sidechain_number) = take(1usize)(input)?;
+        let sidechain_number = sidechain_number[0];
+        let (input, sidechain_block_hash) = take(32usize)(input)?;
+        // Unwrap here is fine, because if we didn't get exactly 32 bytes we'd fail on the previous
+        // line.
+        let sidechain_block_hash = sidechain_block_hash.try_into().unwrap();
+        let message = Self {
+            sidechain_number: SidechainNumber::from(sidechain_number),
+            sidechain_block_hash,
+        };
+        Ok((input, message))
+    }
+}
+
+impl TryFrom<M7BmmAccept> for ScriptBuf {
+    type Error = bitcoin::script::PushBytesError;
+
+    fn try_from(m7: M7BmmAccept) -> Result<Self, Self::Error> {
+        let M7BmmAccept {
+            sidechain_number,
+            sidechain_block_hash,
+        } = m7;
+        let message = [
+            &M7BmmAccept::TAG[..],
+            &[sidechain_number.into()],
+            &sidechain_block_hash,
+        ]
+        .concat();
+        let data = PushBytesBuf::try_from(message)?;
+        Ok(ScriptBuf::new_op_return(&data))
+    }
+}
+
+#[derive(Debug)]
+pub enum CoinbaseMessage {
+    M1ProposeSidechain(M1ProposeSidechain),
+    M2AckSidechain(M2AckSidechain),
+    M3ProposeBundle(M3ProposeBundle),
+    M4AckBundles(M4AckBundles),
+    M7BmmAccept(M7BmmAccept),
+}
+
+impl CoinbaseMessage {
+    pub fn parse(script: &Script) -> IResult<&[u8], Self> {
+        use nom::Parser;
+        fn instruction_failure<'a>(
+            err_msg: Option<&'static str>,
+            instructions: Instructions<'a>,
+        ) -> nom::Err<nom::error::Error<&'a [u8]>> {
+            use nom::error::ContextError as _;
+            let input = instructions.as_script().as_bytes();
+            let err = nom::error::Error {
+                input,
+                code: nom::error::ErrorKind::Fail,
+            };
+            let err = match err_msg {
+                Some(err_msg) => nom::error::Error::add_context(input, err_msg, err),
+                None => err,
+            };
+            nom::Err::Failure(err)
+        }
+        let mut instructions = script.instructions();
+        let Some(Ok(Instruction::Op(OP_RETURN))) = instructions.next() else {
+            return Err(instruction_failure(
+                Some("expected OP_RETURN instruction"),
+                instructions,
+            ));
+        };
+        let Some(Ok(Instruction::PushBytes(data))) = instructions.next() else {
+            return Err(instruction_failure(
+                Some("expected PushBytes instruction"),
+                instructions,
+            ));
+        };
+        let input = data.as_bytes();
+        let (input, message_tag) = alt((
+            tag(M1ProposeSidechain::TAG),
+            tag(M2AckSidechain::TAG),
+            tag(M3ProposeBundle::TAG),
+            tag(M4AckBundles::TAG),
+            tag(M7BmmAccept::TAG),
+        ))(input)?;
+        if message_tag == M1ProposeSidechain::TAG {
+            return M1ProposeSidechain::parse
+                .map(Self::M1ProposeSidechain)
+                .parse(input);
+        } else if message_tag == M2AckSidechain::TAG {
+            return M2AckSidechain::parse.map(Self::M2AckSidechain).parse(input);
+        } else if message_tag == M3ProposeBundle::TAG {
+            return M3ProposeBundle::parse
+                .map(Self::M3ProposeBundle)
+                .parse(input);
+        } else if message_tag == M4AckBundles::TAG {
+            return M4AckBundles::parse.map(Self::M4AckBundles).parse(input);
+        } else if message_tag == M7BmmAccept::TAG {
+            return M7BmmAccept::parse.map(Self::M7BmmAccept).parse(input);
+        }
+        fail(input)
+    }
+}
+
+impl From<M1ProposeSidechain> for CoinbaseMessage {
+    fn from(m1: M1ProposeSidechain) -> Self {
+        Self::M1ProposeSidechain(m1)
+    }
+}
+
+impl From<M2AckSidechain> for CoinbaseMessage {
+    fn from(m2: M2AckSidechain) -> Self {
+        Self::M2AckSidechain(m2)
+    }
+}
+
+impl From<M3ProposeBundle> for CoinbaseMessage {
+    fn from(m3: M3ProposeBundle) -> Self {
+        Self::M3ProposeBundle(m3)
+    }
+}
+
+impl From<M4AckBundles> for CoinbaseMessage {
+    fn from(m4: M4AckBundles) -> Self {
+        Self::M4AckBundles(m4)
+    }
+}
+
+impl From<M7BmmAccept> for CoinbaseMessage {
+    fn from(m7: M7BmmAccept) -> Self {
+        Self::M7BmmAccept(m7)
+    }
+}
+
+impl TryFrom<CoinbaseMessage> for ScriptBuf {
+    type Error = bitcoin::script::PushBytesError;
+
+    fn try_from(msg: CoinbaseMessage) -> Result<Self, Self::Error> {
+        match msg {
+            CoinbaseMessage::M1ProposeSidechain(m1) => m1.try_into(),
+            CoinbaseMessage::M2AckSidechain(m2) => m2.try_into(),
+            CoinbaseMessage::M3ProposeBundle(m3) => m3.try_into(),
+            CoinbaseMessage::M4AckBundles(m4) => m4.try_into(),
+            CoinbaseMessage::M7BmmAccept(m7) => m7.try_into(),
+        }
+    }
+}
+
+#[derive(Debug, Diagnostic, Error)]
+pub enum CoinbaseMessagesError {
+    #[error("M2 that acks proposal for slot `{slot}` already included at index `{index}`")]
+    DuplicateM2 { index: usize, slot: SidechainNumber },
+    #[error("M4 already included at index `{index}`")]
+    DuplicateM4 { index: usize },
+}
+
+/// Valid, ordered list of coinbase messages
+#[derive(Debug, Default)]
+pub struct CoinbaseMessages {
     messages: Vec<CoinbaseMessage>,
+    m2_ack_slot_to_index: HashMap<SidechainNumber, usize>,
+    m4_index: Option<usize>,
+}
+
+impl CoinbaseMessages {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn m2_acks(&self) -> Vec<SidechainNumber> {
+        let mut res: Vec<_> = self.m2_ack_slot_to_index.keys().copied().collect();
+        res.sort();
+        res
+    }
+
+    pub fn m4_exists(&self) -> bool {
+        self.m4_index.is_some()
+    }
+
+    // TODO: ensure that M1, M3, and M7 pushes are valid
+    pub fn push(&mut self, msg: CoinbaseMessage) -> Result<(), CoinbaseMessagesError> {
+        match &msg {
+            CoinbaseMessage::M2AckSidechain(m2) => {
+                match self.m2_ack_slot_to_index.entry(m2.sidechain_number) {
+                    hash_map::Entry::Occupied(entry) => Err(CoinbaseMessagesError::DuplicateM2 {
+                        index: *entry.get(),
+                        slot: m2.sidechain_number,
+                    }),
+                    hash_map::Entry::Vacant(entry) => {
+                        entry.insert(self.messages.len());
+                        self.messages.push(msg);
+                        Ok(())
+                    }
+                }
+            }
+            CoinbaseMessage::M4AckBundles(_) => {
+                if let Some(index) = self.m4_index {
+                    Err(CoinbaseMessagesError::DuplicateM4 { index })
+                } else {
+                    self.m4_index = Some(self.messages.len());
+                    self.messages.push(msg);
+                    Ok(())
+                }
+            }
+            CoinbaseMessage::M1ProposeSidechain(_)
+            | CoinbaseMessage::M3ProposeBundle(_)
+            | CoinbaseMessage::M7BmmAccept(_) => {
+                self.messages.push(msg);
+                Ok(())
+            }
+        }
+    }
+
+    pub fn extend<I>(&mut self, iter: I) -> Result<(), CoinbaseMessagesError>
+    where
+        I: IntoIterator<Item = CoinbaseMessage>,
+    {
+        iter.into_iter().try_for_each(|msg| self.push(msg))
+    }
+
+    fn from_iter<I>(iter: I) -> Result<Self, CoinbaseMessagesError>
+    where
+        I: IntoIterator<Item = CoinbaseMessage>,
+    {
+        let mut res = Self::new();
+        res.extend(iter)?;
+        Ok(res)
+    }
+}
+
+impl<'a> IntoIterator for &'a CoinbaseMessages {
+    type IntoIter = <&'a Vec<CoinbaseMessage> as IntoIterator>::IntoIter;
+    type Item = &'a CoinbaseMessage;
+    fn into_iter(self) -> Self::IntoIter {
+        self.messages.iter()
+    }
+}
+
+impl IntoIterator for CoinbaseMessages {
+    type IntoIter = <Vec<CoinbaseMessage> as IntoIterator>::IntoIter;
+    type Item = CoinbaseMessage;
+    fn into_iter(self) -> Self::IntoIter {
+        self.messages.into_iter()
+    }
+}
+
+pub struct CoinbaseBuilder {
+    messages: CoinbaseMessages,
 }
 
 impl CoinbaseBuilder {
     pub fn new() -> Self {
-        CoinbaseBuilder { messages: vec![] }
+        CoinbaseBuilder {
+            messages: CoinbaseMessages::new(),
+        }
+    }
+
+    pub fn messages(&self) -> &CoinbaseMessages {
+        &self.messages
     }
 
     pub fn build(self) -> Result<Vec<TxOut>, bitcoin::script::PushBytesError> {
@@ -46,72 +508,65 @@ impl CoinbaseBuilder {
             .collect()
     }
 
-    pub fn propose_sidechain(mut self, proposal: SidechainProposal) -> Self {
-        let message = CoinbaseMessage::M1ProposeSidechain {
+    pub fn propose_sidechain(
+        &mut self,
+        proposal: SidechainProposal,
+    ) -> Result<&mut Self, CoinbaseMessagesError> {
+        let message = CoinbaseMessage::M1ProposeSidechain(M1ProposeSidechain {
             sidechain_number: proposal.sidechain_number,
-            data: proposal.description.0,
-        };
-        self.messages.push(message);
-        self
+            description: proposal.description,
+        });
+        self.messages.push(message)?;
+        Ok(self)
     }
 
     pub fn ack_sidechain(
-        mut self,
+        &mut self,
         sidechain_number: SidechainNumber,
         description_hash: sha256d::Hash,
-    ) -> Self {
-        let message = CoinbaseMessage::M2AckSidechain {
+    ) -> Result<&mut Self, CoinbaseMessagesError> {
+        let message = CoinbaseMessage::M2AckSidechain(M2AckSidechain {
             sidechain_number,
-            data_hash: description_hash.to_byte_array(),
-        };
-        self.messages.push(message);
-        self
+            description_hash,
+        });
+        self.messages.push(message)?;
+        Ok(self)
     }
 
-    pub fn propose_bundle(mut self, sidechain_number: SidechainNumber, m6id: M6id) -> Self {
-        let message = CoinbaseMessage::M3ProposeBundle {
+    pub fn propose_bundle(
+        &mut self,
+        sidechain_number: SidechainNumber,
+        m6id: M6id,
+    ) -> Result<&mut Self, CoinbaseMessagesError> {
+        let message = CoinbaseMessage::M3ProposeBundle(M3ProposeBundle {
             sidechain_number,
             bundle_txid: m6id.0.to_byte_array(),
-        };
-        self.messages.push(message);
-        self
+        });
+        self.messages.push(message)?;
+        Ok(self)
     }
 
-    pub fn ack_bundles(mut self, m4_ack_bundles: M4AckBundles) -> Self {
+    pub fn ack_bundles(
+        &mut self,
+        m4_ack_bundles: M4AckBundles,
+    ) -> Result<&mut Self, CoinbaseMessagesError> {
         let message = CoinbaseMessage::M4AckBundles(m4_ack_bundles);
-        self.messages.push(message);
-        self
+        self.messages.push(message)?;
+        Ok(self)
     }
 
-    pub fn bmm_accept(mut self, sidechain_number: SidechainNumber, bmm_hash: &[u8; 32]) -> Self {
-        let message = CoinbaseMessage::M7BmmAccept {
+    pub fn bmm_accept(
+        &mut self,
+        sidechain_number: SidechainNumber,
+        bmm_hash: &[u8; 32],
+    ) -> Result<&mut Self, CoinbaseMessagesError> {
+        let message = CoinbaseMessage::M7BmmAccept(M7BmmAccept {
             sidechain_number,
             sidechain_block_hash: *bmm_hash,
-        };
-        self.messages.push(message);
-        self
+        });
+        self.messages.push(message)?;
+        Ok(self)
     }
-}
-
-#[derive(Debug)]
-pub enum CoinbaseMessage {
-    M1ProposeSidechain {
-        sidechain_number: SidechainNumber,
-        data: Vec<u8>,
-    },
-    M2AckSidechain {
-        sidechain_number: SidechainNumber,
-        data_hash: [u8; 32],
-    },
-    M3ProposeBundle {
-        sidechain_number: SidechainNumber,
-        bundle_txid: [u8; 32],
-    },
-    M4AckBundles(M4AckBundles),
-    M7BmmAccept {
-        sidechain_number: SidechainNumber,
-        sidechain_block_hash: [u8; 32],
-    },
 }
 
 #[derive(Debug)]
@@ -122,101 +577,35 @@ pub struct M8BmmRequest {
     pub prev_mainchain_block_hash: [u8; 32],
 }
 
-pub const M1_PROPOSE_SIDECHAIN_TAG: [u8; 4] = [0xD5, 0xE0, 0xC4, 0xAF];
-pub const M2_ACK_SIDECHAIN_TAG: [u8; 4] = [0xD6, 0xE1, 0xC5, 0xDF];
-pub const M3_PROPOSE_BUNDLE_TAG: [u8; 4] = [0xD4, 0x5A, 0xA9, 0x43];
-pub const M4_ACK_BUNDLES_TAG: [u8; 4] = [0xD7, 0x7D, 0x17, 0x76];
-pub const M7_BMM_ACCEPT_TAG: [u8; 4] = [0xD1, 0x61, 0x73, 0x68];
-pub const M8_BMM_REQUEST_TAG: [u8; 3] = [0x00, 0xBF, 0x00];
+impl M8BmmRequest {
+    pub const TAG: [u8; 3] = [0x00, 0xBF, 0x00];
 
-pub const ABSTAIN_ONE_BYTE: u8 = 0xFF;
-pub const ABSTAIN_TWO_BYTES: u16 = 0xFFFF;
+    pub fn parse(input: &[u8]) -> IResult<&[u8], Self> {
+        const HEADER_LENGTH: u8 = 3;
+        const SIDECHAIN_NUMBER_LENGTH: u8 = 1;
+        const SIDECHAIN_BLOCK_HASH_LENGTH: u8 = 32;
+        const PREV_MAINCHAIN_BLOCK_HASH_LENGTH: u8 = 32;
 
-pub const ALARM_ONE_BYTE: u8 = 0xFE;
-pub const ALARM_TWO_BYTES: u16 = 0xFFFE;
+        const M8_BMM_REQUEST_LENGTH: u8 = HEADER_LENGTH
+            + SIDECHAIN_NUMBER_LENGTH
+            + SIDECHAIN_BLOCK_HASH_LENGTH
+            + PREV_MAINCHAIN_BLOCK_HASH_LENGTH;
 
-#[derive(Debug)]
-pub enum M4AckBundles {
-    RepeatPrevious,
-    OneByte { upvotes: Vec<u8> },
-    TwoBytes { upvotes: Vec<u16> },
-    LeadingBy50,
-}
-
-const REPEAT_PREVIOUS_TAG: [u8; 1] = [0x00];
-const ONE_BYTE_TAG: [u8; 1] = [0x01];
-const TWO_BYTES_TAG: [u8; 1] = [0x02];
-const LEADING_BY_50_TAG: [u8; 1] = [0x03];
-
-/// 0xFF
-// 0xFFFF
-// const ABSTAIN_TAG: &[u8] = &[0xFF];
-
-/// 0xFE
-// 0xFFFE
-// const ALARM_TAG: &[u8] = &[0xFE];
-
-impl M4AckBundles {
-    fn tag(&self) -> [u8; 1] {
-        match self {
-            Self::RepeatPrevious => REPEAT_PREVIOUS_TAG,
-            Self::OneByte { .. } => ONE_BYTE_TAG,
-            Self::TwoBytes { .. } => TWO_BYTES_TAG,
-            Self::LeadingBy50 { .. } => LEADING_BY_50_TAG,
-        }
-    }
-}
-
-pub fn parse_coinbase_script(script: &Script) -> IResult<&[u8], CoinbaseMessage> {
-    fn instruction_failure<'a>(
-        err_msg: Option<&'static str>,
-        instructions: Instructions<'a>,
-    ) -> nom::Err<nom::error::Error<&'a [u8]>> {
-        use nom::error::ContextError as _;
-        let input = instructions.as_script().as_bytes();
-        let err = nom::error::Error {
-            input,
-            code: nom::error::ErrorKind::Fail,
+        let (input, _) = tag(&[OP_RETURN.to_u8(), M8_BMM_REQUEST_LENGTH])(input)?;
+        let (input, _) = tag(Self::TAG)(input)?;
+        let (input, sidechain_number) = take(1usize)(input)?;
+        let sidechain_number = sidechain_number[0];
+        let (input, sidechain_block_hash) = take(32usize)(input)?;
+        let (input, prev_mainchain_block_hash) = take(32usize)(input)?;
+        let sidechain_block_hash = sidechain_block_hash.try_into().unwrap();
+        let prev_mainchain_block_hash = prev_mainchain_block_hash.try_into().unwrap();
+        let message = Self {
+            sidechain_number: sidechain_number.into(),
+            sidechain_block_hash,
+            prev_mainchain_block_hash,
         };
-        let err = match err_msg {
-            Some(err_msg) => nom::error::Error::add_context(input, err_msg, err),
-            None => err,
-        };
-        nom::Err::Failure(err)
+        Ok((input, message))
     }
-    let mut instructions = script.instructions();
-    let Some(Ok(Instruction::Op(OP_RETURN))) = instructions.next() else {
-        return Err(instruction_failure(
-            Some("expected OP_RETURN instruction"),
-            instructions,
-        ));
-    };
-    let Some(Ok(Instruction::PushBytes(data))) = instructions.next() else {
-        return Err(instruction_failure(
-            Some("expected PushBytes instruction"),
-            instructions,
-        ));
-    };
-    let input = data.as_bytes();
-    let (input, message_tag) = alt((
-        tag(M1_PROPOSE_SIDECHAIN_TAG),
-        tag(M2_ACK_SIDECHAIN_TAG),
-        tag(M3_PROPOSE_BUNDLE_TAG),
-        tag(M4_ACK_BUNDLES_TAG),
-        tag(M7_BMM_ACCEPT_TAG),
-    ))(input)?;
-    if message_tag == M1_PROPOSE_SIDECHAIN_TAG {
-        return parse_m1_propose_sidechain(input);
-    } else if message_tag == M2_ACK_SIDECHAIN_TAG {
-        return parse_m2_ack_sidechain(input);
-    } else if message_tag == M3_PROPOSE_BUNDLE_TAG {
-        return parse_m3_propose_bundle(input);
-    } else if message_tag == M4_ACK_BUNDLES_TAG {
-        return parse_m4_ack_bundles(input);
-    } else if message_tag == M7_BMM_ACCEPT_TAG {
-        return parse_m7_bmm_accept(input);
-    }
-    fail(input)
 }
 
 pub fn parse_op_drivechain(input: &[u8]) -> IResult<&[u8], SidechainNumber> {
@@ -271,185 +660,6 @@ where
     })
 }
 
-fn parse_m1_propose_sidechain(input: &[u8]) -> IResult<&[u8], CoinbaseMessage> {
-    let (input, sidechain_number) = take(1usize)(input)?;
-    let sidechain_number = sidechain_number[0];
-    let (input, data) = rest(input)?;
-    let data = data.to_vec();
-    let message = CoinbaseMessage::M1ProposeSidechain {
-        sidechain_number: SidechainNumber::from(sidechain_number),
-        data,
-    };
-    Ok((input, message))
-}
-
-fn parse_m2_ack_sidechain(input: &[u8]) -> IResult<&[u8], CoinbaseMessage> {
-    let (input, sidechain_number) = take(1usize)(input)?;
-    let sidechain_number = sidechain_number[0];
-    let (input, data_hash) = take(32usize)(input)?;
-    let data_hash: [u8; 32] = data_hash.try_into().unwrap();
-    let message = CoinbaseMessage::M2AckSidechain {
-        sidechain_number: SidechainNumber::from(sidechain_number),
-        data_hash,
-    };
-    Ok((input, message))
-}
-
-fn parse_m3_propose_bundle(input: &[u8]) -> IResult<&[u8], CoinbaseMessage> {
-    let (input, sidechain_number) = take(1usize)(input)?;
-    let sidechain_number = sidechain_number[0];
-    let (input, bundle_txid) = take(32usize)(input)?;
-    let bundle_txid: [u8; 32] = bundle_txid.try_into().unwrap();
-    let message = CoinbaseMessage::M3ProposeBundle {
-        sidechain_number: SidechainNumber::from(sidechain_number),
-        bundle_txid,
-    };
-    Ok((input, message))
-}
-
-fn parse_m4_ack_bundles(input: &[u8]) -> IResult<&[u8], CoinbaseMessage> {
-    let (input, m4_tag) = alt((
-        tag(REPEAT_PREVIOUS_TAG),
-        tag(ONE_BYTE_TAG),
-        tag(TWO_BYTES_TAG),
-        tag(LEADING_BY_50_TAG),
-    ))(input)?;
-
-    if m4_tag == REPEAT_PREVIOUS_TAG {
-        let message = CoinbaseMessage::M4AckBundles(M4AckBundles::RepeatPrevious);
-        return Ok((input, message));
-    } else if m4_tag == ONE_BYTE_TAG {
-        let (input, upvotes) = rest(input)?;
-        let upvotes = upvotes.to_vec();
-        let message = CoinbaseMessage::M4AckBundles(M4AckBundles::OneByte { upvotes });
-        return Ok((input, message));
-    } else if m4_tag == TWO_BYTES_TAG {
-        let (input, upvotes) = many0(take(2usize))(input)?;
-        let upvotes: Vec<u16> = upvotes.into_iter().map(LittleEndian::read_u16).collect();
-        let message = CoinbaseMessage::M4AckBundles(M4AckBundles::TwoBytes { upvotes });
-        return Ok((input, message));
-    } else if m4_tag == LEADING_BY_50_TAG {
-        let message = CoinbaseMessage::M4AckBundles(M4AckBundles::LeadingBy50);
-        return Ok((input, message));
-    }
-    fail(input)
-}
-
-fn parse_m7_bmm_accept(input: &[u8]) -> IResult<&[u8], CoinbaseMessage> {
-    let (input, sidechain_number) = take(1usize)(input)?;
-    let sidechain_number = sidechain_number[0];
-    let (input, sidechain_block_hash) = take(32usize)(input)?;
-    // Unwrap here is fine, because if we didn't get exactly 32 bytes we'd fail on the previous
-    // line.
-    let sidechain_block_hash = sidechain_block_hash.try_into().unwrap();
-    let message = CoinbaseMessage::M7BmmAccept {
-        sidechain_number: SidechainNumber::from(sidechain_number),
-        sidechain_block_hash,
-    };
-    Ok((input, message))
-}
-
-pub fn parse_m8_bmm_request(input: &[u8]) -> IResult<&[u8], M8BmmRequest> {
-    const HEADER_LENGTH: u8 = 3;
-    const SIDECHAIN_NUMBER_LENGTH: u8 = 1;
-    const SIDECHAIN_BLOCK_HASH_LENGTH: u8 = 32;
-    const PREV_MAINCHAIN_BLOCK_HASH_LENGTH: u8 = 32;
-
-    const M8_BMM_REQUEST_LENGTH: u8 = HEADER_LENGTH
-        + SIDECHAIN_NUMBER_LENGTH
-        + SIDECHAIN_BLOCK_HASH_LENGTH
-        + PREV_MAINCHAIN_BLOCK_HASH_LENGTH;
-
-    let (input, _) = tag(&[OP_RETURN.to_u8(), M8_BMM_REQUEST_LENGTH])(input)?;
-    let (input, _) = tag(M8_BMM_REQUEST_TAG)(input)?;
-    let (input, sidechain_number) = take(1usize)(input)?;
-    let sidechain_number = sidechain_number[0];
-    let (input, sidechain_block_hash) = take(32usize)(input)?;
-    let (input, prev_mainchain_block_hash) = take(32usize)(input)?;
-    let sidechain_block_hash = sidechain_block_hash.try_into().unwrap();
-    let prev_mainchain_block_hash = prev_mainchain_block_hash.try_into().unwrap();
-    let message = M8BmmRequest {
-        sidechain_number: sidechain_number.into(),
-        sidechain_block_hash,
-        prev_mainchain_block_hash,
-    };
-    Ok((input, message))
-}
-
-impl TryFrom<CoinbaseMessage> for ScriptBuf {
-    type Error = bitcoin::script::PushBytesError;
-
-    fn try_from(val: CoinbaseMessage) -> Result<Self, Self::Error> {
-        match val {
-            CoinbaseMessage::M1ProposeSidechain {
-                sidechain_number,
-                data,
-            } => {
-                let message = [
-                    &M1_PROPOSE_SIDECHAIN_TAG[..],
-                    &[sidechain_number.into()],
-                    &data,
-                ]
-                .concat();
-                let data = PushBytesBuf::try_from(message)?;
-                Ok(ScriptBuf::new_op_return(&data))
-            }
-            CoinbaseMessage::M2AckSidechain {
-                sidechain_number,
-                data_hash,
-            } => {
-                let message = [
-                    &M2_ACK_SIDECHAIN_TAG[..],
-                    &[sidechain_number.into()],
-                    &data_hash,
-                ]
-                .concat();
-                let data = PushBytesBuf::try_from(message)?;
-                Ok(ScriptBuf::new_op_return(&data))
-            }
-            CoinbaseMessage::M3ProposeBundle {
-                sidechain_number,
-                bundle_txid,
-            } => {
-                let message = [
-                    &M3_PROPOSE_BUNDLE_TAG[..],
-                    &[sidechain_number.into()],
-                    &bundle_txid,
-                ]
-                .concat();
-                let data = PushBytesBuf::try_from(message)?;
-                Ok(ScriptBuf::new_op_return(&data))
-            }
-            CoinbaseMessage::M4AckBundles(m4_ack_bundles) => {
-                let upvotes = match &m4_ack_bundles {
-                    M4AckBundles::OneByte { upvotes } => upvotes.clone(),
-                    M4AckBundles::TwoBytes { upvotes } => upvotes
-                        .iter()
-                        .flat_map(|upvote| upvote.to_le_bytes())
-                        .collect(),
-                    _ => vec![],
-                };
-                let message = [&M4_ACK_BUNDLES_TAG[..], &m4_ack_bundles.tag(), &upvotes].concat();
-                let data = PushBytesBuf::try_from(message)?;
-                Ok(ScriptBuf::new_op_return(&data))
-            }
-            CoinbaseMessage::M7BmmAccept {
-                sidechain_number,
-                sidechain_block_hash,
-            } => {
-                let message = [
-                    &M7_BMM_ACCEPT_TAG[..],
-                    &[sidechain_number.into()],
-                    &sidechain_block_hash,
-                ]
-                .concat();
-                let data = PushBytesBuf::try_from(message)?;
-                Ok(ScriptBuf::new_op_return(&data))
-            }
-        }
-    }
-}
-
 #[derive(Debug, Error)]
 enum M6idErrorInner {
     #[error(
@@ -484,16 +694,16 @@ pub fn compute_m6id(
     previous_treasury_utxo_total: Amount,
 ) -> Result<(M6id, SidechainNumber), M6idError> {
     // Check that a new treasury UTXO is created at index 0
-    let Some(treasury_output) = tx.output.first() else {
+    let Some((first_output, payout_outputs)) = tx.output.split_first_mut() else {
         return Err(M6idErrorInner::MissingTreasuryOutput.into());
     };
-    let (_, sidechain_number) = parse_op_drivechain(treasury_output.script_pubkey.as_bytes())
+    let (_, sidechain_number) = parse_op_drivechain(first_output.script_pubkey.as_bytes())
         .map_err(|err| M6idErrorInner::InvalidSpk {
-            script_pubkey: treasury_output.script_pubkey.clone(),
+            script_pubkey: first_output.script_pubkey.clone(),
             source: err.to_owned(),
         })?;
     // Set `T_n` equal to the `nValue` of the treasury UTXO created in this `M6`.
-    let t_n = treasury_output.value;
+    let t_n = first_output.value;
     // Remove the single input spending the previous treasury UTXO from the `vin`
     // vector, so that the `vin` vector is empty.
     match tx.input.len() {
@@ -505,7 +715,7 @@ pub fn compute_m6id(
     // Compute `P_total` by summing the `nValue`s of all pay out outputs in this
     // `M6`, so `P_total` = sum of `nValue`s of all outputs of this `M6` except for
     // the new treasury UTXO at index 0.
-    let p_total: Amount = tx.output[1..]
+    let p_total: Amount = payout_outputs
         .iter()
         .map(|o| o.value)
         .checked_sum()
@@ -526,14 +736,12 @@ pub fn compute_m6id(
     // Encode `F_total` as `F_total_be_bytes`, an array of 8 bytes encoding the 64
     // bit unsigned integer in big endian order.
     let f_total_be_bytes: [u8; 8] = f_total.to_sat().to_be_bytes();
-    // Push an output to the end of `vout` of this `M6` with the `nValue = 0` and
-    // `scriptPubKey = OP_RETURN F_total_be_bytes`.
-    let script_pubkey = ScriptBuf::new_op_return(f_total_be_bytes);
-    let txout = TxOut {
-        script_pubkey,
+    // Replace the treasury output with the fee output
+    let fee_output = TxOut {
+        script_pubkey: ScriptBuf::new_op_return(f_total_be_bytes),
         value: Amount::ZERO,
     };
-    tx.output.push(txout);
+    *first_output = fee_output;
     // At this point we have constructed `M6_blinded`
     Ok((M6id(tx.compute_txid()), sidechain_number))
 }
@@ -569,10 +777,12 @@ pub fn create_sidechain_proposal(
         description: description.clone(),
     };
 
-    let builder = CoinbaseBuilder::new().propose_sidechain(proposal).build()?; // TODO: better error
+    let mut builder = CoinbaseBuilder::new();
+    builder.propose_sidechain(proposal).unwrap();
+    let txouts = builder.build()?; // TODO: better error
 
-    assert!(builder.len() == 1);
-    let tx_out = builder.first().unwrap().clone();
+    assert!(txouts.len() == 1);
+    let tx_out = txouts.first().unwrap().clone();
     Ok((tx_out, description))
 }
 
@@ -605,7 +815,7 @@ mod tests {
 
         let input = hex::decode(INPUT).unwrap();
 
-        let (remaining, result) = parse_m8_bmm_request(&input).unwrap();
+        let (remaining, result) = M8BmmRequest::parse(&input).unwrap();
 
         assert!(remaining.is_empty());
         assert_eq!(result.sidechain_number, sidechain_number);
@@ -627,15 +837,15 @@ mod tests {
         let (tx_out, _) = create_sidechain_proposal(SidechainNumber::from(13), &declaration)
             .expect("Failed to create sidechain proposal");
 
-        let (rest, message) = parse_coinbase_script(&tx_out.script_pubkey)
+        let (rest, message) = CoinbaseMessage::parse(&tx_out.script_pubkey)
             .expect("Failed to parse sidechain proposal");
 
         assert!(rest.is_empty());
 
-        let CoinbaseMessage::M1ProposeSidechain {
+        let CoinbaseMessage::M1ProposeSidechain(M1ProposeSidechain {
             sidechain_number,
-            data,
-        } = message
+            description,
+        }) = message
         else {
             panic!("Failed to parse sidechain proposal");
         };
@@ -644,7 +854,7 @@ mod tests {
 
         let proposal = SidechainProposal {
             sidechain_number,
-            description: data.into(),
+            description,
         };
 
         let parsed: SidechainDeclaration =

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -219,7 +219,9 @@ pub mod crypto {
 
 pub mod mainchain {
     use crate::{
-        messages::{CoinbaseMessage, M4AckBundles},
+        messages::{
+            CoinbaseMessage, M1ProposeSidechain, M2AckSidechain, M3ProposeBundle, M4AckBundles,
+        },
         proto::common::{ConsensusHex, Hex, ReverseHex},
         types::SidechainNumber,
     };
@@ -345,7 +347,7 @@ pub mod mainchain {
         }
     }
 
-    impl TryFrom<get_coinbase_psbt_request::ProposeSidechain> for CoinbaseMessage {
+    impl TryFrom<get_coinbase_psbt_request::ProposeSidechain> for M1ProposeSidechain {
         type Error = super::Error;
 
         fn try_from(
@@ -368,17 +370,17 @@ pub mod mainchain {
                     )
                 })?
             };
-            let data: Vec<u8> = data
+            let description: Vec<u8> = data
                 .ok_or_else(|| Self::Error::missing_field::<ProposeSidechain>("data"))?
                 .decode::<ProposeSidechain, _>("data")?;
-            Ok(CoinbaseMessage::M1ProposeSidechain {
+            Ok(M1ProposeSidechain {
                 sidechain_number,
-                data,
+                description: description.into(),
             })
         }
     }
 
-    impl TryFrom<get_coinbase_psbt_request::AckSidechain> for CoinbaseMessage {
+    impl TryFrom<get_coinbase_psbt_request::AckSidechain> for M2AckSidechain {
         type Error = super::Error;
 
         fn try_from(
@@ -401,17 +403,17 @@ pub mod mainchain {
                     )
                 })?
             };
-            let data_hash: [u8; 32] = data_hash
+            let description_hash = data_hash
                 .ok_or_else(|| Self::Error::missing_field::<AckSidechain>("data_hash"))?
                 .decode::<AckSidechain, _>("data_hash")?;
-            Ok(CoinbaseMessage::M2AckSidechain {
+            Ok(M2AckSidechain {
                 sidechain_number,
-                data_hash,
+                description_hash,
             })
         }
     }
 
-    impl TryFrom<get_coinbase_psbt_request::ProposeBundle> for CoinbaseMessage {
+    impl TryFrom<get_coinbase_psbt_request::ProposeBundle> for M3ProposeBundle {
         type Error = super::Error;
 
         fn try_from(
@@ -437,7 +439,7 @@ pub mod mainchain {
             let bundle_txid: [u8; 32] = bundle_txid
                 .ok_or_else(|| Self::Error::missing_field::<ProposeBundle>("bundle_txid"))?
                 .decode::<ProposeBundle, _>("bundle_txid")?;
-            Ok(CoinbaseMessage::M3ProposeBundle {
+            Ok(M3ProposeBundle {
                 sidechain_number,
                 bundle_txid,
             })

--- a/src/server.rs
+++ b/src/server.rs
@@ -615,7 +615,7 @@ fn stream_proposal_confirmations(
 }
 
 #[tonic::async_trait]
-impl WalletService for Arc<crate::wallet::Wallet> {
+impl WalletService for crate::wallet::Wallet {
     type CreateSidechainProposalStream =
         BoxStream<'static, Result<CreateSidechainProposalResponse, tonic::Status>>;
 
@@ -677,9 +677,7 @@ impl WalletService for Arc<crate::wallet::Wallet> {
         &self,
         _request: tonic::Request<CreateNewAddressRequest>,
     ) -> std::result::Result<tonic::Response<CreateNewAddressResponse>, tonic::Status> {
-        let wallet = self as &Arc<crate::wallet::Wallet>;
-
-        let address = wallet.get_new_address().map_err(|err| err.into_status())?;
+        let address = self.get_new_address().map_err(|err| err.into_status())?;
 
         let response = CreateNewAddressResponse {
             address: address.to_string(),

--- a/src/validator/dbs/block_hashes.rs
+++ b/src/validator/dbs/block_hashes.rs
@@ -3,10 +3,7 @@ use fallible_iterator::FallibleIterator;
 use heed::{types::SerdeBincode, RoTxn};
 
 use crate::{
-    types::{
-        BlockInfo, BmmCommitments, Deposit, HeaderInfo, SidechainProposal, TwoWayPegData,
-        WithdrawalBundleEvent,
-    },
+    types::{BlockEvent, BlockInfo, BmmCommitments, HeaderInfo, TwoWayPegData},
     validator::dbs::util::{db_error, CreateDbError, Database, Env, RwTxn},
 };
 
@@ -119,45 +116,31 @@ pub struct BlockHashDbs {
     cumulative_work: Database<SerdeBincode<BlockHash>, SerdeBincode<Work>>,
     // All ancestors for each block MUST exist in this DB.
     // All keys in this DB MUST also exist in ALL other DBs.
-    deposits: Database<SerdeBincode<BlockHash>, SerdeBincode<Vec<Deposit>>>,
+    events: Database<SerdeBincode<BlockHash>, SerdeBincode<Vec<BlockEvent>>>,
     // All keys in this DB MUST also exist in `height`
     header: Database<SerdeBincode<BlockHash>, SerdeBincode<Header>>,
     // All keys in this DB MUST also exist in `header` as keys AND/OR
     // `prev_blockhash` in a value
     height: Database<SerdeBincode<BlockHash>, SerdeBincode<u32>>,
-    /// Sidechain proposals in each block sorted by coinbase vout
-    // All ancestors for each block MUST exist in this DB.
-    // All keys in this DB MUST also exist in ALL other DBs.
-    sidechain_proposals:
-        Database<SerdeBincode<BlockHash>, SerdeBincode<Vec<(u32, SidechainProposal)>>>,
-    // All ancestors for each block MUST exist in this DB.
-    // All keys in this DB MUST also exist in ALL other DBs.
-    withdrawal_bundle_events:
-        Database<SerdeBincode<BlockHash>, SerdeBincode<Vec<WithdrawalBundleEvent>>>,
 }
 
 impl BlockHashDbs {
-    pub const NUM_DBS: u32 = 8;
+    pub const NUM_DBS: u32 = 6;
 
     pub(super) fn new(env: &Env, rwtxn: &mut RwTxn) -> Result<Self, CreateDbError> {
         let bmm_commitments = env.create_db(rwtxn, "block_hash_to_bmm_commitments")?;
         let coinbase_txid = env.create_db(rwtxn, "block_hash_to_coinbase_txid")?;
         let cumulative_work = env.create_db(rwtxn, "block_hash_to_cumulative_work")?;
-        let deposits = env.create_db(rwtxn, "block_hash_to_deposits")?;
+        let events = env.create_db(rwtxn, "block_hash_to_events")?;
         let header = env.create_db(rwtxn, "block_hash_to_header")?;
         let height = env.create_db(rwtxn, "block_hash_to_height")?;
-        let sidechain_proposals = env.create_db(rwtxn, "block_hash_to_sidechain_proposals")?;
-        let withdrawal_bundle_events =
-            env.create_db(rwtxn, "block_hash_to_withdrawal_bundle_events")?;
         Ok(Self {
             bmm_commitments,
             coinbase_txid,
             cumulative_work,
-            deposits,
+            events,
             header,
             height,
-            sidechain_proposals,
-            withdrawal_bundle_events,
         })
     }
 
@@ -247,15 +230,7 @@ impl BlockHashDbs {
         let () = self
             .cumulative_work
             .put(rwtxn, block_hash, &cumulative_work)?;
-        let () = self.deposits.put(rwtxn, block_hash, &block_info.deposits)?;
-        let () =
-            self.sidechain_proposals
-                .put(rwtxn, block_hash, &block_info.sidechain_proposals)?;
-        let () = self.withdrawal_bundle_events.put(
-            rwtxn,
-            block_hash,
-            &block_info.withdrawal_bundle_events,
-        )?;
+        let () = self.events.put(rwtxn, block_hash, &block_info.events)?;
         Ok(())
     }
 
@@ -350,35 +325,15 @@ impl BlockHashDbs {
             );
             return Err(error::TryGetBlockInfo::InconsistentDbs(err));
         };
-        let Some(deposits) = self.deposits.try_get(rotxn, block_hash)? else {
+        let Some(events) = self.events.try_get(rotxn, block_hash)? else {
             let err =
-                db_error::InconsistentDbs::new(block_hash, &self.bmm_commitments, &self.deposits);
-            return Err(error::TryGetBlockInfo::InconsistentDbs(err));
-        };
-        let Some(sidechain_proposals) = self.sidechain_proposals.try_get(rotxn, block_hash)? else {
-            let err = db_error::InconsistentDbs::new(
-                block_hash,
-                &self.bmm_commitments,
-                &self.sidechain_proposals,
-            );
-            return Err(error::TryGetBlockInfo::InconsistentDbs(err));
-        };
-        let Some(withdrawal_bundle_events) =
-            self.withdrawal_bundle_events.try_get(rotxn, block_hash)?
-        else {
-            let err = db_error::InconsistentDbs::new(
-                block_hash,
-                &self.bmm_commitments,
-                &self.withdrawal_bundle_events,
-            );
+                db_error::InconsistentDbs::new(block_hash, &self.bmm_commitments, &self.events);
             return Err(error::TryGetBlockInfo::InconsistentDbs(err));
         };
         let block_info = BlockInfo {
             bmm_commitments,
             coinbase_txid,
-            deposits,
-            sidechain_proposals,
-            withdrawal_bundle_events,
+            events,
         };
         Ok(Some(block_info))
     }

--- a/src/validator/dbs/mod.rs
+++ b/src/validator/dbs/mod.rs
@@ -1,23 +1,59 @@
 use std::path::{Path, PathBuf};
 
-use bitcoin::{hashes::sha256d, Amount, OutPoint};
+use bitcoin::{Amount, OutPoint};
+use fallible_iterator::FallibleIterator as _;
 use heed::{types::SerdeBincode, EnvOpenOptions, RoTxn};
+use miette::Diagnostic;
 use ordermap::OrderMap;
 use thiserror::Error;
-use util::RoDatabase;
 
-use crate::types::{Ctip, Hash256, M6id, Sidechain, SidechainNumber, TreasuryUtxo};
+use crate::types::{
+    Ctip, Hash256, M6id, PendingM6idInfo, Sidechain, SidechainNumber, SidechainProposalId,
+    TreasuryUtxo,
+};
 
 mod block_hashes;
 mod util;
 
 pub use block_hashes::{error as block_hash_dbs_error, BlockHashDbs};
 pub use util::{
-    db_error, CommitWriteTxnError, Database, Env, ReadTxnError, RwTxn, UnitKey, WriteTxnError,
+    db_error, CommitWriteTxnError, Database, Env, ReadTxnError, RoDatabase, RwTxn, UnitKey,
+    WriteTxnError,
 };
 
-/// Map of pending M6ids to vote count
-pub type PendingM6ids = OrderMap<M6id, u16>;
+#[derive(Debug, Diagnostic, Error)]
+pub enum PutActiveSidechainError {
+    #[error(transparent)]
+    Put(#[from] db_error::Put),
+    #[error(transparent)]
+    TryGet(#[from] db_error::TryGet),
+}
+
+#[derive(Debug, Diagnostic, Error)]
+pub enum TryWithPendingWithdrawalsError {
+    #[error(transparent)]
+    Put(#[from] db_error::Put),
+    #[error(transparent)]
+    TryGet(#[from] db_error::TryGet),
+}
+
+#[derive(Debug, Diagnostic, Error)]
+pub enum TryUpvotePendingWithdrawalError {
+    #[error(transparent)]
+    Put(#[from] db_error::Put),
+    #[error(transparent)]
+    TryGet(#[from] db_error::TryGet),
+}
+
+#[derive(Debug, Diagnostic, Error)]
+pub enum RetainPendingWithdrawalsError {
+    #[error(transparent)]
+    Iter(#[from] db_error::Iter),
+    #[error(transparent)]
+    Put(#[from] db_error::Put),
+}
+
+pub type PendingM6ids = OrderMap<M6id, PendingM6idInfo>;
 
 /// These DBs should all contain exacty the same keys.
 #[derive(Clone)]
@@ -26,8 +62,10 @@ pub(super) struct ActiveSidechainDbs {
     /// MUST contain ALL keys/values that `ctip` has ever contained.
     ctip_outpoint_to_value:
         Database<SerdeBincode<OutPoint>, SerdeBincode<(SidechainNumber, Amount)>>,
-    pub pending_m6ids: Database<SerdeBincode<SidechainNumber>, SerdeBincode<PendingM6ids>>,
-    pub sidechain: Database<SerdeBincode<SidechainNumber>, SerdeBincode<Sidechain>>,
+    // ALL active sidechains MUST exist as keys
+    pending_m6ids: Database<SerdeBincode<SidechainNumber>, SerdeBincode<PendingM6ids>>,
+    // ALL active sidechains MUST exist as keys
+    sidechain: Database<SerdeBincode<SidechainNumber>, SerdeBincode<Sidechain>>,
     pub slot_sequence_to_treasury_utxo:
         Database<SerdeBincode<(SidechainNumber, u64)>, SerdeBincode<TreasuryUtxo>>,
     pub treasury_utxo_count: Database<SerdeBincode<SidechainNumber>, SerdeBincode<u64>>,
@@ -66,6 +104,16 @@ impl ActiveSidechainDbs {
         &self.ctip_outpoint_to_value
     }
 
+    pub fn pending_m6ids(
+        &self,
+    ) -> &RoDatabase<SerdeBincode<SidechainNumber>, SerdeBincode<PendingM6ids>> {
+        &self.pending_m6ids
+    }
+
+    pub fn sidechain(&self) -> &RoDatabase<SerdeBincode<SidechainNumber>, SerdeBincode<Sidechain>> {
+        &self.sidechain
+    }
+
     pub fn put_ctip(
         &self,
         rwtxn: &mut RwTxn,
@@ -75,6 +123,147 @@ impl ActiveSidechainDbs {
         self.ctip.put(rwtxn, &sidechain_number, ctip)?;
         self.ctip_outpoint_to_value
             .put(rwtxn, &ctip.outpoint, &(sidechain_number, ctip.value))
+    }
+
+    // Store a new active sidechain
+    pub fn put_sidechain(
+        &self,
+        rwtxn: &mut RwTxn,
+        sidechain_number: &SidechainNumber,
+        sidechain: &Sidechain,
+    ) -> Result<(), PutActiveSidechainError> {
+        if !self.pending_m6ids.contains_key(rwtxn, sidechain_number)? {
+            self.pending_m6ids
+                .put(rwtxn, sidechain_number, &PendingM6ids::new())?;
+        }
+        self.sidechain.put(rwtxn, sidechain_number, sidechain)?;
+        Ok(())
+    }
+
+    /// Apply the provided function to pending withdrawals.
+    /// Returns `None` if the sidechain is not active.
+    pub fn try_with_pending_withdrawals<T, F>(
+        &self,
+        rwtxn: &mut RwTxn,
+        sidechain_number: &SidechainNumber,
+        f: F,
+    ) -> Result<Option<T>, TryWithPendingWithdrawalsError>
+    where
+        F: FnOnce(&mut PendingM6ids) -> T,
+    {
+        let Some(mut pending_m6ids) = self.pending_m6ids.try_get(rwtxn, sidechain_number)? else {
+            return Ok(None);
+        };
+        let res = f(&mut pending_m6ids);
+        let () = self
+            .pending_m6ids
+            .put(rwtxn, sidechain_number, &pending_m6ids)?;
+        Ok(Some(res))
+    }
+
+    /// Apply the provided function to the specified entry.
+    /// Returns `None` if the sidechain is not active.
+    pub fn try_with_pending_withdrawal_entry<T, F>(
+        &self,
+        rwtxn: &mut RwTxn,
+        sidechain_number: &SidechainNumber,
+        m6id: M6id,
+        f: F,
+    ) -> Result<Option<T>, TryWithPendingWithdrawalsError>
+    where
+        F: FnOnce(ordermap::map::Entry<'_, M6id, PendingM6idInfo>) -> T,
+    {
+        self.try_with_pending_withdrawals(rwtxn, sidechain_number, |pending_withdrawals| {
+            f(pending_withdrawals.entry(m6id))
+        })
+    }
+
+    /// Store a new pending M6id.
+    /// Returns `true` if the sidechain is active.
+    pub fn try_put_pending_m6id(
+        &self,
+        rwtxn: &mut RwTxn,
+        sidechain_number: &SidechainNumber,
+        m6id: M6id,
+        proposal_height: u32,
+    ) -> Result<bool, TryWithPendingWithdrawalsError> {
+        self.try_with_pending_withdrawal_entry(rwtxn, sidechain_number, m6id, |entry| match entry {
+            ordermap::map::Entry::Occupied(mut entry) => {
+                _ = entry.insert(PendingM6idInfo::new(proposal_height))
+            }
+            ordermap::map::Entry::Vacant(entry) => {
+                _ = entry.insert(PendingM6idInfo::new(proposal_height))
+            }
+        })
+        .map(|res| res.is_some())
+    }
+
+    /// Downvote all pending withdrawals
+    /// Returns `true` if the sidechain is active.
+    pub fn try_alarm_pending_m6ids(
+        &self,
+        rwtxn: &mut RwTxn,
+        sidechain_number: &SidechainNumber,
+    ) -> Result<bool, TryWithPendingWithdrawalsError> {
+        self.try_with_pending_withdrawals(rwtxn, sidechain_number, |pending_m6ids| {
+            pending_m6ids
+                .values_mut()
+                .for_each(|info| info.vote_count = info.vote_count.saturating_sub(1))
+        })
+        .map(|res| res.is_some())
+    }
+
+    /// Upvote the pending withdrawal at the specified index
+    /// Returns `true` if the sidechain is active, and there is a pending
+    /// withdrawal at the specified index.
+    pub fn try_upvote_pending_withdrawal(
+        &self,
+        rwtxn: &mut RwTxn,
+        sidechain_number: &SidechainNumber,
+        index: usize,
+    ) -> Result<bool, TryUpvotePendingWithdrawalError> {
+        let Some(mut pending_m6ids) = self.pending_m6ids.try_get(rwtxn, sidechain_number)? else {
+            return Ok(false);
+        };
+        if let Some((_m6id, info)) = pending_m6ids.get_index_mut(index) {
+            info.vote_count = info.vote_count.saturating_add(1);
+            let () = self
+                .pending_m6ids
+                .put(rwtxn, sidechain_number, &pending_m6ids)?;
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    /// Retain pending withdrawals for which the predicate returns `true`
+    pub fn retain_pending_withdrawals<F>(
+        &self,
+        rwtxn: &mut RwTxn,
+        mut f: F,
+    ) -> Result<(), RetainPendingWithdrawalsError>
+    where
+        F: FnMut(SidechainNumber, &M6id, &PendingM6idInfo) -> bool,
+    {
+        let active_sidechains: Vec<_> = self
+            .pending_m6ids
+            .lazy_decode()
+            .iter(rwtxn)
+            .map_err(db_error::Iter::from)?
+            .map(|(sidechain_number, _)| Ok(sidechain_number))
+            .collect()
+            .map_err(db_error::Iter::from)?;
+        for sidechain_number in active_sidechains {
+            let mut pending_m6ids = self
+                .pending_m6ids
+                .get(rwtxn, &sidechain_number)
+                .expect("sidechain number should exist as key");
+            pending_m6ids.retain(|m6id, info| f(sidechain_number, m6id, info));
+            let () = self
+                .pending_m6ids
+                .put(rwtxn, &sidechain_number, &pending_m6ids)?;
+        }
+        Ok(())
     }
 }
 
@@ -102,10 +291,10 @@ pub(super) struct Dbs {
     pub block_hashes: BlockHashDbs,
     /// Tip that the enforcer is synced to
     pub current_chain_tip: Database<SerdeBincode<UnitKey>, SerdeBincode<bitcoin::BlockHash>>,
-    pub description_hash_to_sidechain:
-        Database<SerdeBincode<sha256d::Hash>, SerdeBincode<Sidechain>>,
     pub _leading_by_50: Database<SerdeBincode<UnitKey>, SerdeBincode<Vec<Hash256>>>,
     pub _previous_votes: Database<SerdeBincode<UnitKey>, SerdeBincode<Vec<Hash256>>>,
+    pub proposal_id_to_sidechain:
+        Database<SerdeBincode<SidechainProposalId>, SerdeBincode<Sidechain>>,
 }
 
 impl Dbs {
@@ -133,10 +322,9 @@ impl Dbs {
         let active_sidechains = ActiveSidechainDbs::new(&env, &mut rwtxn)?;
         let block_hashes = BlockHashDbs::new(&env, &mut rwtxn)?;
         let current_chain_tip = env.create_db(&mut rwtxn, "current_chain_tip")?;
-        let description_hash_to_sidechain =
-            env.create_db(&mut rwtxn, "description_hash_to_sidechain")?;
         let leading_by_50 = env.create_db(&mut rwtxn, "leading_by_50")?;
         let previous_votes = env.create_db(&mut rwtxn, "previous_votes")?;
+        let proposal_id_to_sidechain = env.create_db(&mut rwtxn, "proposal_id_to_sidechain")?;
         let () = rwtxn.commit()?;
 
         tracing::info!("Created validator DBs in {}", db_dir.display());
@@ -145,9 +333,9 @@ impl Dbs {
             active_sidechains,
             block_hashes,
             current_chain_tip,
-            description_hash_to_sidechain,
             _leading_by_50: leading_by_50,
             _previous_votes: previous_votes,
+            proposal_id_to_sidechain,
         })
     }
 

--- a/src/validator/task/mod.rs
+++ b/src/validator/task/mod.rs
@@ -572,7 +572,9 @@ fn connect_block(
                 let withdrawal_bundle_event = WithdrawalBundleEvent {
                     m6id,
                     sidechain_id,
-                    kind: WithdrawalBundleEventKind::Succeeded,
+                    kind: WithdrawalBundleEventKind::Succeeded {
+                        transaction: transaction.clone(),
+                    },
                 };
                 withdrawal_bundle_events.push(withdrawal_bundle_event);
             }

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -4,7 +4,7 @@ use std::{
     path::Path,
     str::FromStr,
     sync::Arc,
-    time::{SystemTime, UNIX_EPOCH},
+    time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 use bdk_electrum::{
@@ -41,14 +41,20 @@ use bitcoin::{
     Amount, Block, BlockHash, Network, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut,
     Txid, Witness,
 };
-use fallible_iterator::{FallibleIterator, IteratorExt};
+use fallible_iterator::{FallibleIterator as _, IteratorExt as _};
 use futures::{
     stream::{self, FusedStream},
-    StreamExt,
+    StreamExt as _, TryFutureExt, TryStreamExt as _,
 };
 use miette::{miette, IntoDiagnostic, Result};
 use parking_lot::{Mutex, RwLock};
 use rusqlite::Connection;
+use tokio::{
+    spawn,
+    task::{block_in_place, JoinHandle},
+    time::interval,
+};
+use tokio_stream::wrappers::IntervalStream;
 
 use crate::{
     cli::WalletConfig,
@@ -80,23 +86,23 @@ fn get_block_value(height: u32, fees: Amount, network: Network) -> Amount {
 
 type BundleProposals = Vec<(M6id, BlindedM6<'static>, Option<PendingM6idInfo>)>;
 
-pub struct Wallet {
+struct WalletInner {
     main_client: HttpClient,
     validator: Validator,
     bitcoin_wallet: Mutex<bdk_wallet::PersistedWallet<file_store::Store<ChangeSet>>>,
     bitcoin_db: Mutex<file_store::Store<ChangeSet>>,
-    db_connection: Arc<Mutex<rusqlite::Connection>>,
+    db_connection: Mutex<rusqlite::Connection>,
     bitcoin_blockchain: BdkElectrumClient<bdk_electrum::electrum_client::Client>,
-    last_sync: Arc<RwLock<Option<SystemTime>>>,
+    last_sync: RwLock<Option<SystemTime>>,
 }
 
-impl Wallet {
-    pub async fn new(
+impl WalletInner {
+    fn new(
         data_dir: &Path,
         config: &WalletConfig,
         main_client: HttpClient,
         validator: Validator,
-    ) -> Result<Self> {
+    ) -> Result<Self, miette::Report> {
         let mnemonic = Mnemonic::parse_in_normalized(
             Language::English,
             "betray annual dog current tomorrow media ghost dynamic mule length sure salad",
@@ -249,22 +255,172 @@ impl Wallet {
             db_connection
         };
 
-        let wallet = Self {
+        Ok(Self {
             main_client,
             validator,
-            // bitcoin_wallet: Arc::new(Mutex::new(bitcoin_wallet)),
             bitcoin_wallet: Mutex::new(bitcoin_wallet),
             bitcoin_db: Mutex::new(wallet_database),
-            db_connection: Arc::new(Mutex::new(db_connection)),
+            db_connection: Mutex::new(db_connection),
             bitcoin_blockchain,
+            last_sync: RwLock::new(None),
+        })
+    }
 
-            last_sync: Arc::new(RwLock::new(None)),
+    // Gets wiped upon generating a new block.
+    // TODO: how will this work for non-regtest?
+    fn delete_bundle_proposals<I>(&self, iter: I) -> Result<()>
+    where
+        I: IntoIterator<Item = (SidechainNumber, M6id)>,
+    {
+        // Satisfy clippy with a single function call per lock
+        let with_connection = |connection: &Connection| -> Result<_, _> {
+            for (sidechain_number, m6id) in iter {
+                let _ = connection.execute(
+                    "DELETE FROM bundle_proposals where sidechain_number = ?1 AND bundle_hash = ?2;",
+                    (sidechain_number.0, m6id.0.as_byte_array())
+                ).into_diagnostic()?;
+            }
+            Ok(())
         };
-        Ok(wallet)
+        with_connection(&self.db_connection.lock())
+    }
+
+    fn handle_connect_block(&self, block_info: crate::types::BlockInfo) -> Result<()> {
+        let finalized_withdrawal_bundles =
+            block_info
+                .withdrawal_bundle_events()
+                .filter_map(|event| match event.kind {
+                    WithdrawalBundleEventKind::Failed
+                    | WithdrawalBundleEventKind::Succeeded {
+                        sequence_number: _,
+                        transaction: _,
+                    } => Some((event.sidechain_id, event.m6id)),
+                    WithdrawalBundleEventKind::Submitted => None,
+                });
+        let () = self.delete_bundle_proposals(finalized_withdrawal_bundles)?;
+        Ok(())
+    }
+
+    pub fn handle_event(&self, event: crate::types::Event) -> Result<()> {
+        match event {
+            crate::types::Event::ConnectBlock {
+                header_info: _,
+                block_info,
+            } => {
+                let () = self.handle_connect_block(block_info)?;
+                Ok(())
+            }
+            crate::types::Event::DisconnectBlock { block_hash: _ } => {
+                todo!()
+            }
+        }
+    }
+
+    fn sync(&self) -> Result<(), miette::Report> {
+        let start = SystemTime::now();
+        tracing::trace!("starting wallet sync");
+
+        let mut wallet_lock = self.bitcoin_wallet.lock();
+        let mut last_sync_write = self.last_sync.write();
+        let request = wallet_lock.start_sync_with_revealed_spks();
+
+        const BATCH_SIZE: usize = 5;
+        const FETCH_PREV_TXOUTS: bool = false;
+
+        let update = self
+            .bitcoin_blockchain
+            .sync(request, BATCH_SIZE, FETCH_PREV_TXOUTS)
+            .into_diagnostic()?;
+
+        wallet_lock.apply_update(update).into_diagnostic()?;
+
+        let mut database = self.bitcoin_db.lock();
+        wallet_lock.persist(&mut database).into_diagnostic()?;
+
+        tracing::debug!(
+            "wallet sync complete in {:?}",
+            start.elapsed().unwrap_or_default(),
+        );
+
+        *last_sync_write = Some(SystemTime::now());
+        drop(last_sync_write);
+        drop(wallet_lock);
+        Ok(())
+    }
+}
+
+pub struct Tasks {
+    handle_event: JoinHandle<()>,
+    sync: JoinHandle<()>,
+}
+
+impl Tasks {
+    // TODO: return `Result<!, _>` once `never_type` is stabilized
+    async fn handle_event_task(wallet: Arc<WalletInner>) -> Result<(), miette::Report> {
+        let mut event_stream = wallet.validator.subscribe_events().boxed();
+        while let Some(event) = event_stream.try_next().await? {
+            let () = block_in_place(|| wallet.handle_event(event))?;
+        }
+        Ok(())
+    }
+
+    // TODO: return `Result<!, _>` once `never_type` is stabilized
+    async fn sync_task(wallet: Arc<WalletInner>) -> Result<(), miette::Report> {
+        const SYNC_INTERVAL: Duration = Duration::from_secs(15);
+        let mut interval_stream = IntervalStream::new(interval(SYNC_INTERVAL));
+        while let Some(_instant) = interval_stream.next().await {
+            let () = block_in_place(|| wallet.sync())?;
+        }
+        Ok(())
+    }
+
+    fn new(wallet: Arc<WalletInner>) -> Self {
+        Self {
+            handle_event: spawn(
+                Self::handle_event_task(wallet.clone()).unwrap_or_else(|err| {
+                    tracing::error!("wallet error while handling event: {err:#}")
+                }),
+            ),
+            sync: spawn(
+                Self::sync_task(wallet)
+                    .unwrap_or_else(|err| tracing::error!("wallet sync error: {err:#}")),
+            ),
+        }
+    }
+}
+
+impl Drop for Tasks {
+    fn drop(&mut self) {
+        let Self { handle_event, sync } = self;
+        handle_event.abort();
+        sync.abort();
+    }
+}
+
+/// Cheap to clone, since it uses Arc internally
+#[derive(Clone)]
+pub struct Wallet {
+    inner: Arc<WalletInner>,
+    _tasks: Arc<Tasks>,
+}
+
+impl Wallet {
+    pub fn new(
+        data_dir: &Path,
+        config: &WalletConfig,
+        main_client: HttpClient,
+        validator: Validator,
+    ) -> Result<Self> {
+        let inner = Arc::new(WalletInner::new(data_dir, config, main_client, validator)?);
+        let tasks = Tasks::new(inner.clone());
+        Ok(Self {
+            inner,
+            _tasks: Arc::new(tasks),
+        })
     }
 
     pub fn validator(&self) -> &Validator {
-        &self.validator
+        &self.inner.validator
     }
 
     /// Finalize a new block by constructing the coinbase tx
@@ -282,6 +438,7 @@ impl Wallet {
             best_blockhash,
             ..
         } = self
+            .inner
             .main_client
             .get_blockchain_info()
             .await
@@ -391,7 +548,7 @@ impl Wallet {
 
             Ok(proposals)
         };
-        with_connection(&self.db_connection.lock())
+        with_connection(&self.inner.db_connection.lock())
     }
 
     fn get_sidechain_acks(&self) -> Result<Vec<SidechainAck>> {
@@ -413,7 +570,7 @@ impl Wallet {
                 .into_diagnostic()?;
             Ok(rows)
         };
-        with_connection(&self.db_connection.lock())
+        with_connection(&self.inner.db_connection.lock())
     }
 
     fn get_bundle_proposals(&self) -> Result<HashMap<SidechainNumber, BundleProposals>> {
@@ -447,14 +604,17 @@ impl Wallet {
                 })?;
             Ok(bundle_proposals)
         };
-        let bundle_proposals = with_connection(&self.db_connection.lock())?;
+        let bundle_proposals = with_connection(&self.inner.db_connection.lock())?;
         // Filter out proposals that have already been created
         let res = bundle_proposals
             .into_iter()
             .map(Ok::<_, miette::Report>)
             .transpose_into_fallible()
             .filter_map(|(sidechain_id, m6ids)| {
-                let pending_m6ids = self.validator.get_pending_withdrawals(&sidechain_id)?;
+                let pending_m6ids = self
+                    .inner
+                    .validator
+                    .get_pending_withdrawals(&sidechain_id)?;
                 let res: Vec<_> = m6ids
                     .into_iter()
                     .map(|(m6id, blinded_m6)| (m6id, blinded_m6, pending_m6ids.get(&m6id).copied()))
@@ -475,6 +635,7 @@ impl Wallet {
         &self,
     ) -> Result<HashMap<SidechainNumber, SidechainProposal>> {
         let pending_proposals = self
+            .inner
             .validator
             .get_sidechains()?
             .into_iter()
@@ -490,7 +651,8 @@ impl Wallet {
     ) -> Result<()> {
         let sidechain_number: u8 = sidechain_number.into();
         let data_hash: &[u8; 32] = data_hash.as_byte_array();
-        self.db_connection
+        self.inner
+            .db_connection
             .lock()
             .execute(
                 "INSERT INTO sidechain_acks (number, data_hash) VALUES (?1, ?2)",
@@ -526,7 +688,8 @@ impl Wallet {
     }
 
     fn delete_sidechain_ack(&self, ack: &SidechainAck) -> Result<()> {
-        self.db_connection
+        self.inner
+            .db_connection
             .lock()
             .execute(
                 "DELETE FROM sidechain_acks WHERE number = ?1 AND data_hash = ?2",
@@ -562,13 +725,14 @@ impl Wallet {
 
             Ok(queried)
         };
-        with_connection(&self.db_connection.lock())
+        with_connection(&self.inner.db_connection.lock())
     }
 
     // Gets wiped upon generating a new block.
     // TODO: how will this work for non-regtest?
     fn delete_pending_sidechain_proposals(&self) -> Result<()> {
-        self.db_connection
+        self.inner
+            .db_connection
             .lock()
             .execute("DELETE FROM sidechain_proposals;", ())
             .into_diagnostic()?;
@@ -578,7 +742,8 @@ impl Wallet {
     // Gets wiped upon generating a new block.
     // TODO: how will this work for non-regtest?
     fn delete_bmm_requests(&self, prev_blockhash: &bitcoin::BlockHash) -> Result<()> {
-        self.db_connection
+        self.inner
+            .db_connection
             .lock()
             .execute(
                 "DELETE FROM bmm_requests where prev_block_hash = ?;",
@@ -586,25 +751,6 @@ impl Wallet {
             )
             .into_diagnostic()?;
         Ok(())
-    }
-
-    // Gets wiped upon generating a new block.
-    // TODO: how will this work for non-regtest?
-    fn delete_bundle_proposals<I>(&self, iter: I) -> Result<()>
-    where
-        I: IntoIterator<Item = (SidechainNumber, M6id)>,
-    {
-        // Satisfy clippy with a single function call per lock
-        let with_connection = |connection: &Connection| -> Result<_, _> {
-            for (sidechain_number, m6id) in iter {
-                let _ = connection.execute(
-                    "DELETE FROM bundle_proposals where sidechain_number = ?1 AND bundle_hash = ?2;",
-                    (sidechain_number.0, m6id.0.as_byte_array())
-                ).into_diagnostic()?;
-            }
-            Ok(())
-        };
-        with_connection(&self.db_connection.lock())
     }
 
     /// Mine a block
@@ -627,6 +773,7 @@ impl Wallet {
             .consensus_encode(&mut block_bytes)
             .map_err(error::EncodeBlock)?;
         let () = self
+            .inner
             .main_client
             .submit_block(hex::encode(block_bytes))
             .await
@@ -636,6 +783,7 @@ impl Wallet {
             })?;
         let block_hash = block.header.block_hash();
         tracing::info!(%block_hash, %transaction_count, "Submitted block");
+        tokio::time::sleep(Duration::from_millis(500)).await;
         Ok(block_hash)
     }
 
@@ -709,7 +857,7 @@ impl Wallet {
 
         let mut mempool_transactions = vec![];
 
-        let mainchain_tip = self.validator.get_mainchain_tip()?;
+        let mainchain_tip = self.inner.validator.get_mainchain_tip()?;
         let bmm_hashes = self.get_bmm_requests(&mainchain_tip)?;
         for (sidechain_number, bmm_hash) in &bmm_hashes {
             tracing::info!(
@@ -729,7 +877,7 @@ impl Wallet {
                         let Ctip { outpoint, value } = if let Some(ctip) = ctip {
                             ctip
                         } else {
-                            self.validator.get_ctip(sidechain_id)?
+                            self.inner.validator.get_ctip(sidechain_id)?
                         };
                         let new_value = (value - *blinded_m6.fee()) - *blinded_m6.payout();
                         let m6 = blinded_m6.into_m6(sidechain_id, outpoint, value)?;
@@ -753,11 +901,12 @@ impl Wallet {
         // TODO: Exclusively ack bundles that are known to the wallet
         // TODO: ack bundles when M2 messages are present
         if ack_all_proposals && coinbase_builder.messages().m2_acks().is_empty() {
-            let active_sidechains = self.validator.get_active_sidechains()?;
+            let active_sidechains = self.inner.validator.get_active_sidechains()?;
             let upvotes = active_sidechains
                 .into_iter()
                 .map(|sidechain| {
                     if self
+                        .inner
                         .validator
                         .get_pending_withdrawals(&sidechain.proposal.sidechain_number)?
                         .is_empty()
@@ -781,6 +930,7 @@ impl Wallet {
         // Including all the mempool transactions here ensure that pending sidechain deposit
         // transactions get included into a block.
         let raw_mempool = self
+            .inner
             .main_client
             .get_raw_mempool(BoolWitness::<false>, BoolWitness::<false>)
             .await
@@ -812,14 +962,14 @@ impl Wallet {
         ack_all_proposals: bool,
     ) -> impl FusedStream<Item = Result<BlockHash>>
     where
-        Ref: AsRef<Self>,
+        Ref: std::borrow::Borrow<Self>,
     {
         tracing::info!("Generate: creating {} blocks", count);
         stream::try_unfold((this, count), move |(this, remaining)| async move {
             if remaining == 0 {
                 Ok(None)
             } else {
-                let block_hash = this.as_ref().generate_block(ack_all_proposals).await?;
+                let block_hash = this.borrow().generate_block(ack_all_proposals).await?;
                 Ok(Some((block_hash, (this, remaining - 1))))
             }
         })
@@ -861,6 +1011,7 @@ impl Wallet {
         let block_hash = None;
 
         let transaction_hex = self
+            .inner
             .main_client
             .get_raw_transaction(txid, GetRawTransactionVerbose::<false>, block_hash)
             .await
@@ -1019,7 +1170,7 @@ impl Wallet {
         };
 
         let psbt = {
-            let mut wallet = self.bitcoin_wallet.lock();
+            let mut wallet = self.inner.bitcoin_wallet.lock();
             let mut builder = wallet.borrow_mut().build_tx();
 
             builder
@@ -1070,7 +1221,7 @@ impl Wallet {
         fee: Option<Amount>,
     ) -> Result<bitcoin::Txid> {
         // If this is None, there's been no deposit to this sidechain yet. We're the first one!
-        let sidechain_ctip = self.validator.try_get_ctip(sidechain_number)?;
+        let sidechain_ctip = self.inner.validator.try_get_ctip(sidechain_number)?;
         let sidechain_ctip = sidechain_ctip.as_ref();
 
         let sidechain_ctip_amount = sidechain_ctip
@@ -1123,11 +1274,11 @@ impl Wallet {
     }
 
     pub async fn get_wallet_balance(&self) -> Result<bdk_wallet::Balance> {
-        if self.last_sync.read().is_none() {
+        if self.inner.last_sync.read().is_none() {
             return Err(miette!("get balance: wallet not synced"));
         }
 
-        let balance = self.bitcoin_wallet.lock().balance();
+        let balance = self.inner.bitcoin_wallet.lock().balance();
 
         Ok(balance)
     }
@@ -1139,7 +1290,7 @@ impl Wallet {
     pub async fn list_wallet_transactions(&self) -> Result<Vec<BDKWalletTransaction>> {
         // Massage the wallet data into a format that we can use to calculate fees, etc.
         let wallet_data = {
-            let mut guard = self.bitcoin_wallet.lock();
+            let mut guard = self.inner.bitcoin_wallet.lock();
             let wallet = guard.borrow_mut();
             let transactions = wallet.transactions();
 
@@ -1183,6 +1334,7 @@ impl Wallet {
             // Get input values using getrawtransaction
             for input in inputs {
                 let transaction_hex = self
+                    .inner
                     .main_client
                     .get_raw_transaction(
                         input.previous_output.txid,
@@ -1200,7 +1352,7 @@ impl Wallet {
                         .into_diagnostic()?;
 
                 let value = prev_output.output[input.previous_output.vout as usize].value;
-                if self.bitcoin_wallet.lock().is_mine(
+                if self.inner.bitcoin_wallet.lock().is_mine(
                     prev_output.output[input.previous_output.vout as usize]
                         .script_pubkey
                         .clone(),
@@ -1241,7 +1393,7 @@ impl Wallet {
         op_return_output: Option<bdk_wallet::bitcoin::TxOut>,
     ) -> Result<bdk_wallet::bitcoin::psbt::Psbt> {
         let psbt = {
-            let mut wallet = self.bitcoin_wallet.lock();
+            let mut wallet = self.inner.bitcoin_wallet.lock();
             let mut builder = wallet.borrow_mut().build_tx();
 
             if let Some(op_return_output) = op_return_output {
@@ -1304,48 +1456,16 @@ impl Wallet {
         Ok(convert::bdk_txid_to_bitcoin_txid(txid))
     }
 
-    pub fn sync(&self) -> Result<()> {
-        let start = SystemTime::now();
-        tracing::trace!("starting wallet sync");
-
-        let mut wallet_lock = self.bitcoin_wallet.lock();
-        let mut last_sync_write = self.last_sync.write();
-        let request = wallet_lock.start_sync_with_revealed_spks();
-
-        const BATCH_SIZE: usize = 5;
-        const FETCH_PREV_TXOUTS: bool = false;
-
-        let update = self
-            .bitcoin_blockchain
-            .sync(request, BATCH_SIZE, FETCH_PREV_TXOUTS)
-            .into_diagnostic()?;
-
-        wallet_lock.apply_update(update).into_diagnostic()?;
-
-        let mut database = self.bitcoin_db.lock();
-        wallet_lock.persist(&mut database).into_diagnostic()?;
-
-        tracing::debug!(
-            "wallet sync complete in {:?}",
-            start.elapsed().unwrap_or_default(),
-        );
-
-        *last_sync_write = Some(SystemTime::now());
-        drop(last_sync_write);
-        drop(wallet_lock);
-        Ok(())
-    }
-
     #[allow(
         clippy::significant_drop_tightening,
         reason = "false positive for `bitcoin_wallet`"
     )]
     fn get_utxos(&self) -> Result<()> {
-        if self.last_sync.read().is_none() {
+        if self.inner.last_sync.read().is_none() {
             return Err(miette!("get utxos: wallet not synced"));
         }
 
-        let wallet_lock = self.bitcoin_wallet.lock();
+        let wallet_lock = self.inner.bitcoin_wallet.lock();
         let utxos = wallet_lock.list_unspent();
         for utxo in utxos {
             tracing::trace!(
@@ -1362,7 +1482,7 @@ impl Wallet {
     /// On signet: TBD, but needs some way of getting communicated to the miner.
     pub fn propose_sidechain(&self, proposal: &SidechainProposal) -> Result<(), rusqlite::Error> {
         let sidechain_number: u8 = proposal.sidechain_number.into();
-        self.db_connection.lock().execute(
+        self.inner.db_connection.lock().execute(
             "INSERT INTO sidechain_proposals (number, data) VALUES (?1, ?2)",
             (sidechain_number, &proposal.description.0),
         )?;
@@ -1370,7 +1490,8 @@ impl Wallet {
     }
 
     pub fn nack_sidechain(&self, sidechain_number: u8, data_hash: &[u8; 32]) -> Result<()> {
-        self.db_connection
+        self.inner
+            .db_connection
             .lock()
             .execute(
                 "DELETE FROM sidechain_acks WHERE number = ?1 AND data_hash = ?2",
@@ -1384,9 +1505,10 @@ impl Wallet {
         &self,
         sidechain_number: SidechainNumber,
     ) -> Result<Option<(bitcoin::OutPoint, Amount, u64)>> {
-        let ctip = self.validator.try_get_ctip(sidechain_number)?;
+        let ctip = self.inner.validator.try_get_ctip(sidechain_number)?;
 
         let sequence_number = self
+            .inner
             .validator
             .get_ctip_sequence_number(sidechain_number)?
             .unwrap();
@@ -1400,7 +1522,7 @@ impl Wallet {
     }
 
     pub fn is_sidechain_active(&self, sidechain_number: SidechainNumber) -> Result<bool> {
-        let sidechains = self.validator.get_active_sidechains()?;
+        let sidechains = self.inner.validator.get_active_sidechains()?;
         let active = sidechains
             .iter()
             .any(|sc| sc.proposal.sidechain_number == sidechain_number);
@@ -1413,6 +1535,7 @@ impl Wallet {
         mut psbt: bdk_wallet::bitcoin::psbt::Psbt,
     ) -> Result<bdk_wallet::bitcoin::Transaction> {
         if !self
+            .inner
             .bitcoin_wallet
             .lock()
             .sign(&mut psbt, bdk_wallet::signer::SignOptions::default())
@@ -1463,7 +1586,7 @@ impl Wallet {
         )?;
 
         let psbt = {
-            let mut bitcoin_wallet = self.bitcoin_wallet.lock();
+            let mut bitcoin_wallet = self.inner.bitcoin_wallet.lock();
             let mut builder = bitcoin_wallet.build_tx();
             builder
                 .nlocktime(locktime)
@@ -1502,7 +1625,7 @@ impl Wallet {
                     |_| Ok(true)
                 )
         };
-        with_connection(&self.db_connection.lock()).into_diagnostic()
+        with_connection(&self.inner.db_connection.lock()).into_diagnostic()
     }
 
     /// Creates a BMM request transaction. Does NOT broadcast.
@@ -1558,6 +1681,7 @@ impl Wallet {
 
         const MAX_BURN_AMOUNT: f64 = 21_000_000.0;
         let broadcast_result = self
+            .inner
             .main_client
             .send_raw_transaction(encoded_tx, None, Some(MAX_BURN_AMOUNT))
             .await
@@ -1574,12 +1698,12 @@ impl Wallet {
         // Using next_unused_address here means that we get a new address
         // when funds are received. Without this we'd need to take care not
         // to cross the wallet scan gap.
-        let mut wallet = self.bitcoin_wallet.lock();
+        let mut wallet = self.inner.bitcoin_wallet.lock();
         let info = wallet
             .borrow_mut()
             .next_unused_address(bdk_wallet::KeychainKind::External);
 
-        let mut bitcoin_db = self.bitcoin_db.lock();
+        let mut bitcoin_db = self.inner.bitcoin_db.lock();
         let bitcoin_db = bitcoin_db.borrow_mut();
         wallet.persist(bitcoin_db).into_diagnostic()?;
         Ok(info.address)
@@ -1592,7 +1716,7 @@ impl Wallet {
     ) -> Result<M6id> {
         let m6id = blinded_m6.compute_m6id();
         let tx_bytes = bitcoin::consensus::serialize(blinded_m6.as_ref());
-        self.db_connection
+        self.inner.db_connection
             .lock()
             .execute(
                 "INSERT OR IGNORE INTO bundle_proposals (sidechain_number, bundle_hash, bundle_tx) VALUES (?1, ?2, ?3)",
@@ -1600,36 +1724,5 @@ impl Wallet {
             )
             .into_diagnostic()?;
         Ok(m6id)
-    }
-
-    fn handle_connect_block(&self, block_info: crate::types::BlockInfo) -> Result<()> {
-        let finalized_withdrawal_bundles =
-            block_info
-                .withdrawal_bundle_events()
-                .filter_map(|event| match event.kind {
-                    WithdrawalBundleEventKind::Failed
-                    | WithdrawalBundleEventKind::Succeeded {
-                        sequence_number: _,
-                        transaction: _,
-                    } => Some((event.sidechain_id, event.m6id)),
-                    WithdrawalBundleEventKind::Submitted => None,
-                });
-        let () = self.delete_bundle_proposals(finalized_withdrawal_bundles)?;
-        Ok(())
-    }
-
-    pub fn handle_event(&self, event: crate::types::Event) -> Result<()> {
-        match event {
-            crate::types::Event::ConnectBlock {
-                header_info: _,
-                block_info,
-            } => {
-                let () = self.handle_connect_block(block_info)?;
-                Ok(())
-            }
-            crate::types::Event::DisconnectBlock { block_hash: _ } => {
-                todo!()
-            }
-        }
     }
 }


### PR DESCRIPTION
* Deletes failed and successful withdrawal bundles from the wallet
* Reject blocks with duplicate M2 for a sidechain slot
* Reject blocks with duplicate M4
* Handle one-byte M4 case correctly
* Accept M1 proposals that have the same description, but different sidechain slots
* Do not re-include failed M3 messages
* Wallet: create M6 txs when building blocks
* Fix encoding for blinded M6
* Exit on validator error, ctrl-c handler

Fixes #92, #31