### PR TITLE
rpc client: remove conditional HTTP client builder configuration

### DIFF
--- a/app/main.rs
+++ b/app/main.rs
@@ -901,8 +901,7 @@ async fn main() -> Result<()> {
             return Err(miette::Report::from_err(err));
         }
     }
-    let mainchain_client =
-        rpc_client::create_client(&cli.node_rpc_opts, cli.enable_wallet && cli.enable_mempool)?;
+    let mainchain_client = rpc_client::create_client(&cli.node_rpc_opts)?;
     tracing::info!(
         "created mainchain JSON-RPC client from options: {}:*****@{}",
         cli.node_rpc_opts.user.as_deref().unwrap_or("cookie"),

--- a/lib/validator/main_rest_client.rs
+++ b/lib/validator/main_rest_client.rs
@@ -20,6 +20,8 @@ pub enum MainRestClientError {
     #[error("Invalid block header format")]
     InvalidBlockHeader,
     #[error("Bitcoin Core REST server is not enabled")]
+    #[diagnostic(code(bip300301_enforcer::rest_server_not_enabled))]
+    #[help("do this with the `-rest` flag or `rest=1` in your Bitcoin Core configuration file")]
     RestServerNotEnabled,
     #[error("Bitcoin Core REST server at `{url}` is not reachable")]
     RestServerNotReachable {


### PR DESCRIPTION
We ALWAYS want to apply our configuration logic for the JSON-RPC HTTP
client builder. When fetching batched blocks we can end up exceeding the
default max size of 10MB!

Also contains some minor error handling on startup and logging improvements. 