### PR TITLE
ci: change electrs caching

### DIFF
--- a/.github/workflows/check_lint_build_release.yaml
+++ b/.github/workflows/check_lint_build_release.yaml
@@ -97,6 +97,8 @@ jobs:
     name: Integration test
     runs-on: ubuntu-latest
     needs: [check-clippy, check-clippy-nightly]
+    env:
+      ELECTRS_VERSION: v3.2.0
     steps:
       - name: Download latest bitcoin-patched
         run: |
@@ -119,16 +121,18 @@ jobs:
       - name: Checkout electrs
         run: |
           pushd ..
-          git clone https://github.com/mempool/electrs.git
+          git clone --branch ${{ env.ELECTRS_VERSION }} --depth 1 https://github.com/mempool/electrs.git
           popd
 
-      - name: Rust Cache (electrs)
-        uses: Swatinem/rust-cache@v2
+      - name: Cache electrs binary
+        id: cache-electrs
+        uses: actions/cache@v4
         with:
-          prefix-key: "v0-rust-electrs"
-          workspaces: ../electrs -> target
+          path: ../electrs/target/release/electrs
+          key: electrs-binary-${{ env.ELECTRS_VERSION }}
 
       - name: Install electrs
+        if: steps.cache-electrs.outputs.cache-hit != 'true'
         run: |
           pushd ../electrs
           cargo build --locked --release


### PR DESCRIPTION
The Rust cache we tried to do prior to this commit did not work. Things were being built from scratch every time!

Instead, cache the binary itself. Also, pin the electrs version to a specific release.