### PR TITLE
wallet: fix broken sync logic where multiple blocks are needed

### DIFF
--- a/lib/server.rs
+++ b/lib/server.rs
@@ -32,7 +32,7 @@ use crate::{
         },
         mainchain::{
             create_sidechain_proposal_response, get_block_info_response,
-            get_bmm_h_star_commitment_response, get_ctip_response::Ctip,
+            get_bmm_h_star_commitment_response, get_ctip_response::Ctip, get_info_response,
             get_sidechain_proposals_response::SidechainProposal,
             get_sidechains_response::SidechainInfo,
             list_sidechain_deposit_transactions_response::SidechainDepositTransaction,
@@ -765,6 +765,10 @@ impl WalletService for crate::wallet::Wallet {
                     )
                 })
                 .collect(),
+            tip: Some(get_info_response::Tip {
+                height: info.tip.1,
+                hash: Some(ReverseHex::encode(&info.tip.0)),
+            }),
         };
         Ok(tonic::Response::new(response))
     }

--- a/lib/wallet/error.rs
+++ b/lib/wallet/error.rs
@@ -243,6 +243,14 @@ pub enum ConnectBlock {
     ConnectBlock(#[from] <Validator as CusfEnforcer>::ConnectBlockError),
     #[error(transparent)]
     GetBlockInfo(#[from] validator::GetBlockInfoError),
+    #[error(transparent)]
+    GetBlockInfos(#[from] validator::GetBlockInfosError),
+    #[error("unable to fetch block from mainchain")]
+    #[diagnostic(code(fetch_block_error))]
+    GetBlock(#[source] BitcoinCoreRPC),
+    #[error("unable to fetch block hash from mainchain")]
+    #[diagnostic(code(fetch_block_hash_error))]
+    GetBlockHash(#[source] BitcoinCoreRPC),
     #[error("unable to fetch missing block")]
     #[diagnostic(code(fetch_block_error))]
     FetchBlock(#[source] BitcoinCoreRPC),

--- a/lib/wallet/mod.rs
+++ b/lib/wallet/mod.rs
@@ -772,6 +772,7 @@ pub struct WalletInfo {
     pub network: bdk_wallet::bitcoin::Network,
     pub transaction_count: usize,
     pub unspent_output_count: usize,
+    pub tip: (BlockHash, u32),
 }
 
 /// Cheap to clone, since it uses Arc internally
@@ -1869,11 +1870,14 @@ impl Wallet {
             keychain_descriptors.insert(kind, w.public_descriptor(kind).clone());
         }
 
+        let tip = w.local_chain().tip();
+
         Ok(WalletInfo {
             keychain_descriptors,
             network: w.network(),
             transaction_count: w.transactions().count(),
             unspent_output_count: w.list_unspent().count(),
+            tip: (tip.hash(), tip.height()),
         })
     }
 

--- a/lib/wallet/sync.rs
+++ b/lib/wallet/sync.rs
@@ -3,9 +3,9 @@
 use std::time::SystemTime;
 
 use async_lock::RwLockWriteGuard;
+use bdk_chain::bdk_core;
 use bdk_electrum::electrum_client::ElectrumApi;
 use bdk_esplora::EsploraAsyncExt as _;
-use bip300301::client::{GetBlockClient, U8Witness};
 use either::Either::{self, Left, Right};
 use tokio::time::Instant;
 use tracing::instrument;
@@ -49,12 +49,18 @@ impl SyncWriteGuard<'_> {
 const ESPLORA_PARALLEL_REQUESTS: usize = 25;
 
 impl WalletInner {
+    pub(in crate::wallet) async fn get_tip(&self) -> Result<bdk_core::BlockId, error::NotUnlocked> {
+        let wallet = self.read_wallet().await?;
+
+        Ok(wallet.local_chain().tip().block_id())
+    }
+
     #[instrument(skip_all, fields(block_height))]
     pub(in crate::wallet) async fn handle_connect_block(
         &self,
         block: &bitcoin::Block,
         block_height: u32,
-        block_info: crate::types::BlockInfo,
+        block_info: &crate::types::BlockInfo,
     ) -> Result<(), error::ConnectBlock> {
         // Acquire a wallet lock immediately, so that it does not update
         // while other dbs are being written to
@@ -81,57 +87,10 @@ impl WalletInner {
             .await?;
         let mut database = self.bdk_db.lock().await;
         tracing::info!(
-            hash = %block.block_hash(),
-            height = block_height,
+            block_hash = %block.block_hash(),
+            block_height = block_height,
             "applying block to BDK wallet"
         );
-
-        let bdk_tip_height = wallet_write.local_chain().tip().height();
-
-        // TODO: should really run the entire handle_connect_block logic here
-        if bdk_tip_height < block_height - 1 {
-            tracing::info!(
-                bdk_tip_height = bdk_tip_height,
-                block_height = block_height,
-                "BDK tip is behind newly received block, catching up"
-            );
-
-            // Collect missing blocks by walking backwards
-            let mut missing_blocks = Vec::new();
-            let mut current_hash = block.header.prev_blockhash;
-            let mut current_height = block_height - 1;
-
-            while current_height > bdk_tip_height {
-                let block = self
-                    .main_client
-                    .get_block(current_hash, U8Witness::<0>)
-                    .await
-                    .map_err(|err| {
-                        error::ConnectBlock::FetchBlock(error::BitcoinCoreRPC {
-                            method: "getblock".to_string(),
-                            error: err,
-                        })
-                    })?;
-
-                let block = block.0;
-                missing_blocks.push((current_height, block.clone()));
-                current_hash = block.header.prev_blockhash;
-                current_height -= 1;
-            }
-
-            // Apply blocks in ascending order
-            missing_blocks.reverse();
-
-            for (height, block) in missing_blocks {
-                tracing::trace!(
-                    height = height,
-                    hash = %block.block_hash(),
-                    "applying missing block"
-                );
-
-                let () = wallet_write.with_mut(|wallet| wallet.apply_block(&block, height))?;
-            }
-        }
 
         let () = wallet_write.with_mut(|wallet| wallet.apply_block(block, block_height))?;
         let _: bool = wallet_write


### PR DESCRIPTION
Closes #199 

Also handles chain splits. Note that there's no concept of "disconnecting a block" in BDK. Instead we're supposed to chug along with new block updates, and then BDK makes sure to keep track of all tips and automatically keep track of what's the best one. 