### PR TITLE
multi: implement wallet initialization from BIP39 seed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -113,6 +148,18 @@ name = "anyhow"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
+
+[[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures",
+ "password-hash",
+]
 
 [[package]]
 name = "arrayref"
@@ -451,7 +498,9 @@ dependencies = [
 name = "bip300301_enforcer"
 version = "0.1.0"
 dependencies = [
+ "aes-gcm",
  "anyhow",
+ "argon2",
  "async-broadcast",
  "bdk_electrum",
  "bdk_wallet",
@@ -731,6 +780,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "clang-sys"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -887,7 +946,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
+ "rand_core",
  "typenum",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -1497,6 +1566,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
 name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2065,6 +2144,15 @@ dependencies = [
  "unicode-width 0.2.0",
  "vt100",
  "web-time",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -2717,6 +2805,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2804,6 +2898,17 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-targets",
+]
+
+[[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core",
+ "subtle",
 ]
 
 [[package]]
@@ -2923,6 +3028,18 @@ name = "polonius-the-crab"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a69ee997a6282f8462abf1e0d8c38c965e968799e912b3bed8c9e8a28c2f9f"
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -4216,6 +4333,16 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,13 +12,12 @@ protox = "0.7.1"
 tonic-build = "0.12.3"
 
 [dependencies]
+aes-gcm = "0.10.3"
 anyhow = "1.0.89"
+argon2 = "0.5.3"
 async-broadcast = "0.7.1"
 bdk_electrum = "0.20.1"
-bdk_wallet = { version = "1.0.0", features = [
-    "file_store",
-    "keys-bip39",
-] }
+bdk_wallet = { version = "1.0.0", features = ["file_store", "keys-bip39"] }
 bincode = "1.3.3"
 bitcoin = "0.32.3"
 blake3 = "1.5.4"
@@ -41,8 +40,8 @@ nonempty = "0.11.0"
 ordermap = { version = "0.5.3", features = ["serde"] }
 parking_lot = { version = "0.12.3", features = ["send_guard"] }
 prost = "0.13.2"
-rand = "0.8.5"
 prost-types = "0.13.3"
+rand = "0.8.5"
 regex = "1.11.0"
 rusqlite = { version = "0.32.1", features = ["bundled"] }
 rusqlite_migration = "1.3.1"
@@ -59,8 +58,6 @@ tower-http = { version = "0.6.1", features = ["trace"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 zeromq = "0.4.1"
-argon2 = "0.5.3"
-aes-gcm = "0.10.3"
 
 [dependencies.bip300301]
 git = "https://github.com/Ash-L2L/bip300301.git"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,8 @@ tower-http = { version = "0.6.1", features = ["trace"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 zeromq = "0.4.1"
+argon2 = "0.5.3"
+aes-gcm = "0.10.3"
 
 [dependencies.bip300301]
 git = "https://github.com/Ash-L2L/bip300301.git"

--- a/integration_tests/signet.rs
+++ b/integration_tests/signet.rs
@@ -229,7 +229,7 @@ async fn setup(bin_paths: &BinPaths) -> anyhow::Result<PostSetup> {
         coinbasetxn: false,
     };
     let calibrate_output = signet_miner
-        .command::<String, _, _, _, _>([], "calibrate", ["--seconds=1"])
+        .command(vec![], "calibrate", vec!["--seconds=1"])
         .run_utf8()
         .await?;
     let nbits_hex = {
@@ -252,10 +252,10 @@ async fn setup(bin_paths: &BinPaths) -> anyhow::Result<PostSetup> {
     signet_miner.nbits = Some(hex::FromHex::from_hex(&nbits_hex)?);
     tracing::debug!(%mining_address, %nbits_hex, "Mining 1 block");
     let mine_output = signet_miner
-        .command::<_, _, _, _, _>(
-            ["--debug"],
+        .command(
+            vec![],
             "generate",
-            ["--address".to_owned(), mining_address.to_string()],
+            vec!["--address", &mining_address.to_string()],
         )
         .run_utf8()
         .await?;
@@ -374,14 +374,14 @@ async fn mine_single(
     mining_address: &Address,
 ) -> anyhow::Result<()> {
     let _mine_output = signet_miner
-        .command::<String, _, _, _, _>(
-            [],
+        .command(
+            vec![],
             "generate",
-            [
-                "--address".to_owned(),
-                mining_address.to_string(),
-                "--block-interval".to_owned(),
-                "1".to_owned(),
+            vec![
+                "--address",
+                &mining_address.to_string(),
+                "--block-interval",
+                "1",
             ],
         )
         .run_utf8()

--- a/integration_tests/util.rs
+++ b/integration_tests/util.rs
@@ -435,26 +435,19 @@ pub struct SignetMiner {
 }
 
 impl SignetMiner {
-    pub fn command<CmdArg, Subcommand, SubcommandArg, CmdArgs, SubcommandArgs>(
+    pub fn command(
         &self,
-        command_args: CmdArgs,
-        subcommand: Subcommand,
-        subcommand_args: SubcommandArgs,
-    ) -> tokio::process::Command
-    where
-        CmdArg: AsRef<OsStr>,
-        Subcommand: AsRef<OsStr>,
-        SubcommandArg: AsRef<OsStr>,
-        CmdArgs: IntoIterator<Item = CmdArg>,
-        SubcommandArgs: IntoIterator<Item = SubcommandArg>,
-    {
+        command_args: Vec<&str>,
+        subcommand: &str,
+        subcommand_args: Vec<&str>,
+    ) -> tokio::process::Command {
         let mut command = tokio::process::Command::new(&self.path);
         command.arg(format!(
             "--cli={}",
             self.bitcoin_cli.display_without_chain()
         ));
         command.args(command_args);
-        let generate = subcommand.as_ref() == "generate";
+        let generate = subcommand == "generate";
         command.arg(subcommand);
         command.arg(format!("--grind-cmd={} grind", self.bitcoin_util.display()));
         if generate {

--- a/integration_tests/util.rs
+++ b/integration_tests/util.rs
@@ -446,6 +446,12 @@ impl SignetMiner {
             "--cli={}",
             self.bitcoin_cli.display_without_chain()
         ));
+
+        // Unless debug is explicitly set, we want to run in quiet mode. Otherwise
+        // we'll get lots of error logs about stderr not being empty.
+        if !command_args.contains(&"--debug") {
+            command.arg("--quiet");
+        }
         command.args(command_args);
         let generate = subcommand == "generate";
         command.arg(subcommand);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -94,10 +94,10 @@ pub struct WalletConfig {
     #[arg(long = "wallet-electrum-port")]
     pub electrum_port: Option<u16>,
 
-    /// If no existing wallet is found, automatically initialize a new one.
-    /// Creates an unencrypted, plaintext wallet.
-    #[arg(long = "wallet-auto-init", default_value_t = false)]
-    pub auto_initialize: bool,
+    /// If no existing wallet is found, automatically create and load
+    /// a new, unencrypted wallet from a randomly generated BIP39 mnemonic.
+    #[arg(long = "wallet-auto-create", default_value_t = false)]
+    pub auto_create: bool,
 }
 
 const DEFAULT_SERVE_RPC_ADDR: SocketAddr =

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -93,6 +93,11 @@ pub struct WalletConfig {
     /// Signet: 50001, regtest: 60401
     #[arg(long = "wallet-electrum-port")]
     pub electrum_port: Option<u16>,
+
+    /// If no existing wallet is found, automatically initialize a new one.
+    /// Creates an unencrypted, plaintext wallet.
+    #[arg(long = "wallet-auto-init", default_value_t = false)]
+    pub auto_initialize: bool,
 }
 
 const DEFAULT_SERVE_RPC_ADDR: SocketAddr =

--- a/src/main.rs
+++ b/src/main.rs
@@ -236,8 +236,8 @@ fn task(
             validator,
         )?;
 
-        if !wallet.is_initialized() && cli.wallet_opts.auto_initialize {
-            tracing::info!("auto-initiating new wallet");
+        if !wallet.is_initialized() && cli.wallet_opts.auto_create {
+            tracing::info!("auto-creating new wallet");
             let mnemonic = None;
             let password = None;
             wallet.create_wallet(mnemonic, password)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -196,8 +196,7 @@ async fn mempool_task<Enforcer, RpcClient, F, Fut>(
         {
             Ok(res) => res,
             Err(err) => {
-                let err = anyhow::Error::from(err);
-                tracing::error!("mempool sync error: {err:#}");
+                let err = anyhow::anyhow!("mempool sync error: {err:#}");
                 let _send_err: Result<(), _> = err_tx.send(err);
                 return;
             }

--- a/src/wallet/error.rs
+++ b/src/wallet/error.rs
@@ -31,6 +31,38 @@ impl From<ElectrumError> for tonic::Status {
     }
 }
 
+// Errors related to creating/unlocking wallets.
+#[derive(Debug, Diagnostic, Error)]
+pub enum WalletInitialization {
+    #[error("wallet not unlocked")]
+    #[diagnostic(code(wallet_not_unlocked))]
+    NotUnlocked,
+
+    #[error("wallet already unlocked")]
+    #[diagnostic(code(wallet_already_unlocked))]
+    AlreadyUnlocked,
+
+    #[error("wallet not found (can be created with CreateWallet RPC)")]
+    #[diagnostic(code(wallet_not_found))]
+    NotFound,
+
+    #[error("wallet already exists (but might not be initialized)")]
+    #[diagnostic(code(wallet_already_exists))]
+    AlreadyExists,
+
+    /// This means you've been fooling around with different mnemonics and data directories!
+    /// Wallet directory probably needs to be wiped.
+    #[error(
+        "wallet data mismatch, data directory content does not line up with wallet descriptor"
+    )]
+    #[diagnostic(code(wallet_data_mismatch))]
+    DataMismatch,
+
+    #[error("invalid password")]
+    #[diagnostic(code(wallet_invalid_password))]
+    InvalidPassword,
+}
+
 #[derive(Debug, Diagnostic, Error)]
 #[error("Bitcoin Core RPC error `{method}")]
 #[diagnostic(code(bitcoin_core_rpc_error))]

--- a/src/wallet/mnemonic.rs
+++ b/src/wallet/mnemonic.rs
@@ -1,0 +1,86 @@
+use aes_gcm::{
+    aead::{Aead, AeadCore, KeyInit, OsRng},
+    Aes256Gcm, Key, Nonce,
+};
+use argon2::Argon2;
+use bdk_wallet::{
+    bip39::{Language, Mnemonic},
+    keys::{bip39::WordCount, GeneratableKey, GeneratedKey},
+    miniscript::miniscript,
+};
+use miette::{miette, IntoDiagnostic, Result};
+use std::str::FromStr;
+
+/// Create a cryptographically secure mnemonic.
+pub(crate) fn new_mnemonic() -> Result<Mnemonic, miette::Report> {
+    // This is cribbed from the official docs: https://bitcoindevkit.org/getting-started/
+
+    let options = (WordCount::Words12, Language::English);
+    let generated: GeneratedKey<_, miniscript::Segwitv0> =
+        Mnemonic::generate_with_aux_rand(options, &mut OsRng)
+            .map_err(|err| miette!("failed to generate mnemonic: {:#}", err.unwrap()))?;
+
+    let words = generated.to_string();
+    Mnemonic::parse(words).into_diagnostic()
+}
+
+/// Encrypted with AES-256-GCM. Password is stretched
+/// with argon2 to 32 bytes, before being used as the key.
+pub(crate) struct EncryptedMnemonic {
+    pub initialization_vector: Vec<u8>,
+    pub ciphertext_mnemonic: Vec<u8>,
+    pub key_salt: Vec<u8>,
+}
+
+// Encryption/decryption is based off of this blog post, with the addition of the argon2 key stretch.
+// https://backendengineer.io/aes-encryption-rust
+impl EncryptedMnemonic {
+    pub(crate) fn encrypt(mnemonic: &Mnemonic, password: &str) -> Result<Self, miette::Report> {
+        use rand::Rng;
+        let key_salt = OsRng.gen::<[u8; 16]>();
+
+        let key_bytes = stretch_password(password, &key_salt)?;
+        let key = Key::<Aes256Gcm>::from_slice(&key_bytes);
+
+        let nonce = Aes256Gcm::generate_nonce(&mut OsRng);
+        let cipher = Aes256Gcm::new(key);
+
+        let ciphered_data = cipher
+            .encrypt(&nonce, mnemonic.to_string().as_bytes())
+            .map_err(|err| miette::miette!("failed to encrypt mnemonic: {err:#}"))?;
+
+        Ok(Self {
+            initialization_vector: nonce.to_vec(),
+            ciphertext_mnemonic: ciphered_data,
+            key_salt: key_salt.to_vec(),
+        })
+    }
+
+    pub(crate) fn decrypt(&self, password: &str) -> Result<Mnemonic, miette::Report> {
+        let nonce = Nonce::from_slice(self.initialization_vector.as_ref());
+
+        let key_bytes = stretch_password(password, self.key_salt.as_ref())?;
+        let key = Key::<Aes256Gcm>::from_slice(&key_bytes);
+
+        let cipher = Aes256Gcm::new(key);
+
+        let plaintext = cipher
+            .decrypt(nonce, self.ciphertext_mnemonic.as_ref())
+            .map_err(|err| miette::miette!("failed to decrypt mnemonic: {err:#}"))?;
+
+        let raw_mnemonic = String::from_utf8(plaintext)
+            .map_err(|err| miette::miette!("failed to convert mnemonic to string: {err:#}"))?;
+
+        Mnemonic::from_str(&raw_mnemonic)
+            .map_err(|err| miette::miette!("failed to parse mnemonic: {err:#}"))
+    }
+}
+
+fn stretch_password(password: &str, key_salt: &[u8]) -> Result<[u8; 32], miette::Report> {
+    let mut key_bytes = [0u8; 32];
+    Argon2::default()
+        .hash_password_into(password.as_bytes(), key_salt, &mut key_bytes)
+        .map_err(|err| miette::miette!("failed to stretch password into AES key: {err:#}"))?;
+
+    Ok(key_bytes)
+}


### PR DESCRIPTION
The wallet is now no longer initialized with a hard coded BIP39 seed. In this PR we add support for both plaintext + encrypted mnemonics. They can either be passed in through the new `CreateWallet` endpoint, or generated automatically. 

For testing/dev purposes we also add a new `--wallet-auto-init` flag that generates a brand new, plaintext mnemonic if it doesn't already exist. 

TODO: 
- [x] fix existing integration tests
- [ ] add more integration tests
- [ ] document behavior in the README
- [ ] probably flesh out some of the CLI doc comments