### PR TITLE
wallet: add no-sync source

### DIFF
--- a/lib/cli.rs
+++ b/lib/cli.rs
@@ -289,13 +289,15 @@ pub struct NodeRpcConfig {
     pub pass: Option<String>,
 }
 
-#[derive(Clone, Copy, Debug, Default, ValueEnum)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, ValueEnum)]
 pub enum WalletSyncSource {
     #[default]
     /// Communicates over the Electrum protocol.
     Electrum,
-    /// Communicates over REST to a Esplora server (i.e. mempool.space APIt
+    /// Communicates over REST to a Esplora server (i.e. mempool.space API)
     Esplora,
+    /// The wallet is only synced by new blocks coming in.
+    Disabled,
 }
 
 #[derive(Clone, Args)]

--- a/lib/wallet/cusf_block_producer.rs
+++ b/lib/wallet/cusf_block_producer.rs
@@ -11,6 +11,7 @@ use cusf_enforcer_mempool::{
 use tracing::instrument;
 
 use crate::{
+    cli::WalletSyncSource,
     validator::Validator,
     wallet::{error, Wallet},
 };
@@ -67,7 +68,10 @@ impl CusfEnforcer for Wallet {
         // We previously ran a wallet sync here unconditionally within this function. The sync
         // takes a long time on big wallets (100k+ UTXOs), and therefore has to be omitted in
         // some cases.
-        if !self.inner.config.wallet_opts.skip_periodic_sync {
+        let sync_source_disabled =
+            self.inner.config.wallet_opts.sync_source == WalletSyncSource::Disabled;
+
+        if !self.inner.config.wallet_opts.skip_periodic_sync && !sync_source_disabled {
             tracing::debug!("Sending start signal to wallet task, kicking off periodic sync");
             let mut start_tx_lock = self.task.start_tx.lock();
             if let Some(start_tx) = start_tx_lock.take() {

--- a/lib/wallet/error.rs
+++ b/lib/wallet/error.rs
@@ -7,6 +7,7 @@ use serde::Deserialize;
 use thiserror::Error;
 
 use crate::{
+    cli::WalletSyncSource,
     types::SidechainNumber,
     validator::{self, Validator},
 };
@@ -160,6 +161,10 @@ pub enum FullScan {
 
     #[error("unable to persist wallet post scan")]
     PersistWallet(#[source] SqliteError),
+
+    #[error("chain sync source does not support full scan: {:?}", .sync_source)]
+    #[diagnostic(code(invalid_sync_source))]
+    InvalidSyncSource { sync_source: WalletSyncSource },
 }
 
 #[derive(Debug, Diagnostic, Error)]


### PR DESCRIPTION
This adds a new chain sync source that simply doesn't sync the wallet. When passing this there's no need to connect to an external chain source, which makes everything easier to wire up. Useful in integration test scenarios!

Note that the wallet is still updated on new block events received via Bitcoin Core.