### PR TITLE
multi: add implementation + integration test for basic reorgs

### DIFF
--- a/integration_tests/integration_test.rs
+++ b/integration_tests/integration_test.rs
@@ -564,6 +564,20 @@ pub fn tests(bin_paths: &BinPaths) -> Vec<TestTrial> {
                 )
             });
 
+    let reorg_disconnect_block_tests =
+        [(Network::Regtest, Mode::Mempool)]
+            .iter()
+            .map(|(network, mode)| {
+                let bin_paths = bin_paths.clone();
+                AsyncTrial::new(
+                    format!("reorg_disconnect_block (mode: {mode}, network: {network})"),
+                    Box::pin(async move {
+                        crate::test_reorg_disconnect_block::test_reorg_disconnect_block(bin_paths)
+                            .await
+                    }) as TestFuture,
+                )
+            });
+
     let peer_bmm_request_tests =
         [(Network::Regtest, Mode::Mempool)]
             .iter()
@@ -585,6 +599,7 @@ pub fn tests(bin_paths: &BinPaths) -> Vec<TestTrial> {
     async_trials.extend(deposit_withdraw_roundtrip_tests);
     async_trials.extend(unconfirmed_transactions_tests);
     async_trials.extend(peer_bmm_request_tests);
+    async_trials.extend(reorg_disconnect_block_tests);
 
     async_trials
 }

--- a/integration_tests/lib.rs
+++ b/integration_tests/lib.rs
@@ -2,5 +2,6 @@ pub mod integration_test;
 pub mod mine;
 pub mod setup;
 mod test_peer_bmm_request;
+mod test_reorg_disconnect_block;
 mod test_unconfirmed_transactions;
 pub mod util;

--- a/integration_tests/test_reorg_disconnect_block.rs
+++ b/integration_tests/test_reorg_disconnect_block.rs
@@ -1,0 +1,166 @@
+use std::str::FromStr;
+
+use bip300301_enforcer_lib::{
+    bins::{BitcoinCli, CommandExt as _},
+    proto::mainchain::{GetChainTipRequest, validator_service_client::ValidatorServiceClient},
+};
+use bitcoin::BlockHash;
+use futures::channel::mpsc;
+use serde_json::Map;
+use tonic::transport::Channel;
+
+use crate::{
+    setup::{Mode, Network, generate_regtest_block, setup},
+    util::BinPaths,
+};
+
+// Basic test for reorging and disconnecting a block.
+// TODO: add setup + assertions for different BIP300/301 scenarios
+//   * a freshly enacted sidechain going back to pending
+//   * proposal votes being reset
+//   * a newly deleted sidechain going back to pending
+//   * deposits being reset
+//   * sidechain treasury values being reset
+//   * withdrawal bundle votes being reset
+pub async fn test_reorg_disconnect_block(bin_paths: BinPaths) -> anyhow::Result<()> {
+    let (res_tx, _) = mpsc::unbounded();
+    let mut post_setup = setup(&bin_paths, Network::Regtest, Mode::NoMempool, res_tx).await?;
+
+    let new_block =
+        generate_regtest_block(&post_setup.bitcoin_cli, &post_setup.mining_address).await?;
+
+    let enforcer_tip = fetch_enforcer_tip(&mut post_setup.validator_service_client).await?;
+
+    // invalidate the block in core
+    post_setup
+        .bitcoin_cli
+        .command::<String, _, _, _, _>([], "invalidateblock", [new_block.to_string()])
+        .run_utf8()
+        .await?;
+
+    tracing::info!("invalidated block: {}", new_block.clone());
+
+    let chain_info = fetch_mainchain_info(&post_setup.bitcoin_cli).await?;
+    tracing::info!("chain info post `invalidateblock`: {:#?}", chain_info);
+
+    assert!(chain_info.block_height == enforcer_tip.block_height - 1);
+    assert!(chain_info.best_block_hash == enforcer_tip.prev_block_hash);
+
+    tracing::info!("bitcoin core has reorged to {}", chain_info.best_block_hash);
+
+    let enforcer_tip_post_invalidate =
+        fetch_enforcer_tip(&mut post_setup.validator_service_client).await?;
+
+    assert!(enforcer_tip_post_invalidate.block_hash == enforcer_tip.prev_block_hash);
+    assert!(enforcer_tip_post_invalidate.block_height == enforcer_tip.block_height - 1);
+
+    tracing::info!(
+        "enforcer has reorged to {}",
+        enforcer_tip_post_invalidate.block_hash
+    );
+
+    // If we generate a new block right away Bitcoin Core for some reason
+    // will generate the same block hash as the one we just invalidated...
+    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+
+    let new_block =
+        generate_regtest_block(&post_setup.bitcoin_cli, &post_setup.mining_address).await?;
+
+    tracing::info!("mined new block post invalidate: {}", new_block);
+
+    let chain_info_post_generate = fetch_mainchain_info(&post_setup.bitcoin_cli).await?;
+    tracing::info!(
+        "chain info post `generate`: {:#?}",
+        chain_info_post_generate
+    );
+    assert!(chain_info_post_generate.block_height == enforcer_tip_post_invalidate.block_height + 1);
+    assert!(chain_info_post_generate.best_block_hash == new_block);
+
+    let enforcer_tip_post_generate =
+        fetch_enforcer_tip(&mut post_setup.validator_service_client).await?;
+
+    tracing::info!(
+        "enforcer tip post `generate`: {:#?}",
+        enforcer_tip_post_generate
+    );
+    assert!(enforcer_tip_post_generate.block_hash == chain_info_post_generate.best_block_hash);
+    assert!(enforcer_tip_post_generate.block_height == chain_info_post_generate.block_height);
+
+    Ok(())
+}
+
+#[derive(Debug)]
+struct ChainInfo {
+    block_height: u64,
+    best_block_hash: BlockHash,
+}
+
+async fn fetch_mainchain_info(bitcoin_cli: &BitcoinCli) -> anyhow::Result<ChainInfo> {
+    let raw = bitcoin_cli
+        .command::<String, _, String, _, _>([], "getblockchaininfo", [])
+        .run_utf8()
+        .await
+        .map_err(|err| anyhow::anyhow!("error fetching chain info: {err:#}"))?;
+
+    let chain_info = match serde_json::from_str::<Map<String, serde_json::Value>>(&raw) {
+        Ok(chain_info) => chain_info,
+        Err(err) => {
+            return Err(anyhow::anyhow!(
+                "error parsing chain info ({raw}) : {err:#}",
+            ));
+        }
+    };
+
+    Ok(ChainInfo {
+        block_height: chain_info
+            .get("blocks")
+            .map(|v| v.as_u64().unwrap_or_default())
+            .unwrap_or_default(),
+        best_block_hash: BlockHash::from_str(
+            chain_info
+                .get("bestblockhash")
+                .map(|v| v.as_str().unwrap_or_default())
+                .unwrap_or_default(),
+        )
+        .expect("best block hash should be valid"),
+    })
+}
+
+#[derive(Debug)]
+struct EnforcerTip {
+    block_hash: BlockHash,
+    prev_block_hash: BlockHash,
+    block_height: u64,
+}
+
+async fn fetch_enforcer_tip(
+    validator_service_client: &mut ValidatorServiceClient<Channel>,
+) -> anyhow::Result<EnforcerTip> {
+    let chain_tip = validator_service_client
+        .get_chain_tip(GetChainTipRequest {})
+        .await?
+        .into_inner();
+
+    let header_info = chain_tip
+        .block_header_info
+        .expect("block header info should be present");
+
+    let block_hash = header_info
+        .block_hash
+        .expect("block hash should be present")
+        .hex
+        .expect("block hash hex should be present");
+
+    Ok(EnforcerTip {
+        block_hash: BlockHash::from_str(&block_hash).expect("block hash should be valid"),
+        prev_block_hash: BlockHash::from_str(
+            &header_info
+                .prev_block_hash
+                .unwrap_or_default()
+                .hex
+                .unwrap_or_default(),
+        )
+        .expect("prev block hash should be valid"),
+        block_height: header_info.height as u64,
+    })
+}

--- a/lib/validator/task/error.rs
+++ b/lib/validator/task/error.rs
@@ -255,7 +255,13 @@ impl From<db::Error> for ConnectBlock {
 }
 
 #[derive(Debug, Error)]
-pub(in crate::validator) enum DisconnectBlock {}
+pub(in crate::validator) enum DisconnectBlock {
+    #[error(transparent)]
+    Db(#[from] db::Error),
+
+    #[error(transparent)]
+    GetHeaderInfo(#[from] dbs::block_hash_dbs_error::GetHeaderInfo),
+}
 
 impl fatality::Fatality for DisconnectBlock {
     fn is_fatal(&self) -> bool {

--- a/lib/wallet/cusf_block_producer.rs
+++ b/lib/wallet/cusf_block_producer.rs
@@ -213,12 +213,14 @@ impl CusfEnforcer for Wallet {
         &mut self,
         block_hash: BlockHash,
     ) -> std::result::Result<(), Self::DisconnectBlockError> {
+        // It's sufficient for the enforcer to disconnect the block here. The wallet
+        // has no notion of block disconnects. Once a better tip is found and applied,
+        // BDK logic handles this for us.
         self.inner
             .validator
             .clone()
             .disconnect_block(block_hash)
             .await
-        // FIXME: disconnect block for wallet
     }
 
     type AcceptTxError = <Validator as CusfEnforcer>::AcceptTxError;


### PR DESCRIPTION
I've implemented very basic handling of reorgs in the enforcer here + an accompanying integration test. My PR just moves the chain tip back from the recently invalidated block. For the implementation to be completed it'd also need to undo any M* messages from the block we're disconnecting. To do this 100% I believe we need to introduce the concept of "undo" data. As is we're doing destructive DB operations when processing blocks. Disconnecting a block would require us to take a look at the undo data to ensure we can end up at the correct spot. 