### PR TITLE
main: verify txindex exists on wallet startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ dependencies = [
 [[package]]
 name = "bip300301"
 version = "0.1.1"
-source = "git+https://github.com/Ash-L2L/bip300301.git?rev=543681a65f8f9b44b298482a7f39dd688829a2de#543681a65f8f9b44b298482a7f39dd688829a2de"
+source = "git+https://github.com/Ash-L2L/bip300301.git?rev=8603b40520e432ccff27164a484647aa4a0be250#8603b40520e432ccff27164a484647aa4a0be250"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -1052,7 +1052,7 @@ dependencies = [
 [[package]]
 name = "cusf-enforcer-mempool"
 version = "0.2.0"
-source = "git+https://github.com/LayerTwo-Labs/cusf-enforcer-mempool.git?rev=e041fd65a92f64baddb98689f3b9da3b1c28c61b#e041fd65a92f64baddb98689f3b9da3b1c28c61b"
+source = "git+https://github.com/torkelrogstad/cusf-enforcer-mempool.git?rev=58227511cc63f9ac448a5ecfbb38b743dad5367a#58227511cc63f9ac448a5ecfbb38b743dad5367a"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,11 +34,12 @@ tracing-subscriber = "0.3.18"
 
 [workspace.dependencies.bip300301]
 git = "https://github.com/Ash-L2L/bip300301.git"
-rev = "543681a65f8f9b44b298482a7f39dd688829a2de"
+rev = "8603b40520e432ccff27164a484647aa4a0be250"
 
 [workspace.dependencies.cusf-enforcer-mempool]
-git = "https://github.com/LayerTwo-Labs/cusf-enforcer-mempool.git"
-rev = "e041fd65a92f64baddb98689f3b9da3b1c28c61b"
+# https://github.com/LayerTwo-Labs/cusf-enforcer-mempool/pull/8
+git = "https://github.com/torkelrogstad/cusf-enforcer-mempool.git"
+rev = "58227511cc63f9ac448a5ecfbb38b743dad5367a"
 
 [workspace.dependencies.ouroboros]
 git = "https://github.com/erikjohnston/ouroboros.git"


### PR DESCRIPTION
Currently the wallet assumes that the underlying node has `txindex` enabled. If this is not the case we'll fail later with cryptic error messages. Better to fail early!

It could very well be that the best choice here is to _remove_ the need for a TX index. That's a bigger task that can be done at a later point if needed.

Depends on https://github.com/LayerTwo-Labs/cusf-enforcer-mempool/pull/8.

Also, see https://github.com/LayerTwo-Labs/bip300301_enforcer/pull/205. To my knowledge it seems like the bip300301 dependency has to be bumped in tandem across two places. That's a bit frustrating. Any way around this? I tried modifying `Cargo.toml` with patch sections, but could not get it to work...