### PR TITLE
multi: asyncify, use rusqlite-based persistence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -613,6 +613,7 @@ dependencies = [
  "serde_path_to_error",
  "thiserror 2.0.11",
  "tokio",
+ "tokio-rusqlite",
  "tokio-stream",
  "tonic",
  "tonic-build",
@@ -4399,6 +4400,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.96",
+]
+
+[[package]]
+name = "tokio-rusqlite"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2cc5f712424f089fc6549afe39773e9f8914ce170c45b546be24830b482b127"
+dependencies = [
+ "crossbeam-channel",
+ "rusqlite",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,6 +387,7 @@ dependencies = [
  "bdk_core",
  "bitcoin",
  "miniscript",
+ "rusqlite",
  "serde",
 ]
 
@@ -424,24 +425,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "bdk_file_store"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2502fb75506a21d0b6e1b2002ecd9953ad1f70d82d4c3aaf812db1c028662ff1"
-dependencies = [
- "bdk_core",
- "bincode",
- "serde",
-]
-
-[[package]]
 name = "bdk_wallet"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c6362d350e13a94f68a102dafadbcc1500705016e4c2971b4c4e6f46054cb18"
 dependencies = [
  "bdk_chain",
- "bdk_file_store",
  "bip39",
  "bitcoin",
  "miniscript",
@@ -2662,9 +2651,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.30.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
 dependencies = [
  "cc",
  "pkg-config",
@@ -3617,9 +3606,9 @@ checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
 
 [[package]]
 name = "rusqlite"
-version = "0.32.1"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
 dependencies = [
  "bitflags 2.7.0",
  "fallible-iterator",
@@ -3631,9 +3620,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite_migration"
-version = "1.3.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "923b42e802f7dc20a0a6b5e097ba7c83fe4289da07e49156fecf6af08aa9cd1c"
+checksum = "55709bc01054c69e2f1cefdc886642b5e6376a8db3c86f761be0c423eebf178b"
 dependencies = [
  "log",
  "rusqlite",

--- a/app/main.rs
+++ b/app/main.rs
@@ -370,7 +370,7 @@ struct ErrRxs {
     grpc_server: oneshot::Receiver<miette::Report>,
 }
 
-fn task(
+async fn task(
     enforcer: Either<Validator, Wallet>,
     cli: cli::Config,
     mainchain_client: bip300301::jsonrpsee::http_client::HttpClient,
@@ -580,7 +580,7 @@ async fn main() -> Result<()> {
         Either::Left(validator)
     };
 
-    let (_task, err_rxs) = task(enforcer.clone(), cli, mainchain_client, info.chain)?;
+    let (_task, err_rxs) = task(enforcer.clone(), cli, mainchain_client, info.chain).await?;
 
     tokio::select! {
         enforcer_task_err = err_rxs.enforcer_task => {

--- a/app/main.rs
+++ b/app/main.rs
@@ -1,4 +1,4 @@
-use std::{future::Future, net::SocketAddr, path::Path, str::FromStr, time::Duration};
+use std::{future::Future, net::SocketAddr, path::Path, time::Duration};
 
 use bdk_wallet::bip39::{Language, Mnemonic};
 use bip300301::MainClient;

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -21,7 +21,7 @@ bdk_esplora = { version = "0.20.1", default-features = false, features = [
     "tokio",
     "async-https-rustls",
 ] }
-bdk_wallet = { workspace = true, features = ["file_store", "keys-bip39"] }
+bdk_wallet = { workspace = true, features = ["keys-bip39", "rusqlite"] }
 bincode = "1.3.3"
 bip300301 = { workspace = true }
 bitcoin = { workspace = true }
@@ -51,8 +51,9 @@ prost = "0.13.2"
 prost-types = "0.13.3"
 rand = "0.8.5"
 regex = "1.11.0"
-rusqlite = { version = "0.32.1", features = ["bundled"] }
-rusqlite_migration = "1.3.1"
+# needs to line up with BDK version
+rusqlite = { version = "0.31.0", features = ["bundled"] }
+rusqlite_migration = "1.0.0"
 serde = { version = "1.0.197", features = ["derive"] }
 serde_path_to_error = "0.1.16"
 thiserror = { workspace = true }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -58,6 +58,8 @@ serde = { version = "1.0.197", features = ["derive"] }
 serde_path_to_error = "0.1.16"
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["macros"] }
+# Latest version (0.6.0) introduces a non-compatible libsqlite3-sys version
+tokio-rusqlite = "0.5.1"
 tokio-stream = { workspace = true }
 tonic = { workspace = true }
 tracing = { workspace = true }

--- a/lib/wallet/error.rs
+++ b/lib/wallet/error.rs
@@ -93,7 +93,7 @@ pub enum WalletSync {
     #[error(transparent)]
     BdkWalletConnect(#[from] bdk_wallet::chain::local_chain::CannotConnectError),
     #[error(transparent)]
-    BdkWalletPersist(#[from] bdk_wallet::FileStoreError),
+    BdkWalletPersist(#[from] super::PersistenceError),
     #[error(transparent)]
     ElectrumSync(#[from] bdk_electrum::electrum_client::Error),
     #[error(transparent)]
@@ -158,8 +158,6 @@ pub(in crate::wallet) enum GenerateSuffixTxs {
 pub enum ConnectBlock {
     #[error(transparent)]
     BdkConnect(#[from] bdk_wallet::chain::local_chain::CannotConnectError),
-    #[error(transparent)]
-    BdkFileStore(#[from] bdk_wallet::FileStoreError),
     #[error(transparent)]
     ConnectBlock(#[from] <Validator as CusfEnforcer>::ConnectBlockError),
     #[error(transparent)]

--- a/lib/wallet/error.rs
+++ b/lib/wallet/error.rs
@@ -165,9 +165,29 @@ pub enum ConnectBlock {
     #[error(transparent)]
     GetHeaderInfo(#[from] validator::GetHeaderInfoError),
     #[error(transparent)]
-    Rustqlite(#[from] rusqlite::Error),
+    Sqlite(#[from] SqliteError),
     #[error(transparent)]
     WalletNotUnlocked(#[from] NotUnlocked),
+}
+
+#[derive(Debug, Error)]
+pub enum SqliteError {
+    #[error(transparent)]
+    Rusqlite(#[from] rusqlite::Error),
+    #[error(transparent)]
+    TokioRusqlite(#[from] tokio_rusqlite::Error),
+}
+
+impl From<tokio_rusqlite::Error> for ConnectBlock {
+    fn from(error: tokio_rusqlite::Error) -> Self {
+        Self::Sqlite(SqliteError::TokioRusqlite(error))
+    }
+}
+
+impl From<rusqlite::Error> for ConnectBlock {
+    fn from(error: rusqlite::Error) -> Self {
+        Self::Sqlite(SqliteError::Rusqlite(error))
+    }
 }
 
 #[derive(Debug, Diagnostic, Error)]

--- a/lib/wallet/mod.rs
+++ b/lib/wallet/mod.rs
@@ -63,7 +63,7 @@ mod util;
 type BundleProposals = Vec<(M6id, BlindedM6<'static>, Option<PendingM6idInfo>)>;
 
 pub(crate) type Persistence = thread_safe_connection::ThreadSafeConnection;
-pub(crate) type PersistenceError = bdk_wallet::rusqlite::Error;
+pub(crate) type PersistenceError = tokio_rusqlite::Error;
 type BdkWallet = bdk_wallet::PersistedWallet<Persistence>;
 
 type ElectrumClient = BdkElectrumClient<bdk_electrum::electrum_client::Client>;
@@ -287,8 +287,9 @@ impl WalletInner {
             network,
         );
 
-        let mut wallet_database =
-            thread_safe_connection::ThreadSafeConnection::open(database_path).into_diagnostic()?;
+        let mut wallet_database = thread_safe_connection::ThreadSafeConnection::open(database_path)
+            .await
+            .into_diagnostic()?;
 
         let chain_source = match config.wallet_opts.sync_source {
             WalletSyncSource::Electrum => {

--- a/lib/wallet/thread_safe_connection.rs
+++ b/lib/wallet/thread_safe_connection.rs
@@ -1,0 +1,64 @@
+use std::future::Future;
+use std::path::Path;
+use std::pin::Pin;
+use std::sync::Mutex;
+
+use rusqlite::{Connection, Result};
+
+use bdk_wallet::{AsyncWalletPersister, ChangeSet};
+
+/// A simple thread‑safe wrapper around a rusqlite::Connection that implements AsyncWalletPersister.
+#[derive(Debug)]
+pub struct ThreadSafeConnection(Mutex<Connection>);
+
+impl ThreadSafeConnection {
+    /// Opens a new connection at the given path and returns a new ThreadSafeConnection.
+    pub fn open<P: AsRef<Path>>(path: P) -> Result<Self> {
+        let conn = Connection::open(path)?;
+        Ok(ThreadSafeConnection(Mutex::new(conn)))
+    }
+}
+
+/// Cribbed from the implementation of WalletPersister from BDK
+/// https://github.com/bitcoindevkit/bdk/blob/7067da1522c5c2ae4e457846cfe5bd6aefafbe9e/crates/wallet/src/wallet/persisted.rs#L271-L287
+impl AsyncWalletPersister for ThreadSafeConnection {
+    type Error = rusqlite::Error;
+
+    /// Initializes the persister, e.g., running any necessary migrations.
+    /// This implementation acquires a transaction, runs the necessary initialization
+    /// on sqlite tables, builds a ChangeSet from the transaction, commits, and returns it.
+    fn initialize<'a>(
+        persister: &'a mut Self,
+    ) -> Pin<Box<dyn Future<Output = Result<ChangeSet, Self::Error>> + Send + 'a>>
+    where
+        Self: 'a,
+    {
+        Box::pin(async move {
+            let mut conn = persister.0.lock().expect("Mutex poisoned");
+            let tx = conn.transaction()?;
+            ChangeSet::init_sqlite_tables(&tx)?;
+            let cs = ChangeSet::from_sqlite(&tx)?;
+            tx.commit()?;
+            drop(conn);
+            Ok(cs)
+        })
+    }
+
+    /// Persists the given changeset.
+    fn persist<'a>(
+        persister: &'a mut Self,
+        changeset: &'a ChangeSet,
+    ) -> Pin<Box<dyn Future<Output = Result<(), Self::Error>> + Send + 'a>>
+    where
+        Self: 'a,
+    {
+        Box::pin(async move {
+            let mut conn = persister.0.lock().expect("Mutex poisoned");
+            let tx = conn.transaction()?;
+            changeset.persist_to_sqlite(&tx)?;
+            tx.commit()?;
+            drop(conn);
+            Ok(())
+        })
+    }
+}


### PR DESCRIPTION
Currently struggling with the type check 😅 

Need to be able to run async functions within `with_mut` of the wallet `RwLockWriteGuardSome`. Is that possible?