### PR TITLE
update proto, track ctip seq numbers, bump minor version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "bip300301_enforcer"
-version = "0.1.7"
+version = "0.2.0"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bip300301_enforcer"
-version = "0.1.7"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, num::TryFromIntError};
+use std::{borrow::Cow, num::TryFromIntError, sync::Arc};
 
 use bdk_wallet::chain::{ChainPosition, ConfirmationBlockTime};
 use bitcoin::{
@@ -9,7 +9,7 @@ use bitcoin::{
         OP_TRUE,
     },
     script::{Instruction, Instructions},
-    Amount, BlockHash, Opcode, OutPoint, ScriptBuf, Txid, Work,
+    Amount, BlockHash, Opcode, OutPoint, ScriptBuf, Transaction, Txid, Work,
 };
 use derive_more::derive::Display;
 use hashlink::LinkedHashMap;
@@ -397,6 +397,7 @@ pub enum Event {
 #[derive(Debug)]
 pub struct BDKWalletTransaction {
     pub txid: bitcoin::Txid,
+    pub tx: Arc<Transaction>,
     pub chain_position: ChainPosition<ConfirmationBlockTime>,
     pub fee: Amount,
     pub received: Amount,

--- a/src/validator/task/error.rs
+++ b/src/validator/task/error.rs
@@ -108,9 +108,6 @@ pub(in crate::validator) enum HandleFailedM6Ids {
 pub(in crate::validator) enum HandleM5M6 {
     #[error(transparent)]
     #[fatal]
-    DbPut(#[from] db_error::Put),
-    #[error(transparent)]
-    #[fatal]
     DbTryGet(#[from] db_error::TryGet),
     #[error("Invalid M6")]
     InvalidM6,
@@ -118,6 +115,9 @@ pub(in crate::validator) enum HandleM5M6 {
     M6id(#[from] crate::messages::M6idError),
     #[error("Old Ctip for sidechain {} is unspent", .sidechain_number.0)]
     OldCtipUnspent { sidechain_number: SidechainNumber },
+    #[error(transparent)]
+    #[fatal]
+    PutCtip(#[from] dbs::PutCtipError),
     #[error(transparent)]
     #[fatal]
     TryWithPendingWithdrawals(#[from] dbs::TryWithPendingWithdrawalsError),

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -1272,14 +1272,14 @@ impl Wallet {
                     // Just collect the inputs - we'll get their values using getrawtransaction later
                     let inputs = tx.input.clone();
 
-                    (txid, chain_position, output_ownership, inputs)
+                    (txid, tx, chain_position, output_ownership, inputs)
                 })
                 .collect::<Vec<_>>()
         };
 
         // Calculate fees, received, and sent amounts
         let mut txs = Vec::new();
-        for (txid, chain_position, output_ownership, inputs) in wallet_data {
+        for (txid, tx, chain_position, output_ownership, inputs) in wallet_data {
             let mut input_value = Amount::ZERO;
             let mut output_value = Amount::ZERO;
             let mut received = Amount::ZERO;
@@ -1335,6 +1335,7 @@ impl Wallet {
 
             txs.push(BDKWalletTransaction {
                 txid,
+                tx,
                 chain_position,
                 fee,
                 received: final_received,


### PR DESCRIPTION
This is a breaking change to the validator DB.
Upgrading the signet miner server will require:
* stopping the mining script
* saving the wallet db
* syncing a new enforcer (v0.2.0) with a different data dir, etc, in order to get a new validator db
* shutting down the old enforcer (v0.1.x)
* copying over the wallet db