### PR TITLE
integration tests: dump core+enforcer logs on failure

### DIFF
--- a/integration_tests/integration_test.rs
+++ b/integration_tests/integration_test.rs
@@ -16,18 +16,83 @@ use bitcoin::Amount;
 use futures::{StreamExt as _, TryStreamExt as _, channel::mpsc};
 use tokio::time::sleep;
 use tokio_stream::wrappers::IntervalStream;
-use tracing::Instrument;
 
 use crate::{
     mine::{
         mine, mine_check_block_events, mine_gbt_check, mine_generateblocks_check, mine_signet_check,
     },
     setup::{DummySidechain, MiningMode, Mode, Network, PostSetup, Sidechain, setup},
-    util::{self, AsyncTrial, BinPaths},
+    util::{AsyncTrial, BinPaths, FileDumpConfig, TestFileRegistry},
 };
 
 type TestFuture = std::pin::Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send>>;
 type TestTrial = AsyncTrial<TestFuture>;
+
+struct TestSetupComponents {
+    bin_paths: BinPaths,
+    network: Network,
+    mode: Mode,
+    file_registry: TestFileRegistry,
+}
+
+fn new_trial_with_setup<F, Fut>(name: String, comps: TestSetupComponents, test_fn: F) -> TestTrial
+where
+    F: FnOnce(PostSetup) -> Fut + Send + 'static,
+    Fut: Future<Output = anyhow::Result<()>> + Send + 'static,
+{
+    let file_registry = comps.file_registry.clone();
+    AsyncTrial::new(
+        name.clone(),
+        Box::pin(async move {
+            let (res_tx, _) = mpsc::unbounded();
+            let post_setup = setup(&comps.bin_paths, comps.network, comps.mode, res_tx).await?;
+
+            // Register specific files with their own configurations
+            file_registry.register_file(
+                &name,
+                post_setup
+                    .out_dir
+                    .path()
+                    .join("bitcoind")
+                    .join("stdout.txt"),
+                FileDumpConfig::new().with_label("Bitcoin Core stdout"),
+            );
+
+            file_registry.register_file(
+                &name,
+                post_setup
+                    .out_dir
+                    .path()
+                    .join("bitcoind")
+                    .join("stderr.txt"),
+                FileDumpConfig::new().with_label("Bitcoin Core stderr"),
+            );
+
+            file_registry.register_file(
+                &name,
+                post_setup
+                    .out_dir
+                    .path()
+                    .join("enforcer")
+                    .join("stdout.txt"),
+                FileDumpConfig::new().with_label("Enforcer stdout"),
+            );
+
+            file_registry.register_file(
+                &name,
+                post_setup
+                    .out_dir
+                    .path()
+                    .join("enforcer")
+                    .join("stderr.txt"),
+                FileDumpConfig::new().with_label("Enforcer stderr"),
+            );
+
+            test_fn(post_setup).await
+        }) as TestFuture,
+    )
+    .with_file_registry(comps.file_registry)
+}
 
 pub async fn propose_sidechain<S>(post_setup: &mut PostSetup) -> anyhow::Result<()>
 where
@@ -419,27 +484,24 @@ where
 
 #[allow(clippy::significant_drop_tightening, reason = "false positive")]
 async fn deposit_withdraw_roundtrip_task<S>(
-    bin_paths: &BinPaths,
-    network: Network,
-    mode: Mode,
+    post_setup: &mut PostSetup,
     res_tx: mpsc::UnboundedSender<anyhow::Result<()>>,
     sidechain_init: S::Init,
 ) -> anyhow::Result<()>
 where
     S: Sidechain,
 {
-    let mut post_setup = setup(bin_paths, network, mode, res_tx.clone()).await?;
-    let mut sidechain = S::setup(sidechain_init, &post_setup, res_tx).await?;
+    let mut sidechain = S::setup(sidechain_init, post_setup, res_tx).await?;
     tracing::info!("Setup successfully");
-    let () = propose_sidechain::<S>(&mut post_setup).await?;
+    let () = propose_sidechain::<S>(post_setup).await?;
     tracing::info!("Proposed sidechain successfully");
-    let () = activate_sidechain::<S>(&mut post_setup).await?;
+    let () = activate_sidechain::<S>(post_setup).await?;
     tracing::info!("Activated sidechain successfully");
-    let () = fund_enforcer::<S>(&mut post_setup).await?;
+    let () = fund_enforcer::<S>(post_setup).await?;
     tracing::info!("Funded enforcer successfully");
     let deposit_address = sidechain.get_deposit_address().await?;
     let () = deposit(
-        &mut post_setup,
+        post_setup,
         &mut sidechain,
         &deposit_address,
         DEPOSIT_AMOUNT,
@@ -452,7 +514,7 @@ where
     let () = wait_for_wallet_sync().await?;
     tracing::info!("Attempting second deposit");
     let () = deposit(
-        &mut post_setup,
+        post_setup,
         &mut sidechain,
         &deposit_address,
         DEPOSIT_AMOUNT,
@@ -460,10 +522,10 @@ where
     )
     .await?;
     tracing::info!("Deposited to sidechain successfully");
-    let pending_withdrawal_value = match mode.mining_mode() {
+    let pending_withdrawal_value = match post_setup.mode.mining_mode() {
         MiningMode::GenerateBlocks => {
             let () = withdraw_expire(
-                &mut post_setup,
+                post_setup,
                 &mut sidechain,
                 WITHDRAW_AMOUNT_0,
                 WITHDRAW_FEE_0,
@@ -475,7 +537,7 @@ where
         MiningMode::GetBlockTemplate => Amount::ZERO,
     };
     let () = withdraw_succeed(
-        &mut post_setup,
+        post_setup,
         &mut sidechain,
         WITHDRAW_AMOUNT_1,
         WITHDRAW_FEE_1,
@@ -484,11 +546,6 @@ where
     .await?;
     tracing::info!("Withdrawal succeeded");
     drop(sidechain);
-    tracing::info!("Removing {}", post_setup.out_dir.path().display());
-    drop(post_setup.tasks);
-    // Wait for tasks to die
-    sleep(std::time::Duration::from_secs(1)).await;
-    post_setup.out_dir.cleanup()?;
     Ok(())
 }
 
@@ -498,39 +555,18 @@ where
 /// * If mode is not GBT, creates a withdrawal that will be allowed to expire
 /// * Creates and handles a withdrawal
 pub async fn deposit_withdraw_roundtrip<S>(
-    bin_paths: BinPaths,
-    network: Network,
-    mode: Mode,
+    mut post_setup: PostSetup,
     sidechain_init: S::Init,
 ) -> anyhow::Result<()>
 where
     S: Sidechain + Send,
     S::Init: Send + 'static,
 {
-    let (res_tx, mut res_rx) = mpsc::unbounded();
-    let _test_task: util::AbortOnDrop<()> = tokio::task::spawn({
-        let res_tx = res_tx.clone();
-        async move {
-            let res = deposit_withdraw_roundtrip_task::<S>(
-                &bin_paths,
-                network,
-                mode,
-                res_tx.clone(),
-                sidechain_init,
-            )
-            .await;
-            let _send_err: Result<(), _> = res_tx.unbounded_send(res);
-        }
-        .in_current_span()
-    })
-    .into();
-    res_rx
-        .next()
-        .await
-        .ok_or_else(|| anyhow::anyhow!("Unexpected end of test task result stream"))?
+    let (res_tx, _) = mpsc::unbounded();
+    deposit_withdraw_roundtrip_task::<S>(&mut post_setup, res_tx, sidechain_init).await
 }
 
-pub fn tests(bin_paths: &BinPaths) -> Vec<TestTrial> {
+pub fn tests(bin_paths: &BinPaths, file_registry: TestFileRegistry) -> Vec<TestTrial> {
     let deposit_withdraw_roundtrip_tests = [
         (Network::Regtest, Mode::GetBlockTemplate),
         (Network::Regtest, Mode::Mempool),
@@ -539,12 +575,15 @@ pub fn tests(bin_paths: &BinPaths) -> Vec<TestTrial> {
     ]
     .iter()
     .map(|(network, mode)| {
-        let bin_paths = bin_paths.clone();
-        AsyncTrial::new(
+        new_trial_with_setup(
             format!("deposit_withdraw_roundtrip (mode: {mode}, network: {network})"),
-            Box::pin(async move {
-                deposit_withdraw_roundtrip::<DummySidechain>(bin_paths, *network, *mode, ()).await
-            }) as TestFuture,
+            TestSetupComponents {
+                bin_paths: bin_paths.clone(),
+                network: *network,
+                mode: *mode,
+                file_registry: file_registry.clone(),
+            },
+            |post_setup| deposit_withdraw_roundtrip::<DummySidechain>(post_setup, ()),
         )
     });
 
@@ -553,14 +592,18 @@ pub fn tests(bin_paths: &BinPaths) -> Vec<TestTrial> {
         [(Network::Regtest, Mode::Mempool)]
             .iter()
             .map(|(network, mode)| {
-                let bin_paths = bin_paths.clone();
-                AsyncTrial::new(
+                new_trial_with_setup(
                     format!("unconfirmed_transactions (mode: {mode}, network: {network})"),
-                    Box::pin(async move {
+                    TestSetupComponents {
+                        bin_paths: bin_paths.clone(),
+                        network: *network,
+                        mode: *mode,
+                        file_registry: file_registry.clone(),
+                    },
+                    |post_setup| {
                         use crate::test_unconfirmed_transactions::test_unconfirmed_transactions;
-
-                        test_unconfirmed_transactions(bin_paths, *network, *mode).await
-                    }) as TestFuture,
+                        test_unconfirmed_transactions(post_setup)
+                    },
                 )
             });
 
@@ -568,18 +611,17 @@ pub fn tests(bin_paths: &BinPaths) -> Vec<TestTrial> {
         [(Network::Regtest, Mode::Mempool)]
             .iter()
             .map(|(network, mode)| {
-                let bin_paths = bin_paths.clone();
-                AsyncTrial::new(
+                new_trial_with_setup(
                     format!("peer_bmm_request (mode: {mode}, network: {network})"),
-                    Box::pin(async move {
-                        crate::test_peer_bmm_request::test_peer_bmm_request(
-                            bin_paths, *network, *mode,
-                        )
-                        .await
-                    }) as TestFuture,
+                    TestSetupComponents {
+                        bin_paths: bin_paths.clone(),
+                        network: *network,
+                        mode: *mode,
+                        file_registry: file_registry.clone(),
+                    },
+                    crate::test_peer_bmm_request::test_peer_bmm_request,
                 )
             });
-
     let mut async_trials = vec![];
 
     async_trials.extend(deposit_withdraw_roundtrip_tests);

--- a/integration_tests/main.rs
+++ b/integration_tests/main.rs
@@ -1,4 +1,7 @@
-use bip300301_enforcer_integration_tests::{integration_test, util::BinPaths};
+use bip300301_enforcer_integration_tests::{
+    integration_test,
+    util::{BinPaths, TestFileRegistry},
+};
 use clap::Parser;
 use tracing_subscriber::{filter as tracing_filter, layer::SubscriberExt};
 
@@ -86,10 +89,12 @@ async fn main() -> anyhow::Result<std::process::ExitCode> {
         tracing::info!("Loaded env vars from `{}`", env_filepath.display());
     }
 
+    let file_registry = TestFileRegistry::new();
+
     // Create a list of tests
     let mut tests = Vec::<libtest_mimic::Trial>::new();
     tests.extend(
-        integration_test::tests(&BinPaths::from_env()?)
+        integration_test::tests(&BinPaths::from_env()?, file_registry)
             .into_iter()
             .map(|trial| trial.run_blocking(rt_handle.clone())),
     );

--- a/integration_tests/test_peer_bmm_request.rs
+++ b/integration_tests/test_peer_bmm_request.rs
@@ -1,13 +1,11 @@
 use bip300301_enforcer_lib::{bins::CommandExt, proto::common::ConsensusHex};
-use futures::{StreamExt, channel::mpsc};
+use futures::channel::mpsc;
 use tokio::time::sleep;
-use tracing::Instrument;
 
 use crate::{
     integration_test::{activate_sidechain, fund_enforcer, propose_sidechain},
     mine,
-    setup::{DummySidechain, Mode, Network, PostSetup, Sidechain, setup},
-    util::{self, BinPaths},
+    setup::{DummySidechain, PostSetup, Sidechain},
 };
 
 async fn create_bmm_request_tx(
@@ -76,52 +74,40 @@ async fn create_bmm_request_tx(
 }
 
 async fn test_peer_bmm_request_task(
-    bin_paths: &BinPaths,
-    network: Network,
-    mode: Mode,
+    post_setup: &mut PostSetup,
     res_tx: mpsc::UnboundedSender<anyhow::Result<()>>,
 ) -> anyhow::Result<()> {
-    let mut post_setup = setup(bin_paths, network, mode, res_tx.clone()).await?;
-    let sidechain = DummySidechain::setup((), &post_setup, res_tx).await?;
+    let sidechain = DummySidechain::setup((), post_setup, res_tx).await?;
     tracing::info!("Setup successfully");
-    let () = propose_sidechain::<DummySidechain>(&mut post_setup).await?;
+    let () = propose_sidechain::<DummySidechain>(post_setup).await?;
     tracing::info!("Proposed sidechain successfully");
-    let () = activate_sidechain::<DummySidechain>(&mut post_setup).await?;
+    let () = activate_sidechain::<DummySidechain>(post_setup).await?;
     tracing::info!("Activated sidechain successfully");
-    let () = fund_enforcer::<DummySidechain>(&mut post_setup).await?;
+    let () = fund_enforcer::<DummySidechain>(post_setup).await?;
     tracing::info!("Funded enforcer successfully");
 
     let sidechain_block_hash: [u8; 32] = {
         use bitcoin::hashes::Hash;
         bitcoin::hashes::sha256::Hash::hash(b"dummy sidechain block").to_byte_array()
     };
-    let _txid = create_bmm_request_tx(&mut post_setup, &sidechain_block_hash).await?;
+    let _txid = create_bmm_request_tx(post_setup, &sidechain_block_hash).await?;
     tracing::info!("Created BMM request tx successfully");
     // Wait for mempool inclusion
     sleep(std::time::Duration::from_secs(1)).await;
     // Mine a block and check that the BMM request worked
-    let () = mine::mine_check_block_events::<_, DummySidechain>(
-        &mut post_setup,
-        1,
-        None,
-        |_, block_info| {
+    let () =
+        mine::mine_check_block_events::<_, DummySidechain>(post_setup, 1, None, |_, block_info| {
             let bmm_commitment = block_info
                 .bmm_commitment
                 .ok_or_else(|| anyhow::anyhow!("Expected a BMM commitment"))?;
             let expected_bmm_commitment = ConsensusHex::encode(&sidechain_block_hash);
             anyhow::ensure!(bmm_commitment == expected_bmm_commitment);
             Ok(())
-        },
-    )
-    .await?;
+        })
+        .await?;
     tracing::info!("Included BMM request tx successfully");
 
     drop(sidechain);
-    tracing::info!("Removing {}", post_setup.out_dir.path().display());
-    drop(post_setup.tasks);
-    // Wait for tasks to die
-    sleep(std::time::Duration::from_secs(1)).await;
-    post_setup.out_dir.cleanup()?;
     Ok(())
 }
 
@@ -130,23 +116,6 @@ async fn test_peer_bmm_request_task(
 /// * Creates two deposits
 /// * If mode is not GBT, creates a withdrawal that will be allowed to expire
 /// * Creates and handles a withdrawal
-pub async fn test_peer_bmm_request(
-    bin_paths: BinPaths,
-    network: Network,
-    mode: Mode,
-) -> anyhow::Result<()> {
-    let (res_tx, mut res_rx) = mpsc::unbounded();
-    let _test_task: util::AbortOnDrop<()> = tokio::task::spawn({
-        let res_tx = res_tx.clone();
-        async move {
-            let res = test_peer_bmm_request_task(&bin_paths, network, mode, res_tx.clone()).await;
-            let _send_err: Result<(), _> = res_tx.unbounded_send(res);
-        }
-        .in_current_span()
-    })
-    .into();
-    res_rx
-        .next()
-        .await
-        .ok_or_else(|| anyhow::anyhow!("Unexpected end of test task result stream"))?
+pub async fn test_peer_bmm_request(mut post_setup: PostSetup) -> anyhow::Result<()> {
+    test_peer_bmm_request_task(&mut post_setup, mpsc::unbounded().0).await
 }

--- a/integration_tests/test_unconfirmed_transactions.rs
+++ b/integration_tests/test_unconfirmed_transactions.rs
@@ -3,25 +3,16 @@ use std::collections::HashMap;
 use bip300301_enforcer_lib::proto::mainchain::{
     ListTransactionsRequest, ListUnspentOutputsRequest, SendTransactionRequest,
 };
-use futures::channel::mpsc;
 
 use crate::{
     integration_test,
-    setup::{DummySidechain, Mode, Network, setup},
-    util::BinPaths,
+    setup::{DummySidechain, PostSetup},
 };
 
 // Verify that unconfirmed transactions are immediately available when listing wallet
 // transactions.
-pub async fn test_unconfirmed_transactions(
-    bin_paths: BinPaths,
-    network: Network,
-    mode: Mode,
-) -> anyhow::Result<()> {
-    let (res_tx, _) = mpsc::unbounded();
-    let mut post_setup = setup(&bin_paths, network, mode, res_tx).await?;
-
-    integration_test::fund_enforcer::<DummySidechain>(&mut post_setup).await?;
+pub async fn test_unconfirmed_transactions_task(post_setup: &mut PostSetup) -> anyhow::Result<()> {
+    integration_test::fund_enforcer::<DummySidechain>(post_setup).await?;
 
     let txs_pre = post_setup
         .wallet_service_client
@@ -91,4 +82,8 @@ pub async fn test_unconfirmed_transactions(
     assert!(!new_utxos.is_empty());
 
     Ok(())
+}
+
+pub async fn test_unconfirmed_transactions(mut post_setup: PostSetup) -> anyhow::Result<()> {
+    test_unconfirmed_transactions_task(&mut post_setup).await
 }

--- a/integration_tests/util.rs
+++ b/integration_tests/util.rs
@@ -1,7 +1,9 @@
 use std::{
+    collections::HashMap,
     ffi::{OsStr, OsString},
     future::Future,
     path::PathBuf,
+    sync::{Arc, Mutex},
 };
 
 use futures::TryFutureExt as _;
@@ -68,9 +70,95 @@ impl BinPaths {
     }
 }
 
+/// Configuration for individual file dumping behavior
+#[derive(Clone, Debug)]
+pub struct FileDumpConfig {
+    /// Number of lines to show from the end of large files (default: 100)
+    pub lines: usize,
+    /// Whether to show this file on test failure (default: true)
+    pub show_on_failure: bool,
+    /// Optional label for the file
+    pub label: Option<String>,
+}
+
+impl Default for FileDumpConfig {
+    fn default() -> Self {
+        Self {
+            lines: 10,
+            show_on_failure: true,
+            label: None,
+        }
+    }
+}
+
+impl FileDumpConfig {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_lines(mut self, lines: usize) -> Self {
+        self.lines = lines;
+        self
+    }
+
+    pub fn with_label<S: Into<String>>(mut self, label: S) -> Self {
+        self.label = Some(label.into());
+        self
+    }
+
+    pub fn hide_on_failure(mut self) -> Self {
+        self.show_on_failure = false;
+        self
+    }
+}
+
+/// A file with its associated dump configuration
+#[derive(Clone, Debug)]
+pub struct FileWithConfig {
+    pub path: PathBuf,
+    pub config: FileDumpConfig,
+}
+
+/// Registry to track stdout/stderr files for active tests
+#[derive(Clone, Debug, Default)]
+pub struct TestFileRegistry {
+    inner: Arc<Mutex<HashMap<String, Vec<FileWithConfig>>>>,
+}
+
+impl TestFileRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a single file with its configuration for a test
+    pub fn register_file<P: Into<PathBuf>>(
+        &self,
+        test_name: &str,
+        path: P,
+        config: FileDumpConfig,
+    ) {
+        let mut registry = self.inner.lock().unwrap();
+        let file_with_config = FileWithConfig {
+            path: path.into(),
+            config,
+        };
+        registry
+            .entry(test_name.to_string())
+            .or_default()
+            .push(file_with_config);
+    }
+
+    /// Get all registered files with their configurations for a test
+    fn get_files(&self, test_name: &str) -> Vec<FileWithConfig> {
+        let registry = self.inner.lock().unwrap();
+        registry.get(test_name).cloned().unwrap_or_default()
+    }
+}
+
 pub struct AsyncTrial<Fut> {
     name: String,
     test: Fut,
+    file_registry: Option<TestFileRegistry>,
 }
 
 impl<Fut> AsyncTrial<Fut> {
@@ -81,7 +169,13 @@ impl<Fut> AsyncTrial<Fut> {
         Self {
             name: name.as_ref().to_owned(),
             test,
+            file_registry: None,
         }
+    }
+
+    pub fn with_file_registry(mut self, registry: TestFileRegistry) -> Self {
+        self.file_registry = Some(registry);
+        self
     }
 
     // Run the trial on the provided runtime
@@ -91,12 +185,98 @@ impl<Fut> AsyncTrial<Fut> {
         Fut: Future<Output = Result<(), Err>> + Send + 'static,
     {
         let span = tracing::info_span!("test", name = %self.name);
+        let test_name = self.name.clone();
+        let file_registry = self.file_registry.clone();
+
         libtest_mimic::Trial::test(self.name, move || {
             span.in_scope(|| {
-                rt_handle.block_on(async { self.test.map_err(libtest_mimic::Failed::from).await })
+                rt_handle.block_on(async {
+                    let result = self.test.map_err(libtest_mimic::Failed::from).await;
+                    result.inspect_err(|_err| {
+                        // Display stdout/stderr files if available
+                        if let Some(registry) = &file_registry {
+                            let files = registry.get_files(&test_name);
+                            if !files.is_empty() {
+                                let output = format_test_output_files(&test_name, &files);
+                                if !output.is_empty() {
+                                    #[allow(clippy::print_stderr)]
+                                    {
+                                        eprintln!("{output}");
+                                    }
+                                }
+                            }
+                        }
+                    })
+                })
             })
         })
     }
+}
+
+/// Read file contents with optional tail functionality for large files
+pub fn read_file_with_tail(
+    path: &std::path::Path,
+    config: &FileDumpConfig,
+) -> Result<String, std::io::Error> {
+    // Read last N lines
+    let content = std::fs::read_to_string(path)?;
+    let lines: Vec<&str> = content.lines().collect();
+
+    if lines.len() <= config.lines {
+        Ok(content)
+    } else {
+        let tail_start = lines.len() - config.lines;
+        let tail_content = lines[tail_start..].join("\n");
+        Ok(format!(
+            "... [showing last {} lines of {} total lines] ...\n{}",
+            config.lines,
+            lines.len(),
+            tail_content
+        ))
+    }
+}
+
+/// Format and display stdout/stderr files for a test
+pub fn format_test_output_files(test_name: &str, files: &[FileWithConfig]) -> String {
+    if files.is_empty() {
+        return String::new();
+    }
+
+    let mut output = format!("\n=== Test '{test_name}' Output Files ===");
+
+    for file in files {
+        // Skip files that are configured to be hidden
+        if !file.config.show_on_failure {
+            continue;
+        }
+
+        let mut file_with_config_label = file.path.display().to_string();
+
+        if let Some(label) = &file.config.label {
+            file_with_config_label = format!("{label} ({file_with_config_label})");
+        }
+
+        match read_file_with_tail(&file.path, &file.config) {
+            Ok(content) if !content.trim().is_empty() => {
+                // Only show the label if the content is not empty
+                output.push_str(&format!("\n--- {file_with_config_label} ---\n"));
+
+                output.push_str(&content);
+                if !content.ends_with('\n') {
+                    output.push('\n');
+                }
+
+                // Include the label in the end marker as well!
+                output.push_str(&format!("--- End {file_with_config_label} ---\n"));
+            }
+            Ok(_) => {}
+            Err(err) => {
+                output.push_str(&format!("Error reading file: {err}\n"));
+            }
+        }
+    }
+
+    output
 }
 
 /// Wrapper around `JoinHandle` that aborts the task on drop


### PR DESCRIPTION
Right now the integration test failures are pretty inscrutable, especially on CI. This PR attempts to remedy that by dumping file paths for Enforcer + Core logs, as well as the last parts of the files. 