### PR TITLE
multi: rework sync for big wallets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -572,6 +572,7 @@ dependencies = [
  "argon2",
  "async-broadcast",
  "async-lock",
+ "bdk_chain",
  "bdk_electrum",
  "bdk_esplora",
  "bdk_wallet",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -16,6 +16,7 @@ aes-gcm = "0.10.3"
 argon2 = "0.5.3"
 async-broadcast = "0.7.1"
 async-lock = "3.4.0"
+bdk_chain = "0.21.1"
 bdk_electrum = { version = "0.20.1", default-features = false }
 bdk_esplora = { version = "0.20.1", default-features = false, features = [
     "tokio",


### PR DESCRIPTION
1. If the periodic sync is disabled, skip syncing alltogether in `sync_to_tip`

2. Rework the full scan into using chain checkpoints. Do this only after the validator has finished its initial sync