### PR TITLE
validator: fetch block headers via REST

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1052,6 +1052,7 @@ dependencies = [
 [[package]]
 name = "cusf-enforcer-mempool"
 version = "0.2.0"
+source = "git+https://github.com/LayerTwo-Labs/cusf-enforcer-mempool.git?rev=e041fd65a92f64baddb98689f3b9da3b1c28c61b#e041fd65a92f64baddb98689f3b9da3b1c28c61b"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ dependencies = [
 [[package]]
 name = "bip300301"
 version = "0.1.1"
-source = "git+https://github.com/Ash-L2L/bip300301.git?rev=45f74e37b8295207d29ddbbce10d563ec9f67151#45f74e37b8295207d29ddbbce10d563ec9f67151"
+source = "git+https://github.com/Ash-L2L/bip300301.git?rev=543681a65f8f9b44b298482a7f39dd688829a2de#543681a65f8f9b44b298482a7f39dd688829a2de"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -496,6 +496,7 @@ dependencies = [
  "http 1.2.0",
  "jsonrpsee",
  "miette",
+ "reqwest 0.12.15",
  "tokio",
  "tonic",
  "tonic-health",
@@ -585,9 +586,11 @@ dependencies = [
  "protox",
  "rand",
  "regex",
+ "reqwest 0.12.15",
  "rusqlite",
  "rusqlite_migration",
  "serde",
+ "serde_json",
  "serde_path_to_error",
  "thiserror 2.0.12",
  "tokio",
@@ -1049,7 +1052,6 @@ dependencies = [
 [[package]]
 name = "cusf-enforcer-mempool"
 version = "0.2.0"
-source = "git+https://github.com/torkelrogstad/cusf-enforcer-mempool.git?rev=26bb6bdeb6cb9a7d5222889f49bb1768ccc2e011#26bb6bdeb6cb9a7d5222889f49bb1768ccc2e011"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1353,7 +1355,7 @@ dependencies = [
  "bitcoin",
  "hex-conservative 0.2.1",
  "log",
- "reqwest",
+ "reqwest 0.11.27",
  "serde",
  "tokio",
 ]
@@ -3581,6 +3583,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http 1.2.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tower 0.5.2",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-registry",
+]
+
+[[package]]
 name = "reserve-port"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4198,6 +4236,9 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synchronoise"
@@ -5100,6 +5141,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3"
 
 [[package]]
+name = "windows-registry"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
+dependencies = [
+ "windows-result",
+ "windows-strings",
+ "windows-targets 0.53.0",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06374efe858fab7e4f881500e6e86ec8bc28f9462c47e5a9941a0142ad86b189"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5150,11 +5220,27 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+dependencies = [
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -5170,6 +5256,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5180,6 +5272,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5194,10 +5292,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5212,6 +5322,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5222,6 +5338,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5236,6 +5358,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5246,6 +5374,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ rev = "543681a65f8f9b44b298482a7f39dd688829a2de"
 
 [workspace.dependencies.cusf-enforcer-mempool]
 git = "https://github.com/LayerTwo-Labs/cusf-enforcer-mempool.git"
-rev = "4730a57b9f9d84779174f061ad704eea317409b2"
+rev = "e041fd65a92f64baddb98689f3b9da3b1c28c61b"
 
 [workspace.dependencies.ouroboros]
 git = "https://github.com/erikjohnston/ouroboros.git"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,11 +2,7 @@
 
 [workspace]
 resolver = "2"
-members = [
-    "app",
-    "lib",
-    "integration_tests",
-]
+members = ["app", "lib", "integration_tests"]
 
 [workspace.package]
 authors = [
@@ -27,6 +23,7 @@ futures = "0.3.30"
 hex = "0.4.3"
 jsonrpsee = { version = "0.24.7" }
 miette = { version = "7.1.0", default-features = false }
+reqwest = { version = "0.12.15", default-features = false, features = ["json"] }
 thiserror = "2.0.11"
 tokio = { version = "1.36.0", default-features = false }
 tokio-stream = "0.1.15"
@@ -37,12 +34,11 @@ tracing-subscriber = "0.3.18"
 
 [workspace.dependencies.bip300301]
 git = "https://github.com/Ash-L2L/bip300301.git"
-rev = "45f74e37b8295207d29ddbbce10d563ec9f67151"
+rev = "543681a65f8f9b44b298482a7f39dd688829a2de"
 
 [workspace.dependencies.cusf-enforcer-mempool]
-# https://github.com/LayerTwo-Labs/cusf-enforcer-mempool/pull/5
-git = "https://github.com/torkelrogstad/cusf-enforcer-mempool.git"
-rev = "26bb6bdeb6cb9a7d5222889f49bb1768ccc2e011"
+git = "https://github.com/LayerTwo-Labs/cusf-enforcer-mempool.git"
+rev = "4730a57b9f9d84779174f061ad704eea317409b2"
 
 [workspace.dependencies.ouroboros]
 git = "https://github.com/erikjohnston/ouroboros.git"

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
    # as you set the CLI arg for bip300301_enforcer
    zmqpubsequence=tcp://0.0.0.0:29000
    txindex=1
+   rest=1
    ```
 
 1. Rustc & Cargo, version 1.78.0 or higher. Installing via Rustup is

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -17,6 +17,7 @@ futures = { workspace = true }
 http = "1.2.0"
 jsonrpsee = { workspace = true, features = ["server"] }
 miette = { workspace = true, features = ["fancy"] }
+reqwest = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 tonic = { workspace = true }
 tonic-health = "0.13.0"

--- a/app/main.rs
+++ b/app/main.rs
@@ -375,8 +375,8 @@ async fn mempool_task<Enforcer, RpcClient, F, Fut>(
     let (sequence_stream, mempool, tx_cache) = match init_sync_mempool_future.await {
         Ok(res) => res,
         Err(err) => {
-            tracing::error!("mempool: initial sync error: {err:#?}");
-            let err = miette::miette!("mempool: initial sync error: {err:#}");
+            let err = miette::Report::from_err(err);
+            tracing::error!("mempool: initial sync error: {err:#}");
             let _send_err: Result<(), _> = err_tx.send(err);
             return;
         }

--- a/integration_tests/util.rs
+++ b/integration_tests/util.rs
@@ -158,6 +158,11 @@ where
             }
         };
         cmd.stdout(std::process::Stdio::from(stdout_file));
+        tracing::debug!(
+            stdout_file = stdout_fp.to_string_lossy().to_string(),
+            stderr_file = stderr_fp.to_string_lossy().to_string(),
+            "Running command: {cmd:?}",
+        );
         let mut cmd = match cmd.spawn() {
             Ok(cmd) => cmd,
             Err(err) => {
@@ -165,6 +170,8 @@ where
                 return anyhow::anyhow!("Spawning command {command} failed: `{err:#}`");
             }
         };
+
+        tracing::debug!("Waiting for `{command}` to finish");
         let exit_status = match cmd.wait().await {
             Ok(exit_status) => exit_status,
             Err(err) => {
@@ -184,7 +191,7 @@ where
             stderr_file = stderr_fp.to_string_lossy().to_string(),
         );
 
-        let mut msg = format!("Command `{command}` finished: `{}`", exit_status,);
+        let mut msg = format!("Command `{command}` finished: `{}`", exit_status);
 
         if let Ok(stderr) = std::fs::read_to_string(stderr_fp).map(|s| s.trim().to_owned()) {
             if !stderr.is_empty() {
@@ -263,6 +270,7 @@ impl Bitcoind {
             format!("-rpcuser={}", self.rpc_user),
             format!("-rpcpassword={}", self.rpc_pass),
             format!("-rpcport={}", self.rpc_port),
+            "-rest".to_owned(), // needed for batch requesting block headers
             "-server".to_owned(),
             format!("-zmqpubsequence=tcp://127.0.0.1:{}", self.zmq_sequence_port),
         ];

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -52,10 +52,12 @@ prost = "0.13.2"
 prost-types = "0.13.3"
 rand = "0.8.5"
 regex = "1.11.0"
+reqwest = { workspace = true }
 # needs to line up with BDK version
 rusqlite = { version = "0.31.0", features = ["bundled"] }
 rusqlite_migration = "1.0.0"
 serde = { version = "1.0.197", features = ["derive"] }
+serde_json = "1.0.140"
 serde_path_to_error = "0.1.16"
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["macros"] }

--- a/lib/rpc_client.rs
+++ b/lib/rpc_client.rs
@@ -2,7 +2,7 @@ use bip300301::{
     jsonrpsee::{core::ClientError, http_client::HttpClient},
     MainClient,
 };
-use miette::{miette, IntoDiagnostic};
+use miette::miette;
 
 use crate::cli::NodeRpcConfig;
 
@@ -59,7 +59,8 @@ pub fn create_client(
         None
     };
 
-    bip300301::client(conf.addr, client_builder, &conf_pass, &conf_user).into_diagnostic()
+    bip300301::client(conf.addr, client_builder, &conf_pass, &conf_user)
+        .map_err(|err| miette!("failed to create mainchain RPC client: {err:#}"))
 }
 
 /// Broadcasts a transaction to the Bitcoin network.

--- a/lib/validator/cusf_enforcer.rs
+++ b/lib/validator/cusf_enforcer.rs
@@ -181,7 +181,7 @@ fn connect_block_no_commit<'validator>(
         validator
             .dbs
             .block_hashes
-            .put_header(&mut parent_rwtxn, &block.header, height)?;
+            .put_headers(&mut parent_rwtxn, &[(block.header, height)])?;
     }
     // Commit on block accept, abort on block reject
     let mut parent_child_rwtxn = ParentChildRwTxnTryBuilder {
@@ -325,6 +325,7 @@ impl CusfEnforcer for Validator {
             &self.events_tx,
             &header_sync_progress_tx,
             &self.mainchain_client,
+            &self.mainchain_rest_client,
             tip,
         )
         .map_err(SyncError)

--- a/lib/validator/main_rest_client.rs
+++ b/lib/validator/main_rest_client.rs
@@ -1,0 +1,103 @@
+use std::time::Instant;
+
+use bitcoin::{block::Header, hashes::Hash, BlockHash, CompactTarget, TxMerkleNode};
+use reqwest::{Client, Url};
+use serde::Deserialize;
+use thiserror::Error;
+use tracing::instrument;
+
+#[derive(Debug, Error)]
+pub enum MainRestClientError {
+    #[error("URL parse error: {0}")]
+    URL(#[from] url::ParseError),
+    #[error("HTTP request failed: {0}")]
+    Http(#[from] reqwest::Error),
+    #[error("Invalid block hash format")]
+    InvalidBlockHash,
+    #[error("Invalid block header format")]
+    InvalidBlockHeader,
+}
+
+#[derive(Debug, Clone)]
+pub struct MainRestClient {
+    client: Client,
+    base_url: Url,
+}
+
+#[derive(Debug, Deserialize)]
+struct RestHeader {
+    hash: BlockHash,
+    height: u32,
+    version: bitcoin::blockdata::block::Version,
+    previousblockhash: Option<BlockHash>,
+    merkleroot: TxMerkleNode,
+    time: u32,
+    bits: String,
+    nonce: u32,
+}
+
+impl MainRestClient {
+    pub fn new(base_url: Url) -> Self {
+        Self {
+            client: Client::new(),
+            base_url,
+        }
+    }
+
+    /// Fetches a block header from Bitcoin Core's REST API
+    /// https://github.com/bitcoin/bitcoin/blob/master/doc/REST-interface.md#blockheaders
+    #[instrument(skip(self))]
+    pub async fn get_block_headers(
+        &self,
+        block_hash: &BlockHash,
+        descendants: usize,
+    ) -> Result<Vec<(Header, BlockHash, u32)>, MainRestClientError> {
+        let start = Instant::now();
+
+        let url = self.base_url.join(&format!(
+            "rest/headers/{}.json?count={}",
+            block_hash, descendants
+        ))?;
+
+        let response = self.client.get(url).send().await?;
+
+        if !response.status().is_success() {
+            return Err(MainRestClientError::Http(
+                response.error_for_status().unwrap_err(),
+            ));
+        }
+
+        let headers = response
+            .json::<Vec<RestHeader>>()
+            .await
+            .inspect_err(|err| {
+                tracing::warn!("Failed to parse block headers: {err:#?}");
+            })?;
+
+        tracing::debug!(
+            "Fetched {} block header(s) in {:?}: {} -> {}",
+            headers.len(),
+            start.elapsed(),
+            headers.first().map(|h| h.height).unwrap_or(0),
+            headers.last().map(|h| h.height).unwrap_or(0),
+        );
+
+        Ok(headers
+            .into_iter()
+            .map(|header| {
+                (
+                    Header {
+                        version: header.version,
+                        prev_blockhash: header.previousblockhash.unwrap_or(BlockHash::all_zeros()),
+                        merkle_root: header.merkleroot,
+                        time: header.time,
+                        bits: CompactTarget::from_unprefixed_hex(&header.bits).unwrap(),
+                        nonce: header.nonce,
+                    },
+                    header.hash,
+                    header.height,
+                )
+            })
+            .collect())
+    }
+}

--- a/lib/validator/mod.rs
+++ b/lib/validator/mod.rs
@@ -5,6 +5,7 @@ use bip300301::jsonrpsee;
 use bitcoin::{self, Amount, BlockHash, OutPoint};
 use fallible_iterator::{FallibleIterator, IteratorExt};
 use futures::{stream::FusedStream, StreamExt};
+use main_rest_client::MainRestClient;
 use miette::{Diagnostic, IntoDiagnostic};
 use nonempty::NonEmpty;
 use thiserror::Error;
@@ -20,6 +21,7 @@ use crate::{
 
 pub mod cusf_enforcer;
 mod dbs;
+pub mod main_rest_client;
 mod task;
 
 use dbs::{db_error, CreateDbsError, Dbs, PendingM6ids};
@@ -223,12 +225,14 @@ pub struct Validator {
     events_tx: BroadcastSender<Event>,
     header_sync_progress_rx: Arc<parking_lot::RwLock<Option<WatchReceiver<HeaderSyncProgress>>>>,
     mainchain_client: jsonrpsee::http_client::HttpClient,
+    mainchain_rest_client: MainRestClient,
     network: bitcoin::Network,
 }
 
 impl Validator {
     pub fn new(
         mainchain_client: jsonrpsee::http_client::HttpClient,
+        mainchain_rest_client: MainRestClient,
         data_dir: &Path,
         network: bitcoin::Network,
     ) -> Result<Self, InitError> {
@@ -245,6 +249,7 @@ impl Validator {
             events_tx,
             header_sync_progress_rx: Arc::new(parking_lot::RwLock::new(None)),
             mainchain_client,
+            mainchain_rest_client,
             network,
         })
     }

--- a/lib/wallet/sync.rs
+++ b/lib/wallet/sync.rs
@@ -124,7 +124,7 @@ impl WalletInner {
             missing_blocks.reverse();
 
             for (height, block) in missing_blocks {
-                tracing::debug!(
+                tracing::trace!(
                     height = height,
                     hash = %block.block_hash(),
                     "applying missing block"


### PR DESCRIPTION
Notes: this relies on https://github.com/Ash-L2L/bip300301/pull/5 getting merged. 

Closes #195 

This is tested with a few different reorg scenarios on regtest. I've done tests with actual reorgs (two nodes running, where one overtakes the other), as well as by doing RPC calls to `invalidateblock`. Note that calling `invalidateblock` leads to a TODO panic within `cusf-enforcer-mempool`, but that is unrelated to this PR. 

The implementation here is rather chaotic and messy. I've tried my best to comment things liberally, but I'm very much open to suggestions on how to simplify. 

Stats for syncing headers on signet, on my Macbook Pro with Bitcoin Core running locally: 

* ~This PR: 5.05525225s~
* This PR after reorg logic integrated: 6.464624708s
* master: 47.817417791s