### PR TITLE
multi: mining fixes

### DIFF
--- a/app/main.rs
+++ b/app/main.rs
@@ -519,7 +519,10 @@ async fn main() -> Result<()> {
 
         let payload = match info.payload().downcast_ref::<&str>() {
             Some(s) => s.to_string(),
-            None => format!("{:#?}", info.payload()).to_string(),
+            None => match info.payload().downcast_ref::<String>() {
+                Some(s) => s.clone(),
+                None => format!("{:#?}", info.payload()).to_string(),
+            },
         };
         tracing::error!(location, "Panicked during execution: `{payload}`");
         default_hook(info); // Panics are bad. re-throw!

--- a/lib/bins.rs
+++ b/lib/bins.rs
@@ -42,6 +42,12 @@ impl CommandExt for tokio::process::Command {
                     Ok(err_msgs) => err_msgs,
                     Err(err) => hex::encode(err.into_bytes()),
                 };
+
+                // Check for some known error modes in stderr output
+                if stderr.contains("WARNING submitblock returned bad-diffbits") {
+                    let err_msg = "block rejected: bad-diffbits";
+                    return Err(CommandError::Stderr(err_msg.to_string().into_bytes()));
+                }
                 tracing::warn!("Command ran successfully, but stderr was not empty: `{stderr}`")
             }
             Ok(output.stdout)

--- a/lib/wallet/mine.rs
+++ b/lib/wallet/mine.rs
@@ -527,7 +527,7 @@ impl Wallet {
                 // Execute the download script
                 let mut command = Command::new("bash");
 
-                // https://github.com/LayerTwo-Labs/bitcoin-patched/commit/db46e768a88a5c5cf5ec1b1a6bc56023cc201884
+                // https://github.com/LayerTwo-Labs/bitcoin-patched/blob/db46e768a88a5c5cf5ec1b1a6bc56023cc201884/contrib/signet/miner
                 const BITCOIN_PATCHED_COMMIT: &str = "db46e768a88a5c5cf5ec1b1a6bc56023cc201884";
                 command.current_dir(&dir)
                 .arg("-c")


### PR DESCRIPTION
1. Clearer error message and failure mode when unable to mine a new block
2. Refine panic hooks, to make it easier to pick up the actual message
3. Most important: let Bitcoin Core mine on its own when it's time for difficulty adjustments. I'm unable to get the PoW target calculations working correctly, and this is a hacky workaround that gets blocks flowing again.