### PR TITLE
app: add request IDs to req/res/traces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -503,6 +503,7 @@ dependencies = [
  "cusf-enforcer-mempool",
  "either",
  "futures",
+ "http",
  "jsonrpsee",
  "miette",
  "tokio",
@@ -514,6 +515,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]
@@ -4309,6 +4311,7 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -4535,9 +4538,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.11.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b913a3b5fe84142e269d63cc62b64319ccaf89b748fc31fe025177f767a756c4"
+checksum = "b3758f5e68192bb96cc8f9b7e2c2cfdabb435499a28499a42f8f984092adad4b"
 dependencies = [
  "getrandom",
 ]

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -13,6 +13,7 @@ clap = { workspace = true }
 cusf-enforcer-mempool = { workspace = true }
 either = { workspace = true }
 futures = { workspace = true }
+http = "1.2.0"
 jsonrpsee = { workspace = true, features = ["server"] }
 miette = { workspace = true, features = ["fancy"] }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
@@ -20,10 +21,11 @@ tonic = { workspace = true }
 tonic-health = "0.12.3"
 tonic-reflection = "0.12.3"
 tower = "0.5.1"
-tower-http = { version = "0.6.1", features = ["trace"] }
+tower-http = { version = "0.6.1", features = ["trace", "request-id"] }
 tracing = { workspace = true }
 tracing-appender = "0.2.3"
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
+uuid = "1.12.1"
 
 [features]
 default = ["rustls"]


### PR DESCRIPTION
Adds a new ID to all requests/responses. The ID is propagated to logs, under the `request_id` field. The ID can be specified in the request, in the `x-request-id` header. If none is provided, a random UUID is used. The request ID is sent back in the response, in the same header.