### PR TITLE
wallet: make balance endpoint immediately available

### DIFF
--- a/lib/server.rs
+++ b/lib/server.rs
@@ -545,7 +545,7 @@ impl WalletService for crate::wallet::Wallet {
 
         tracing::trace!("get_balance: fetching from BDK wallet");
 
-        let balance = self
+        let (balance, has_synced) = self
             .get_wallet_balance()
             .await
             .map_err(|err| err.builder().to_status())?;
@@ -555,6 +555,7 @@ impl WalletService for crate::wallet::Wallet {
         let response = GetBalanceResponse {
             confirmed_sats: balance.confirmed.to_sat(),
             pending_sats: (balance.total() - balance.confirmed).to_sat(),
+            has_synced,
         };
 
         Ok(tonic::Response::new(response))

--- a/lib/wallet/mod.rs
+++ b/lib/wallet/mod.rs
@@ -1355,14 +1355,15 @@ impl Wallet {
     }
 
     #[instrument(skip_all)]
-    pub async fn get_wallet_balance(&self) -> Result<bdk_wallet::Balance, error::GetWalletBalance> {
-        if self.inner.last_sync.read().await.is_none() {
-            return Err(error::NotSynced.into());
-        }
+    /// Returns the balance of the wallet, alongside a bool indicating whether the wallet is synced.
+    pub async fn get_wallet_balance(
+        &self,
+    ) -> Result<(bdk_wallet::Balance, bool), error::GetWalletBalance> {
+        let has_synced = self.inner.last_sync.read().await.is_some();
 
         let balance = self.inner.read_wallet().await?.balance();
 
-        Ok(balance)
+        Ok((balance, has_synced))
     }
 
     #[allow(


### PR DESCRIPTION
Indicate with a bool whether the wallet has completed its first sync.

Closes #223

Matching PR for protos: https://github.com/LayerTwo-Labs/cusf_sidechain_proto/pull/50