### PR TITLE
multi: refactor task structure, add shutdown to JSON-RPC server

### DIFF
--- a/app/main.rs
+++ b/app/main.rs
@@ -2,7 +2,7 @@ use std::{future::Future, net::SocketAddr, time::Duration};
 
 use bdk_wallet::bip39::{Language, Mnemonic};
 use bip300301_enforcer_lib::{
-    cli::{self, LogFormatter},
+    cli::{self, LogFormatter, WalletSyncSource},
     errors::ErrorChain,
     p2p::compute_signet_magic,
     proto::{
@@ -420,14 +420,14 @@ async fn spawn_gbt_server(
     Ok(handle)
 }
 
-async fn run_gbt_server(
+async fn start_gbt_server(
     mining_reward_address: bitcoin::Address,
     network: bitcoin::Network,
     network_info: bitcoin_jsonrpsee::client::NetworkInfo,
     sample_block_template: bitcoin_jsonrpsee::client::BlockTemplate,
     mempool: cusf_enforcer_mempool::mempool::MempoolSync<Wallet>,
     serve_addr: SocketAddr,
-) -> miette::Result<()> {
+) -> miette::Result<jsonrpsee::server::ServerHandle> {
     let gbt_server = cusf_enforcer_mempool::server::Server::new(
         mining_reward_address.script_pubkey(),
         mempool,
@@ -437,8 +437,7 @@ async fn run_gbt_server(
     )
     .into_diagnostic()?;
     let gbt_server_handle = spawn_gbt_server(gbt_server, serve_addr).await?;
-    let () = gbt_server_handle.stopped().await;
-    Ok(())
+    Ok(gbt_server_handle)
 }
 
 async fn is_address_port_open(addr: &str) -> Result<bool, std::io::Error> {
@@ -482,18 +481,16 @@ where
     NoMempool(#[from] cusf_enforcer_mempool::cusf_enforcer::TaskError<Enforcer>),
 }
 
-async fn mempool_task<Enforcer, RpcClient, F, Fut, Signal>(
+async fn sync_mempool<Enforcer, RpcClient, Signal>(
     mut enforcer: Enforcer,
     rpc_client: RpcClient,
     zmq_addr_sequence: &str,
     err_tx: oneshot::Sender<MempoolTaskError<Enforcer>>,
-    on_mempool_synced: F,
     shutdown_signal: Signal,
-) where
+) -> Result<cusf_enforcer_mempool::mempool::MempoolSync<Enforcer>, MempoolTaskError<Enforcer>>
+where
     Enforcer: cusf_enforcer_mempool::cusf_enforcer::CusfEnforcer + Send + Sync + 'static,
     RpcClient: bitcoin_jsonrpsee::client::MainClient + Send + Sync + 'static,
-    F: FnOnce(cusf_enforcer_mempool::mempool::MempoolSync<Enforcer>) -> Fut,
-    Fut: Future<Output = ()>,
     Signal: Future<Output = ()> + Send,
 {
     tracing::debug!(%zmq_addr_sequence, "Ensuring ZMQ address for mempool sync is reachable");
@@ -504,16 +501,14 @@ async fn mempool_task<Enforcer, RpcClient, F, Fut, Signal>(
             let err = MempoolTaskError::ZmqNotReachable {
                 zmq_addr_sequence: zmq_addr_sequence.to_owned(),
             };
-            let _send_err: Result<(), _> = err_tx.send(err);
-            return;
+            return Err(err);
         }
         Err(err) => {
             let err = MempoolTaskError::ZmqCheck {
                 addr: zmq_addr_sequence.to_owned(),
                 source: err,
             };
-            let _send_err: Result<(), _> = err_tx.send(err);
-            return;
+            return Err(err);
         }
     }
 
@@ -531,10 +526,10 @@ async fn mempool_task<Enforcer, RpcClient, F, Fut, Signal>(
         Err(err) => {
             let err = MempoolTaskError::InitialSync(err);
             tracing::error!("{:#}", ErrorChain::new(&err));
-            let _send_err: Result<(), _> = err_tx.send(err);
-            return;
+            return Err(err);
         }
     };
+
     let mempool = cusf_enforcer_mempool::mempool::MempoolSync::new(
         enforcer,
         mempool,
@@ -546,7 +541,8 @@ async fn mempool_task<Enforcer, RpcClient, F, Fut, Signal>(
             let _send_err: Result<(), _> = err_tx.send(err);
         },
     );
-    on_mempool_synced(mempool).await
+
+    Ok(mempool)
 }
 
 #[derive(Debug, Diagnostic, Error)]
@@ -615,12 +611,18 @@ async fn get_zmq_addr_sequence(
     Ok(address)
 }
 
-async fn task(
+/// Returns a join handle for the main task, a shared future for the shutdown signal,
+/// and error receivers for the main task sub components
+async fn spawn_task(
     enforcer: Either<Validator, Wallet>,
     cli: cli::Config,
     mainchain_client: bitcoin_jsonrpsee::jsonrpsee::http_client::HttpClient,
     network: bitcoin::Network,
-) -> Result<(JoinHandle<Result<()>>, ErrRxs)> {
+) -> Result<(
+    JoinHandle<Result<()>>,
+    futures::future::Shared<impl Future<Output = ()>>,
+    ErrRxs,
+)> {
     let (enforcer_task_err_tx, enforcer_task_err_rx) = oneshot::channel();
 
     let (shutdown_signal_tx, shutdown_signal_rx) = oneshot::channel();
@@ -640,7 +642,9 @@ async fn task(
                 shutdown_signal_tx
                     .send(())
                     .inspect(|_| tracing::trace!("sent shutdown signal"))
-                    .inspect_err(|_| tracing::error!("unable to send shutdown signal"))
+                    .inspect_err(|_| {
+                        tracing::error!("unable to send shutdown signal, receiver was dropped")
+                    })
                     .ok()
             })
             .unwrap_or(())
@@ -677,15 +681,14 @@ async fn task(
             let shutdown_signal = shutdown_signal.clone();
             let task_handle = tokio::task::spawn(async move {
                 tracing::info!("mempool sync task w/validator: starting");
-                mempool_task(
+                let _mempool = sync_mempool(
                     validator,
                     mainchain_client,
                     &node_zmq_addr_sequence,
                     enforcer_task_err_tx,
-                    |_mempool| futures::future::pending(),
                     shutdown_signal,
                 )
-                .await;
+                .await?;
                 Ok(())
             });
             (
@@ -732,29 +735,34 @@ async fn task(
                             return Err(err.wrap_err("failed to get sample block template"));
                         }
                     };
-                mempool_task(
+                let mempool = sync_mempool(
                     wallet,
                     mainchain_client,
                     &node_zmq_addr_sequence,
                     enforcer_task_err_tx,
-                    |mempool| async {
-                        match run_gbt_server(
-                            mining_reward_address,
-                            network,
-                            network_info,
-                            sample_block_template,
-                            mempool,
-                            cli.serve_rpc_addr,
-                        )
-                        .await
-                        {
-                            Ok(()) => (),
-                            Err(err) => tracing::error!("JSON-RPC server error: {err:#}"),
-                        }
-                    },
-                    shutdown_signal,
+                    shutdown_signal.clone(),
                 )
-                .await;
+                .await?;
+
+                let server_handle = start_gbt_server(
+                    mining_reward_address,
+                    network,
+                    network_info,
+                    sample_block_template,
+                    mempool,
+                    cli.serve_rpc_addr,
+                )
+                .await?;
+
+                shutdown_signal.clone().await;
+
+                tracing::debug!("stopping JSON-RPC server");
+
+                // This should never fail. The only failure mode is the server
+                // already being stopped, and we have full control over that.
+                if let Err(err) = server_handle.stop() {
+                    tracing::error!("error stopping JSON-RPC server: {err:#}");
+                }
                 Ok(())
             });
             (
@@ -783,7 +791,7 @@ async fn task(
         shutdown_signal: shutdown_signal_rx,
         shutdown_tx: shutdown_tx.clone(),
     };
-    Ok((task_handle, err_rxs))
+    Ok((task_handle, shutdown_signal, err_rxs))
 }
 
 #[tokio::main]
@@ -1020,26 +1028,80 @@ async fn main() -> Result<()> {
         .await
         .map_err(|err| miette!("Failed to spawn JSON-RPC server: {err:#}"))?;
 
-    let (task_handle, mut err_rxs) =
-        task(enforcer.clone(), cli, mainchain_client, info.chain).await?;
+    let (main_task_handle, shutdown_signal, mut err_rxs) =
+        spawn_task(enforcer.clone(), cli.clone(), mainchain_client, info.chain).await?;
+
+    let mut wallet_sync_task_handle: Option<JoinHandle<Result<(), miette::Report>>> = None;
+
+    if let Either::Right(wallet) = enforcer.clone() {
+        // Big wallets (thousands of UTXOs) can get really bad performance for the
+        // periodic sync. Therefore we expose a knob to disable it.
+        let sync_source_disabled = cli.wallet_opts.sync_source == WalletSyncSource::Disabled;
+
+        if cli.wallet_opts.full_scan {
+            wallet.full_scan().await?;
+        }
+
+        if !cli.wallet_opts.skip_periodic_sync && !sync_source_disabled {
+            let wallet = wallet.clone();
+            let shutdown_signal = shutdown_signal.clone();
+            let handle = tokio::spawn(async move { wallet.sync_task(shutdown_signal).await });
+            wallet_sync_task_handle = Some(handle);
+        }
+    };
 
     struct TaskHandles {
         main_task: JoinHandle<Result<(), miette::Report>>,
+        wallet_sync_task: Option<JoinHandle<Result<(), miette::Report>>>,
     }
 
     impl TaskHandles {
         async fn join_all(self) -> Result<(), miette::Report> {
-            let Self { main_task } = self;
-            main_task.await.unwrap_or_else(|join_err| {
-                Err(miette!("main task panicked or was cancelled: {join_err:#}"))
-            })
+            let Self {
+                main_task,
+                wallet_sync_task,
+            } = self;
+
+            let mut tasks: Vec<std::pin::Pin<Box<dyn Future<Output = _> + Send>>> = vec![Box::pin(
+                main_task.inspect(|_| tracing::info!("main task finished")),
+            )];
+            let mut task_labels = vec!["main task"];
+
+            if let Some(wallet_sync_task) = wallet_sync_task {
+                tasks.push(Box::pin(
+                    wallet_sync_task.inspect(|_| tracing::info!("wallet sync task finished")),
+                ));
+                task_labels.push("wallet sync task");
+            }
+
+            for (i, result) in futures::future::join_all(tasks)
+                .await
+                .into_iter()
+                .enumerate()
+            {
+                let task_name = task_labels[i];
+
+                match result {
+                    Ok(Ok(())) => (),
+                    Ok(Err(err)) => return Err(miette!("task {task_name} failed: {err:#}")),
+
+                    Err(join_err) => {
+                        return Err(miette!(
+                            "task {task_name} panicked or was cancelled: {join_err:#}"
+                        ))
+                    }
+                }
+            }
+
+            Ok(())
         }
     }
 
     // If other tasks also need to be gracefully waited for on shutdown,
     // add them here.
     let mut handles = TaskHandles {
-        main_task: task_handle,
+        main_task: main_task_handle,
+        wallet_sync_task: wallet_sync_task_handle,
     };
 
     async fn graceful_shutdown(
@@ -1049,7 +1111,7 @@ async fn main() -> Result<()> {
         // If we've not yet sent the shutdown signal, do so now. In the case of an interrupt signal,
         // this branch will hit
         if (shutdown_tx.send(()).await).is_ok() {
-            tracing::debug!("sent shutdown signal");
+            tracing::debug!("shutdown: sent signal");
         }
 
         if let Err(err) = tokio::time::timeout(
@@ -1058,9 +1120,18 @@ async fn main() -> Result<()> {
             handles.join_all(),
         )
         .await
-        .map_err(|err| miette!("shutdown: error while waiting for tasks to finish: {err:#}"))
-        {
-            tracing::error!("{:#}", err);
+        .map_err(|err| {
+            #[derive(Debug, Diagnostic, Error)]
+            #[error("shutdown: error while waiting for tasks to finish")]
+            #[diagnostic(code(bip300301_enforcer::shutdown))]
+            struct ShutdownError {
+                #[source]
+                err: tokio::time::error::Elapsed,
+            }
+            ShutdownError { err }
+        }) {
+            // why isn't the source displayed here?
+            tracing::error!("{err:#}");
         };
     }
 

--- a/lib/wallet/error.rs
+++ b/lib/wallet/error.rs
@@ -78,6 +78,7 @@ impl ToStatus for NotSynced {
 #[derive(Debug, Diagnostic, Error)]
 #[diagnostic(code(wallet_not_unlocked))]
 #[error("enforcer wallet not unlocked")]
+#[help("use the cusf.mainchain.v1.WalletService/UnlockWallet RPC to unlock the wallet")]
 pub struct NotUnlocked;
 
 impl ToStatus for NotUnlocked {

--- a/lib/wallet/mod.rs
+++ b/lib/wallet/mod.rs
@@ -1,8 +1,9 @@
 use std::{
     collections::HashMap,
+    future::Future,
     path::Path,
     str::FromStr,
-    sync::{atomic::AtomicBool, Arc},
+    sync::Arc,
     time::{Duration, SystemTime},
 };
 
@@ -31,10 +32,9 @@ use bitcoin_jsonrpsee::{
 };
 use either::Either;
 use fallible_iterator::{FallibleIterator as _, IteratorExt as _};
-use futures::{channel::oneshot, FutureExt, TryFutureExt};
-use parking_lot::Mutex;
+use futures::{FutureExt, TryFutureExt};
 use rusqlite::Connection;
-use tokio::{spawn, task::JoinHandle, time::Instant};
+use tokio::time::Instant;
 use tracing::instrument;
 use uuid::Uuid;
 
@@ -643,105 +643,6 @@ impl WalletInner {
     }
 }
 
-pub struct Task {
-    /// Send a startup signal
-    start_tx: Mutex<Option<oneshot::Sender<()>>>,
-    /// Send a shutdown signal.
-    /// Should only be `None` during drop.
-    /// Shutdown signal must be sent before dropping owned tasks.
-    shutdown_tx: Option<oneshot::Sender<()>>,
-    sync: JoinHandle<()>,
-}
-
-impl Task {
-    /// This task may block, and so attempting to abort it may fail.
-    /// see https://docs.rs/tokio/latest/tokio/task/fn.block_in_place.html
-    /// A shutdown signal is used to ensure that the task stops after
-    /// the blocking task completes.
-    async fn sync_task(
-        wallet: Arc<WalletInner>,
-        start_rx: oneshot::Receiver<()>,
-        mut shutdown_rx: oneshot::Receiver<()>,
-    ) {
-        use futures::future::{select, Either};
-        const SYNC_INTERVAL: Duration = Duration::from_secs(15);
-        tracing::debug!(
-            interval = %jiff::SignedDuration::try_from(SYNC_INTERVAL).unwrap(),
-            "wallet sync task: starting"
-        );
-        // Wait for the start signal to be sent before starting the sync.
-        // Take care to also listen for the shutdown signal or channel
-        // closures, which might happen while waiting for the start signal
-        shutdown_rx = match select(start_rx, shutdown_rx).await {
-            // Start signal received
-            Either::Left((Ok(()), shutdown_rx)) => shutdown_rx,
-            // Start signal cancelled
-            Either::Left((Err(_), _shutdown_rx)) => {
-                tracing::info!("shutting down (start signal channel closed)");
-                return;
-            }
-            // Shutdown signal received
-            Either::Right((Ok(()), _start_rx)) => {
-                tracing::info!("shutting down)");
-                return;
-            }
-            // Shutdown signal cancelled
-            Either::Right((Err(_), _start_rx)) => {
-                tracing::info!("shutting down (shutdown signal channel closed)");
-                return;
-            }
-        };
-        let mut sleep = tokio::time::sleep(SYNC_INTERVAL).boxed();
-        loop {
-            tokio::select! {
-                biased;  // Prioritize shutdown
-
-                _ = &mut shutdown_rx => {
-                    tracing::info!("shutting down");
-                    return
-                }
-                _ = &mut sleep => {
-                    let tick = Uuid::new_v4().simple();
-                    let span = tracing::span!(tracing::Level::DEBUG,
-                        "wallet_sync",
-                        %tick,
-                    );
-                    let guard = span.enter();
-                    if let Err(err) = wallet.sync().await {
-                        tracing::error!("wallet sync error: {:#}", ErrorChain::new(&err));
-                    }
-                    drop(guard);
-                    sleep = tokio::time::sleep(SYNC_INTERVAL).boxed();
-                }
-            }
-        }
-    }
-
-    fn new(wallet: Arc<WalletInner>) -> Self {
-        let (start_tx, start_rx) = oneshot::channel();
-        let (shutdown_tx, shutdown_rx) = oneshot::channel();
-        Self {
-            start_tx: Mutex::new(Some(start_tx)),
-            shutdown_tx: Some(shutdown_tx),
-            sync: spawn(Self::sync_task(wallet, start_rx, shutdown_rx)),
-        }
-    }
-}
-
-impl Drop for Task {
-    fn drop(&mut self) {
-        let Self {
-            start_tx: _start_tx,
-            shutdown_tx,
-            sync,
-        } = self;
-        if let Some(shutdown_tx) = shutdown_tx.take() {
-            let _send_shutdown_signal_result: Result<(), ()> = shutdown_tx.send(());
-        };
-        sync.abort();
-    }
-}
-
 /// Optional parameters for sending a wallet transaction
 #[derive(Debug, Default)]
 pub struct CreateTransactionParams {
@@ -772,9 +673,6 @@ pub struct WalletInfo {
 #[derive(Clone)]
 pub struct Wallet {
     inner: Arc<WalletInner>,
-    task: Arc<Task>,
-
-    has_initial_synced: Arc<AtomicBool>,
 }
 
 impl Wallet {
@@ -787,12 +685,46 @@ impl Wallet {
     ) -> Result<Self, error::InitWallet> {
         let inner =
             Arc::new(WalletInner::new(data_dir, config, main_client, validator, magic).await?);
-        let task = Task::new(inner.clone());
-        Ok(Self {
-            inner,
-            task: Arc::new(task),
-            has_initial_synced: Arc::new(AtomicBool::new(false)),
-        })
+        Ok(Self { inner })
+    }
+
+    pub async fn sync_task<F: Future<Output = ()>>(
+        &self,
+        shutdown_signal: F,
+    ) -> Result<(), miette::Report> {
+        const SYNC_INTERVAL: Duration = Duration::from_secs(15);
+        tracing::debug!(
+            interval = %jiff::SignedDuration::try_from(SYNC_INTERVAL).unwrap(),
+            "wallet sync task: starting"
+        );
+
+        // Needed so we can use `tokio::select!`
+        futures::pin_mut!(shutdown_signal);
+
+        let mut sleep = tokio::time::sleep(SYNC_INTERVAL).boxed();
+        loop {
+            tokio::select! {
+                biased;  // Prioritize shutdown
+
+                res = &mut shutdown_signal => {
+                    tracing::info!("shutting down sync task");
+                    return Ok(res);
+                }
+                _ = &mut sleep => {
+                    let tick = Uuid::new_v4().simple();
+                    let span = tracing::span!(tracing::Level::DEBUG,
+                        "wallet_sync",
+                        %tick,
+                    );
+                    let guard = span.enter();
+                    if let Err(err) = self.inner.sync().await {
+                        tracing::error!("wallet sync error: {:#}", ErrorChain::new(&err));
+                    }
+                    drop(guard);
+                    sleep = tokio::time::sleep(SYNC_INTERVAL).boxed();
+                }
+            }
+        }
     }
 
     #[allow(clippy::result_large_err)]


### PR DESCRIPTION
1. Instead of implicitly spawning a wallet sync task on wallet instantation, make this explicit and spawn from main.rs. This allows us to rip out some start/stop complexity, and also allows us to spawn the wallet sync task right away, instead of waiting until the validator has synced.

2. Remove callback usage from the mempool sync task. Instead return the synced mempool, and allow what used to be a callback instead be a regular function call on the mempool. Allows to reduce some complexity around senders/receivers.

3. Implement support for shutting down the `getblocktemplate` JSON-RPC server. Previously this was never cancelled, leading us to always hit the force shutdown after a short timeout.

4. Implement support for shutting down the main validator JSON-RPC server

This fixes the second point of this comment: https://github.com/LayerTwo-Labs/bip300301_enforcer/issues/207#issuecomment-2922748187