### PR TITLE
dev: add rust-toolchain.toml file

### DIFF
--- a/.github/workflows/build_docker.yaml
+++ b/.github/workflows/build_docker.yaml
@@ -50,6 +50,16 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
+
+      - name: Determine Rust version
+        id: rust-version
+        run: |
+          RUST_VERSION=$(awk -F'"' '/^[[:space:]]*channel[[:space:]]*=/{split($2,v,"."); print v[1]"."v[2]; exit}' rust-toolchain.toml)
+          echo "rust-version=$RUST_VERSION" >> $GITHUB_OUTPUT
+
       - name: Build (and maybe push) Docker image
         uses: docker/build-push-action@v6
         with:
@@ -65,3 +75,4 @@ jobs:
           # prettier-ignore
           cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/bip300301_enforcer:latest
           cache-to: type=inline
+          build-args: RUST_VERSION=${{ steps.rust-version.outputs.rust-version }}

--- a/.github/workflows/check_lint_build_release.yaml
+++ b/.github/workflows/check_lint_build_release.yaml
@@ -74,10 +74,12 @@ jobs:
         with:
           submodules: "recursive"
 
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: stable
-          components: clippy
+      # Must happen /after/ the checkout step, to pick up the toolchain
+      # from the `rust-toolchain.toml` file.
+      - name: Install toolchain
+        run: |
+          rustup install 
+          rustup component add clippy
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
@@ -120,13 +122,6 @@ jobs:
           git clone https://github.com/mempool/electrs.git
           popd
 
-      - name: Install latest stable toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          # Stable, as of January 2015. If updating, also update
-          # the version in the Dockerfile.
-          toolchain: "1.84"
-
       - name: Rust Cache (electrs)
         uses: Swatinem/rust-cache@v2
         with:
@@ -142,6 +137,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: "recursive"
+
+      # `rustup` is already installed on GitHub Actions runners, so
+      # this reads the content from our `rust-toolchain.toml` file.
+      # Must happen /after/ the checkout step.
+      - name: Install Rust toolchain
+        run: rustup install
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
@@ -193,11 +194,8 @@ jobs:
         with:
           submodules: "recursive"
 
-      - name: Install latest stable toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: stable
-          target: ${{ matrix.name }}
+      # Must happen /after/ the checkout step, to pick up the toolchain
+      - run: rustup target add ${{ matrix.name }}
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-# Stable Rust version, as of January 2015. If updating, also update
-# the version in the Dockerfile.
-FROM rust:1.84-slim-bookworm AS builder
+ARG RUST_VERSION=1
+
+FROM rust:${RUST_VERSION}-slim-bookworm AS builder
 WORKDIR /workspace
 COPY . .
 RUN cargo build --locked --release

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.84.0"


### PR DESCRIPTION
This allows us to centralize the Rust version number in a single place, and both CI and the Docker build can deduce their versions from this.