### PR TITLE
validator: avoid underflow bug, clearer invariant assertions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -545,6 +545,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "sneed",
+ "temp-dir",
  "thiserror 2.0.16",
  "tokio",
  "tokio-rusqlite",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -82,6 +82,9 @@ default = ["rustls"]
 openssl = ["bdk_electrum/use-openssl"]
 rustls = ["bdk_electrum/use-rustls"]
 
+[dev-dependencies]
+temp-dir = "0.2.0"
+
 [lints]
 workspace = true
 

--- a/lib/messages.rs
+++ b/lib/messages.rs
@@ -946,6 +946,8 @@ pub fn create_sidechain_proposal(
 #[cfg(test)]
 mod tests {
 
+    use miette::IntoDiagnostic;
+
     use super::*;
     use crate::types::SidechainProposal;
 
@@ -1022,36 +1024,41 @@ mod tests {
     // ── M8 script_pubkey roundtrip ──
 
     #[test]
-    fn m8_script_pubkey_roundtrip() {
+    fn m8_script_pubkey_roundtrip() -> miette::Result<()> {
         for n in [0u8, 1, 127, 255] {
             let sc = SidechainNumber(n);
             let sc_block_hash = BmmCommitment([n; 32]);
             let prev_hash = BlockHash::from_byte_array([n.wrapping_add(1); 32]);
 
-            let script = M8BmmRequest::script_pubkey(sc, sc_block_hash, prev_hash).unwrap();
+            let script =
+                M8BmmRequest::script_pubkey(sc, sc_block_hash, prev_hash).into_diagnostic()?;
             let bytes = script.to_bytes();
-            let (rest, parsed) = M8BmmRequest::parse(&bytes).unwrap();
+            let (rest, parsed) = M8BmmRequest::parse(&bytes)
+                .map_err(|err| miette::miette!("parse failed for sc {n}: {err}"))?;
 
             assert!(rest.is_empty(), "sc {n}: unexpected trailing bytes");
             assert_eq!(parsed.sidechain_number, sc);
             assert_eq!(parsed.sidechain_block_hash, sc_block_hash);
             assert_eq!(parsed.prev_mainchain_block_hash, prev_hash);
         }
+        Ok(())
     }
 
     // ── parse_op_drivechain / op_drivechain_script roundtrip ──
 
     #[test]
-    fn op_drivechain_script_roundtrip() {
+    fn op_drivechain_script_roundtrip() -> miette::Result<()> {
         use crate::types::op_drivechain_script;
 
         for n in [0u8, 1, 42, 255] {
             let sc = SidechainNumber(n);
             let script = op_drivechain_script(sc);
             let bytes = script.to_bytes();
-            let (_rest, parsed_sc) = parse_op_drivechain(&bytes).unwrap();
+            let (_rest, parsed_sc) = parse_op_drivechain(&bytes)
+                .map_err(|err| miette::miette!("parse failed for sc {n}: {err}"))?;
             assert_eq!(parsed_sc, sc, "sidechain number mismatch for {n}");
         }
+        Ok(())
     }
 
     #[test]
@@ -1069,19 +1076,24 @@ mod tests {
     // ── try_parse_op_return_address ──
 
     #[test]
-    fn try_parse_op_return_address_valid() {
+    fn try_parse_op_return_address_valid() -> miette::Result<()> {
         let address_bytes = b"hello_sidechain";
-        let script =
-            ScriptBuf::new_op_return(PushBytesBuf::try_from(address_bytes.to_vec()).unwrap());
-        let result = try_parse_op_return_address(&script);
-        assert_eq!(result.unwrap(), address_bytes);
+        let script = ScriptBuf::new_op_return(
+            PushBytesBuf::try_from(address_bytes.to_vec()).into_diagnostic()?,
+        );
+        let result = try_parse_op_return_address(&script)
+            .ok_or_else(|| miette::miette!("expected Some address bytes"))?;
+        assert_eq!(result, address_bytes);
+        Ok(())
     }
 
     #[test]
-    fn try_parse_op_return_address_empty_push() {
-        let script = ScriptBuf::new_op_return(PushBytesBuf::try_from(vec![]).unwrap());
-        let result = try_parse_op_return_address(&script);
-        assert_eq!(result.unwrap(), Vec::<u8>::new());
+    fn try_parse_op_return_address_empty_push() -> miette::Result<()> {
+        let script = ScriptBuf::new_op_return(PushBytesBuf::try_from(vec![]).into_diagnostic()?);
+        let result = try_parse_op_return_address(&script)
+            .ok_or_else(|| miette::miette!("expected Some empty bytes"))?;
+        assert_eq!(result, Vec::<u8>::new());
+        Ok(())
     }
 
     #[test]
@@ -1106,19 +1118,19 @@ mod tests {
     // ── create_m5_deposit_output ──
 
     #[test]
-    fn create_m5_deposit_output_value_and_script() {
-        // Non-zero starting balance
+    fn create_m5_deposit_output_value_and_script() -> miette::Result<()> {
         let sc = SidechainNumber(3);
         let output = create_m5_deposit_output(sc, Amount::from_sat(5_000), Amount::from_sat(1_000));
         assert_eq!(output.value, Amount::from_sat(6_000));
         let bytes = output.script_pubkey.to_bytes();
-        let (_, parsed_sc) = parse_op_drivechain(&bytes).unwrap();
+        let (_, parsed_sc) =
+            parse_op_drivechain(&bytes).map_err(|err| miette::miette!("parse failed: {err}"))?;
         assert_eq!(parsed_sc, sc);
 
-        // Zero starting balance
         let output =
             create_m5_deposit_output(SidechainNumber(0), Amount::ZERO, Amount::from_sat(100));
         assert_eq!(output.value, Amount::from_sat(100));
+        Ok(())
     }
 
     // ── compute_m6id ──
@@ -1147,14 +1159,14 @@ mod tests {
     }
 
     #[test]
-    fn compute_m6id_valid_inputs() {
+    fn compute_m6id_valid_inputs() -> miette::Result<()> {
         let sc = SidechainNumber(1);
         // Standard case with non-zero fee
         let (m6id, parsed_sc) = compute_m6id(
             build_m6_tx(sc, Amount::from_sat(6_000), &[Amount::from_sat(3_000)]),
             Amount::from_sat(10_000),
         )
-        .unwrap();
+        .into_diagnostic()?;
         assert_eq!(parsed_sc, sc);
         assert_ne!(m6id.0, bitcoin::Txid::all_zeros());
 
@@ -1183,23 +1195,24 @@ mod tests {
             )
             .is_ok()
         );
+        Ok(())
     }
 
     #[test]
-    fn compute_m6id_is_deterministic_and_treasury_sensitive() {
-        // Same tx + same treasury → same M6id
+    fn compute_m6id_is_deterministic_and_treasury_sensitive() -> miette::Result<()> {
         let tx1 = build_m6_tx(
             SidechainNumber(1),
             Amount::from_sat(5_000),
             &[Amount::from_sat(2_000)],
         );
-        let (id1, _) = compute_m6id(tx1.clone(), Amount::from_sat(8_000)).unwrap();
-        let (id1_again, _) = compute_m6id(tx1.clone(), Amount::from_sat(8_000)).unwrap();
+        let (id1, _) = compute_m6id(tx1.clone(), Amount::from_sat(8_000)).into_diagnostic()?;
+        let (id1_again, _) =
+            compute_m6id(tx1.clone(), Amount::from_sat(8_000)).into_diagnostic()?;
         assert_eq!(id1, id1_again);
 
-        // Different old_treasury → different fee → different M6id
-        let (id2, _) = compute_m6id(tx1, Amount::from_sat(9_000)).unwrap();
+        let (id2, _) = compute_m6id(tx1, Amount::from_sat(9_000)).into_diagnostic()?;
         assert_ne!(id1, id2);
+        Ok(())
     }
 
     #[test]

--- a/lib/messages.rs
+++ b/lib/messages.rs
@@ -710,6 +710,25 @@ pub struct M8BmmRequest {
 impl M8BmmRequest {
     pub const TAG: [u8; 3] = [0x00, 0xBF, 0x00];
 
+    /// Build the OP_RETURN script for an M8 BMM request.
+    /// Argument order matches the on-wire layout:
+    /// `TAG sidechain_number sidechain_block_hash prev_mainchain_block_hash`.
+    pub fn script_pubkey(
+        sidechain_number: SidechainNumber,
+        sidechain_block_hash: BmmCommitment,
+        prev_mainchain_block_hash: BlockHash,
+    ) -> Result<ScriptBuf, bitcoin::script::PushBytesError> {
+        let message = [
+            &Self::TAG[..],
+            &[sidechain_number.into()],
+            sidechain_block_hash.0.as_slice(),
+            &prev_mainchain_block_hash.to_byte_array(),
+        ]
+        .concat();
+        let bytes = PushBytesBuf::try_from(message)?;
+        Ok(ScriptBuf::new_op_return(&bytes))
+    }
+
     pub fn parse(input: &[u8]) -> IResult<&[u8], Self> {
         const HEADER_LENGTH: u8 = 3;
         const SIDECHAIN_NUMBER_LENGTH: u8 = 1;
@@ -998,5 +1017,227 @@ mod tests {
             (&proposal.description).try_into().expect("Failed to parse");
 
         assert_eq!(parsed, declaration);
+    }
+
+    // ── M8 script_pubkey roundtrip ──
+
+    #[test]
+    fn m8_script_pubkey_roundtrip() {
+        for n in [0u8, 1, 127, 255] {
+            let sc = SidechainNumber(n);
+            let sc_block_hash = BmmCommitment([n; 32]);
+            let prev_hash = BlockHash::from_byte_array([n.wrapping_add(1); 32]);
+
+            let script = M8BmmRequest::script_pubkey(sc, sc_block_hash, prev_hash).unwrap();
+            let bytes = script.to_bytes();
+            let (rest, parsed) = M8BmmRequest::parse(&bytes).unwrap();
+
+            assert!(rest.is_empty(), "sc {n}: unexpected trailing bytes");
+            assert_eq!(parsed.sidechain_number, sc);
+            assert_eq!(parsed.sidechain_block_hash, sc_block_hash);
+            assert_eq!(parsed.prev_mainchain_block_hash, prev_hash);
+        }
+    }
+
+    // ── parse_op_drivechain / op_drivechain_script roundtrip ──
+
+    #[test]
+    fn op_drivechain_script_roundtrip() {
+        use crate::types::op_drivechain_script;
+
+        for n in [0u8, 1, 42, 255] {
+            let sc = SidechainNumber(n);
+            let script = op_drivechain_script(sc);
+            let bytes = script.to_bytes();
+            let (_rest, parsed_sc) = parse_op_drivechain(&bytes).unwrap();
+            assert_eq!(parsed_sc, sc, "sidechain number mismatch for {n}");
+        }
+    }
+
+    #[test]
+    fn parse_op_drivechain_rejects_invalid_scripts() {
+        // Empty input
+        assert!(parse_op_drivechain(&[]).is_err());
+        // Just OP_RETURN (wrong opcode)
+        assert!(parse_op_drivechain(&[OP_RETURN.to_u8(), 0x01, 0x00]).is_err());
+        // Missing OP_TRUE at end
+        assert!(
+            parse_op_drivechain(&[OP_DRIVECHAIN.to_u8(), OP_PUSHBYTES_1.to_u8(), 0x01]).is_err()
+        );
+    }
+
+    // ── try_parse_op_return_address ──
+
+    #[test]
+    fn try_parse_op_return_address_valid() {
+        let address_bytes = b"hello_sidechain";
+        let script =
+            ScriptBuf::new_op_return(PushBytesBuf::try_from(address_bytes.to_vec()).unwrap());
+        let result = try_parse_op_return_address(&script);
+        assert_eq!(result.unwrap(), address_bytes);
+    }
+
+    #[test]
+    fn try_parse_op_return_address_empty_push() {
+        let script = ScriptBuf::new_op_return(PushBytesBuf::try_from(vec![]).unwrap());
+        let result = try_parse_op_return_address(&script);
+        assert_eq!(result.unwrap(), Vec::<u8>::new());
+    }
+
+    #[test]
+    fn try_parse_op_return_address_not_op_return() {
+        // A P2PKH-ish script — not OP_RETURN
+        let script = ScriptBuf::from_bytes(vec![0x76, 0xa9, 0x14]);
+        assert!(try_parse_op_return_address(&script).is_none());
+    }
+
+    #[test]
+    fn try_parse_op_return_address_extra_instructions() {
+        // OP_RETURN <push> <push> — rejected because of the extra instruction
+        use bitcoin::script::Builder;
+        let script = Builder::new()
+            .push_opcode(OP_RETURN)
+            .push_slice([1, 2, 3])
+            .push_slice([4, 5, 6])
+            .into_script();
+        assert!(try_parse_op_return_address(&script).is_none());
+    }
+
+    // ── create_m5_deposit_output ──
+
+    #[test]
+    fn create_m5_deposit_output_value_and_script() {
+        // Non-zero starting balance
+        let sc = SidechainNumber(3);
+        let output = create_m5_deposit_output(sc, Amount::from_sat(5_000), Amount::from_sat(1_000));
+        assert_eq!(output.value, Amount::from_sat(6_000));
+        let bytes = output.script_pubkey.to_bytes();
+        let (_, parsed_sc) = parse_op_drivechain(&bytes).unwrap();
+        assert_eq!(parsed_sc, sc);
+
+        // Zero starting balance
+        let output =
+            create_m5_deposit_output(SidechainNumber(0), Amount::ZERO, Amount::from_sat(100));
+        assert_eq!(output.value, Amount::from_sat(100));
+    }
+
+    // ── compute_m6id ──
+
+    /// Build a minimal M6-shaped transaction: 1 input + OP_DRIVECHAIN treasury
+    /// output at index 0 + payout outputs.
+    fn build_m6_tx(
+        sidechain_number: SidechainNumber,
+        new_treasury_value: Amount,
+        payouts: &[Amount],
+    ) -> Transaction {
+        let mut output = vec![TxOut {
+            script_pubkey: crate::types::op_drivechain_script(sidechain_number),
+            value: new_treasury_value,
+        }];
+        output.extend(payouts.iter().map(|value| TxOut {
+            script_pubkey: ScriptBuf::new(),
+            value: *value,
+        }));
+        Transaction {
+            version: bitcoin::transaction::Version::TWO,
+            lock_time: bitcoin::locktime::absolute::LockTime::ZERO,
+            input: vec![bitcoin::TxIn::default()],
+            output,
+        }
+    }
+
+    #[test]
+    fn compute_m6id_valid_inputs() {
+        let sc = SidechainNumber(1);
+        // Standard case with non-zero fee
+        let (m6id, parsed_sc) = compute_m6id(
+            build_m6_tx(sc, Amount::from_sat(6_000), &[Amount::from_sat(3_000)]),
+            Amount::from_sat(10_000),
+        )
+        .unwrap();
+        assert_eq!(parsed_sc, sc);
+        assert_ne!(m6id.0, bitcoin::Txid::all_zeros());
+
+        // Zero fee (old = new + payouts) is valid
+        assert!(
+            compute_m6id(
+                build_m6_tx(sc, Amount::from_sat(3_000), &[Amount::from_sat(2_000)]),
+                Amount::from_sat(5_000),
+            )
+            .is_ok()
+        );
+
+        // Multiple payouts
+        assert!(
+            compute_m6id(
+                build_m6_tx(
+                    sc,
+                    Amount::from_sat(4_000),
+                    &[
+                        Amount::from_sat(1_000),
+                        Amount::from_sat(2_000),
+                        Amount::from_sat(500),
+                    ],
+                ),
+                Amount::from_sat(10_000),
+            )
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn compute_m6id_is_deterministic_and_treasury_sensitive() {
+        // Same tx + same treasury → same M6id
+        let tx1 = build_m6_tx(
+            SidechainNumber(1),
+            Amount::from_sat(5_000),
+            &[Amount::from_sat(2_000)],
+        );
+        let (id1, _) = compute_m6id(tx1.clone(), Amount::from_sat(8_000)).unwrap();
+        let (id1_again, _) = compute_m6id(tx1.clone(), Amount::from_sat(8_000)).unwrap();
+        assert_eq!(id1, id1_again);
+
+        // Different old_treasury → different fee → different M6id
+        let (id2, _) = compute_m6id(tx1, Amount::from_sat(9_000)).unwrap();
+        assert_ne!(id1, id2);
+    }
+
+    #[test]
+    fn compute_m6id_rejects_invalid_inputs() {
+        let sc = SidechainNumber(1);
+        let valid_tx = || build_m6_tx(sc, Amount::from_sat(5_000), &[Amount::from_sat(1_000)]);
+        let tx_with = |f: fn(&mut Transaction)| {
+            let mut tx = valid_tx();
+            f(&mut tx);
+            tx
+        };
+
+        // No outputs → MissingTreasuryOutput
+        assert!(compute_m6id(tx_with(|t| t.output.clear()), Amount::from_sat(1_000)).is_err());
+
+        // No inputs → MissingTreasuryInput
+        assert!(compute_m6id(tx_with(|t| t.input.clear()), Amount::from_sat(2_000)).is_err());
+
+        // Multiple inputs → ManyInputs
+        assert!(
+            compute_m6id(
+                tx_with(|t| t.input.push(bitcoin::TxIn::default())),
+                Amount::from_sat(7_000),
+            )
+            .is_err()
+        );
+
+        // First output isn't OP_DRIVECHAIN → InvalidSpk
+        assert!(
+            compute_m6id(
+                tx_with(|t| t.output[0].script_pubkey = ScriptBuf::new()),
+                Amount::from_sat(2_000),
+            )
+            .is_err()
+        );
+
+        // Spend > old treasury → InsufficientTreasury
+        let overspending = build_m6_tx(sc, Amount::from_sat(5_000), &[Amount::from_sat(3_000)]);
+        assert!(compute_m6id(overspending, Amount::from_sat(7_000)).is_err());
     }
 }

--- a/lib/validator/dbs/diff.rs
+++ b/lib/validator/dbs/diff.rs
@@ -5,6 +5,8 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 
 use serde::{Deserialize, Serialize};
 use sneed::{RoTxn, RwTxn, db};
+use thiserror::Error;
+use transitive::Transitive;
 
 use crate::{
     types::{Ctip, M6id, PendingM6idInfo, Sidechain, SidechainNumber, SidechainProposalId},
@@ -15,9 +17,54 @@ pub(in crate::validator) trait Diff {
     /// The DBs that the diff applies to
     type Dbs;
 
-    fn apply(&self, rwtxn: &mut RwTxn, dbs: &Self::Dbs, height: u32) -> Result<(), db::Error>;
+    type ApplyError;
+    type UndoError;
 
-    fn undo(&self, rwtxn: &mut RwTxn, dbs: &Self::Dbs) -> Result<(), db::Error>;
+    fn apply(
+        &self,
+        rwtxn: &mut RwTxn,
+        dbs: &Self::Dbs,
+        height: u32,
+    ) -> Result<(), Self::ApplyError>;
+
+    fn undo(&self, rwtxn: &mut RwTxn, dbs: &Self::Dbs) -> Result<(), Self::UndoError>;
+}
+
+/// Errors that can occur when undoing a block diff.
+///
+/// A `VoteCountUnderflow` indicates the block being disconnected — or some
+/// inconsistency between the block and the state — would have driven a
+/// vote count below zero. Treat as an invalid block, not corrupt state.
+#[derive(Debug, Error, Transitive)]
+#[transitive(
+    from(db::error::Delete, db::Error),
+    from(db::error::Get, db::Error),
+    from(db::error::Put, db::Error),
+    from(db::error::TryGet, db::Error)
+)]
+pub(in crate::validator) enum UndoError {
+    #[error(transparent)]
+    Db(Box<db::Error>),
+    #[error(
+        "vote count underflow on undo for sidechain proposal slot `{}`",
+        .sidechain_number.0
+    )]
+    SidechainVoteCountUnderflow { sidechain_number: SidechainNumber },
+    #[error(
+        "vote count underflow on undo for sidechain `{}` m6id `{}`",
+        .sidechain_number.0,
+        .m6id.0
+    )]
+    BundleVoteCountUnderflow {
+        sidechain_number: SidechainNumber,
+        m6id: M6id,
+    },
+}
+
+impl From<db::Error> for UndoError {
+    fn from(err: db::Error) -> Self {
+        Self::Db(Box::new(err))
+    }
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -29,6 +76,8 @@ pub struct NewSidechainProposal {
 
 impl Diff for NewSidechainProposal {
     type Dbs = dbs::ProposalIdToSidechain;
+    type ApplyError = db::Error;
+    type UndoError = db::Error;
 
     fn apply(&self, rwtxn: &mut RwTxn, dbs: &Self::Dbs, _height: u32) -> Result<(), db::Error> {
         dbs.put(rwtxn, &self.id, &self.sidechain)?;
@@ -56,6 +105,8 @@ pub struct AckSidechain {
 
 impl Diff for AckSidechain {
     type Dbs = dbs::Dbs;
+    type ApplyError = db::Error;
+    type UndoError = UndoError;
 
     fn apply(&self, rwtxn: &mut RwTxn, dbs: &Self::Dbs, height: u32) -> Result<(), db::Error> {
         let mut sidechain = dbs.proposal_id_to_sidechain.get(rwtxn, &self.id)?;
@@ -80,7 +131,7 @@ impl Diff for AckSidechain {
         Ok(())
     }
 
-    fn undo(&self, rwtxn: &mut RwTxn, dbs: &Self::Dbs) -> Result<(), db::Error> {
+    fn undo(&self, rwtxn: &mut RwTxn, dbs: &Self::Dbs) -> Result<(), UndoError> {
         let mut sidechain = if self.activated {
             let mut sidechain = dbs
                 .active_sidechains
@@ -94,7 +145,11 @@ impl Diff for AckSidechain {
         } else {
             dbs.proposal_id_to_sidechain.get(rwtxn, &self.id)?
         };
-        sidechain.status.vote_count = sidechain.status.vote_count.saturating_sub(1);
+        sidechain.status.vote_count = sidechain.status.vote_count.checked_sub(1).ok_or(
+            UndoError::SidechainVoteCountUnderflow {
+                sidechain_number: self.id.sidechain_number,
+            },
+        )?;
         dbs.proposal_id_to_sidechain
             .put(rwtxn, &self.id, &sidechain)?;
         Ok(())
@@ -110,6 +165,8 @@ pub struct ProposeBundle {
 
 impl Diff for ProposeBundle {
     type Dbs = dbs::ActiveSidechainDbs;
+    type ApplyError = db::Error;
+    type UndoError = db::Error;
 
     fn apply(&self, rwtxn: &mut RwTxn, dbs: &Self::Dbs, height: u32) -> Result<(), db::Error> {
         let () = dbs.put_pending_m6id(rwtxn, &self.sidechain_number, self.m6id, height)?;
@@ -140,6 +197,8 @@ pub struct AckBundles(pub HashMap<SidechainNumber, AckBundleAction>);
 
 impl Diff for AckBundles {
     type Dbs = dbs::ActiveSidechainDbs;
+    type ApplyError = db::Error;
+    type UndoError = UndoError;
 
     fn apply(&self, rwtxn: &mut RwTxn, dbs: &Self::Dbs, _height: u32) -> Result<(), db::Error> {
         for (sidechain_number, bundle_action) in &self.0 {
@@ -163,7 +222,7 @@ impl Diff for AckBundles {
         Ok(())
     }
 
-    fn undo(&self, rwtxn: &mut RwTxn, dbs: &Self::Dbs) -> Result<(), db::Error> {
+    fn undo(&self, rwtxn: &mut RwTxn, dbs: &Self::Dbs) -> Result<(), UndoError> {
         for (sidechain_number, bundle_action) in &self.0 {
             match bundle_action {
                 AckBundleAction::Alarm {
@@ -182,14 +241,21 @@ impl Diff for AckBundles {
                     )?;
                 }
                 AckBundleAction::Upvote { m6id } => {
-                    let () = dbs.with_pending_withdrawals(
+                    let undo_result = dbs.with_pending_withdrawals(
                         rwtxn,
                         sidechain_number,
-                        |pending_withdrawals| {
-                            pending_withdrawals[m6id].vote_count =
-                                pending_withdrawals[m6id].vote_count.saturating_sub(1);
+                        |pending_withdrawals| -> Result<(), UndoError> {
+                            let entry = &mut pending_withdrawals[m6id];
+                            entry.vote_count = entry.vote_count.checked_sub(1).ok_or(
+                                UndoError::BundleVoteCountUnderflow {
+                                    sidechain_number: *sidechain_number,
+                                    m6id: *m6id,
+                                },
+                            )?;
+                            Ok(())
                         },
                     )?;
+                    undo_result?;
                 }
             }
         }
@@ -208,6 +274,8 @@ pub enum CoinbaseMsg {
 
 impl Diff for CoinbaseMsg {
     type Dbs = dbs::Dbs;
+    type ApplyError = db::Error;
+    type UndoError = UndoError;
 
     fn apply(&self, rwtxn: &mut RwTxn, dbs: &Self::Dbs, height: u32) -> Result<(), db::Error> {
         match self {
@@ -227,7 +295,7 @@ impl Diff for CoinbaseMsg {
         Ok(())
     }
 
-    fn undo(&self, rwtxn: &mut RwTxn, dbs: &Self::Dbs) -> Result<(), db::Error> {
+    fn undo(&self, rwtxn: &mut RwTxn, dbs: &Self::Dbs) -> Result<(), UndoError> {
         match self {
             Self::AckBundles(diff) => {
                 let () = diff.undo(rwtxn, &dbs.active_sidechains)?;
@@ -253,6 +321,8 @@ pub struct FailedProposals(pub HashMap<SidechainProposalId, Sidechain>);
 
 impl Diff for FailedProposals {
     type Dbs = dbs::ProposalIdToSidechain;
+    type ApplyError = db::Error;
+    type UndoError = db::Error;
 
     fn apply(&self, rwtxn: &mut RwTxn, dbs: &Self::Dbs, _height: u32) -> Result<(), db::Error> {
         for failed_proposal_id in self.0.keys() {
@@ -276,6 +346,8 @@ pub struct FailedM6ids(pub HashMap<SidechainNumber, BTreeMap<usize, (M6id, Pendi
 
 impl Diff for FailedM6ids {
     type Dbs = dbs::ActiveSidechainDbs;
+    type ApplyError = db::Error;
+    type UndoError = db::Error;
 
     fn apply(&self, rwtxn: &mut RwTxn, dbs: &Self::Dbs, _height: u32) -> Result<(), db::Error> {
         fn remove_failed_withdrawals(
@@ -366,6 +438,8 @@ pub struct Coinbase {
 
 impl Diff for Coinbase {
     type Dbs = dbs::Dbs;
+    type ApplyError = db::Error;
+    type UndoError = UndoError;
 
     fn apply(&self, rwtxn: &mut RwTxn, dbs: &Self::Dbs, height: u32) -> Result<(), db::Error> {
         let Self {
@@ -381,7 +455,7 @@ impl Diff for Coinbase {
         Ok(())
     }
 
-    fn undo(&self, rwtxn: &mut RwTxn, dbs: &Self::Dbs) -> Result<(), db::Error> {
+    fn undo(&self, rwtxn: &mut RwTxn, dbs: &Self::Dbs) -> Result<(), UndoError> {
         let Self {
             msgs,
             failed_proposals,
@@ -406,6 +480,8 @@ pub struct Tx {
 
 impl Diff for Tx {
     type Dbs = dbs::ActiveSidechainDbs;
+    type ApplyError = db::Error;
+    type UndoError = db::Error;
 
     fn apply(&self, rwtxn: &mut RwTxn, dbs: &Self::Dbs, _height: u32) -> Result<(), db::Error> {
         let Self {
@@ -449,6 +525,8 @@ pub struct Block {
 
 impl Diff for Block {
     type Dbs = dbs::Dbs;
+    type ApplyError = db::Error;
+    type UndoError = UndoError;
 
     fn apply(&self, rwtxn: &mut RwTxn, dbs: &Self::Dbs, height: u32) -> Result<(), db::Error> {
         let Self { coinbase, txs } = self;
@@ -459,7 +537,7 @@ impl Diff for Block {
         Ok(())
     }
 
-    fn undo(&self, rwtxn: &mut RwTxn, dbs: &Self::Dbs) -> Result<(), db::Error> {
+    fn undo(&self, rwtxn: &mut RwTxn, dbs: &Self::Dbs) -> Result<(), UndoError> {
         let Self { coinbase, txs } = self;
         for tx in txs.iter().rev() {
             let () = tx.undo(rwtxn, &dbs.active_sidechains)?;
@@ -508,7 +586,7 @@ where
     }
 
     /// Apply a diff
-    pub fn apply(&mut self, diff: D) -> Result<(), db::Error> {
+    pub fn apply(&mut self, diff: D) -> Result<(), D::ApplyError> {
         let () = diff.apply(self.rwtxn, self.dbs, self.height)?;
         self.diffs.push(diff);
         Ok(())
@@ -520,6 +598,7 @@ mod tests {
     use std::collections::{HashMap, HashSet};
 
     use bitcoin::{Txid, hashes::Hash as _};
+    use miette::{IntoDiagnostic, Result};
 
     use super::*;
     use crate::{
@@ -532,60 +611,60 @@ mod tests {
     }
 
     #[test]
-    fn ack_sidechain_apply_undo_roundtrip_and_saturating_undo() {
-        let (_dir, dbs) = create_test_dbs();
-        let mut rwtxn = dbs.write_txn().unwrap();
+    fn ack_sidechain_apply_undo_roundtrip_and_underflow_error() -> Result<()> {
+        let (_dir, dbs) = create_test_dbs()?;
+        let mut rwtxn = dbs.write_txn().into_diagnostic()?;
 
         let sidechain = test_sidechain(1, 100);
         let proposal_id = sidechain.proposal.compute_id();
         dbs.proposal_id_to_sidechain
             .put(&mut rwtxn, &proposal_id, &sidechain)
-            .unwrap();
+            .into_diagnostic()?;
 
         let diff = AckSidechain {
             id: proposal_id,
             activated: false,
         };
 
-        // Apply: 0 → 1
-        diff.apply(&mut rwtxn, &dbs, 101).unwrap();
+        diff.apply(&mut rwtxn, &dbs, 101).into_diagnostic()?;
         let s = dbs
             .proposal_id_to_sidechain
             .get(&rwtxn, &proposal_id)
-            .unwrap();
+            .into_diagnostic()?;
         assert_eq!(s.status.vote_count, 1);
 
-        // Undo: 1 → 0
-        diff.undo(&mut rwtxn, &dbs).unwrap();
+        diff.undo(&mut rwtxn, &dbs).into_diagnostic()?;
         let s = dbs
             .proposal_id_to_sidechain
             .get(&rwtxn, &proposal_id)
-            .unwrap();
+            .into_diagnostic()?;
         assert_eq!(s.status.vote_count, 0);
 
-        // Undo again at 0: should saturate, not panic
-        diff.undo(&mut rwtxn, &dbs).unwrap();
-        let s = dbs
-            .proposal_id_to_sidechain
-            .get(&rwtxn, &proposal_id)
-            .unwrap();
-        assert_eq!(s.status.vote_count, 0);
+        let err = diff
+            .undo(&mut rwtxn, &dbs)
+            .expect_err("undo at vote_count=0 must error");
+        assert!(matches!(
+            err,
+            UndoError::SidechainVoteCountUnderflow { sidechain_number }
+                if sidechain_number == proposal_id.sidechain_number
+        ));
+        Ok(())
     }
 
     #[test]
-    fn ack_bundles_upvote_apply_undo_roundtrip() {
-        let (_dir, dbs) = create_test_dbs();
-        let mut rwtxn = dbs.write_txn().unwrap();
+    fn ack_bundles_upvote_apply_undo_roundtrip() -> Result<()> {
+        let (_dir, dbs) = create_test_dbs()?;
+        let mut rwtxn = dbs.write_txn().into_diagnostic()?;
 
         let sc = SidechainNumber(1);
         dbs.active_sidechains
             .put_sidechain(&mut rwtxn, &sc, &test_sidechain(1, 0))
-            .unwrap();
+            .into_diagnostic()?;
 
         let m6id = test_m6id(0xBB);
         dbs.active_sidechains
             .put_pending_m6id(&mut rwtxn, &sc, m6id, 0)
-            .unwrap();
+            .into_diagnostic()?;
 
         let diff = AckBundles({
             let mut map = HashMap::new();
@@ -593,43 +672,45 @@ mod tests {
             map
         });
 
-        diff.apply(&mut rwtxn, &dbs.active_sidechains, 1).unwrap();
+        diff.apply(&mut rwtxn, &dbs.active_sidechains, 1)
+            .into_diagnostic()?;
         let pending = dbs
             .active_sidechains
             .pending_m6ids()
             .get(&rwtxn, &sc)
-            .unwrap();
+            .into_diagnostic()?;
         assert_eq!(pending[&m6id].vote_count, 1);
 
-        diff.undo(&mut rwtxn, &dbs.active_sidechains).unwrap();
+        diff.undo(&mut rwtxn, &dbs.active_sidechains)
+            .into_diagnostic()?;
         let pending = dbs
             .active_sidechains
             .pending_m6ids()
             .get(&rwtxn, &sc)
-            .unwrap();
+            .into_diagnostic()?;
         assert_eq!(pending[&m6id].vote_count, 0);
+        Ok(())
     }
 
     #[test]
-    fn ack_bundles_alarm_apply_undo_roundtrip() {
-        let (_dir, dbs) = create_test_dbs();
-        let mut rwtxn = dbs.write_txn().unwrap();
+    fn ack_bundles_alarm_apply_undo_roundtrip() -> Result<()> {
+        let (_dir, dbs) = create_test_dbs()?;
+        let mut rwtxn = dbs.write_txn().into_diagnostic()?;
 
         let sc = SidechainNumber(1);
         dbs.active_sidechains
             .put_sidechain(&mut rwtxn, &sc, &test_sidechain(1, 0))
-            .unwrap();
+            .into_diagnostic()?;
 
         let m6id_a = test_m6id(0xAA);
         let m6id_b = test_m6id(0xBB);
         dbs.active_sidechains
             .put_pending_m6id(&mut rwtxn, &sc, m6id_a, 0)
-            .unwrap();
+            .into_diagnostic()?;
         dbs.active_sidechains
             .put_pending_m6id(&mut rwtxn, &sc, m6id_b, 0)
-            .unwrap();
+            .into_diagnostic()?;
 
-        // Set initial vote counts
         for (m6id, count) in [(m6id_a, 3u16), (m6id_b, 1)] {
             dbs.active_sidechains
                 .with_pending_withdrawal_entry(&mut rwtxn, &sc, m6id, |entry| {
@@ -637,7 +718,7 @@ mod tests {
                         e.get_mut().vote_count = count;
                     }
                 })
-                .unwrap();
+                .into_diagnostic()?;
         }
 
         let diff = AckBundles({
@@ -651,43 +732,43 @@ mod tests {
             map
         });
 
-        // Apply alarm: 3→2, 1→0
-        diff.apply(&mut rwtxn, &dbs.active_sidechains, 1).unwrap();
+        diff.apply(&mut rwtxn, &dbs.active_sidechains, 1)
+            .into_diagnostic()?;
         let p = dbs
             .active_sidechains
             .pending_m6ids()
             .get(&rwtxn, &sc)
-            .unwrap();
+            .into_diagnostic()?;
         assert_eq!(p[&m6id_a].vote_count, 2);
         assert_eq!(p[&m6id_b].vote_count, 0);
 
-        // Undo: 2→3, 0→1
-        diff.undo(&mut rwtxn, &dbs.active_sidechains).unwrap();
+        diff.undo(&mut rwtxn, &dbs.active_sidechains)
+            .into_diagnostic()?;
         let p = dbs
             .active_sidechains
             .pending_m6ids()
             .get(&rwtxn, &sc)
-            .unwrap();
+            .into_diagnostic()?;
         assert_eq!(p[&m6id_a].vote_count, 3);
         assert_eq!(p[&m6id_b].vote_count, 1);
+        Ok(())
     }
 
     #[test]
-    fn upvote_then_alarm_then_undo_upvote_does_not_crash() {
-        let (_dir, dbs) = create_test_dbs();
-        let mut rwtxn = dbs.write_txn().unwrap();
+    fn upvote_then_alarm_then_undo_upvote_errors_on_underflow() -> Result<()> {
+        let (_dir, dbs) = create_test_dbs()?;
+        let mut rwtxn = dbs.write_txn().into_diagnostic()?;
 
         let sc = SidechainNumber(1);
         dbs.active_sidechains
             .put_sidechain(&mut rwtxn, &sc, &test_sidechain(1, 0))
-            .unwrap();
+            .into_diagnostic()?;
 
         let m6id = test_m6id(0xCC);
         dbs.active_sidechains
             .put_pending_m6id(&mut rwtxn, &sc, m6id, 0)
-            .unwrap();
+            .into_diagnostic()?;
 
-        // Upvote: 0 → 1
         let upvote_diff = AckBundles({
             let mut map = HashMap::new();
             map.insert(sc, AckBundleAction::Upvote { m6id });
@@ -695,17 +776,16 @@ mod tests {
         });
         upvote_diff
             .apply(&mut rwtxn, &dbs.active_sidechains, 1)
-            .unwrap();
+            .into_diagnostic()?;
         assert_eq!(
             dbs.active_sidechains
                 .pending_m6ids()
                 .get(&rwtxn, &sc)
-                .unwrap()[&m6id]
+                .into_diagnostic()?[&m6id]
                 .vote_count,
             1
         );
 
-        // Alarm: 1 → 0
         let alarm_diff = AckBundles({
             let mut map = HashMap::new();
             map.insert(
@@ -718,27 +798,26 @@ mod tests {
         });
         alarm_diff
             .apply(&mut rwtxn, &dbs.active_sidechains, 2)
-            .unwrap();
+            .into_diagnostic()?;
         assert_eq!(
             dbs.active_sidechains
                 .pending_m6ids()
                 .get(&rwtxn, &sc)
-                .unwrap()[&m6id]
+                .into_diagnostic()?[&m6id]
                 .vote_count,
             0
         );
 
-        // Undo upvote at vote_count=0: saturates to 0 instead of panic
-        upvote_diff
+        let err = upvote_diff
             .undo(&mut rwtxn, &dbs.active_sidechains)
-            .unwrap();
-        assert_eq!(
-            dbs.active_sidechains
-                .pending_m6ids()
-                .get(&rwtxn, &sc)
-                .unwrap()[&m6id]
-                .vote_count,
-            0
-        );
+            .expect_err("undo at vote_count=0 must error");
+        assert!(matches!(
+            err,
+            UndoError::BundleVoteCountUnderflow {
+                sidechain_number,
+                m6id: err_m6id,
+            } if sidechain_number == sc && err_m6id == m6id
+        ));
+        Ok(())
     }
 }

--- a/lib/validator/dbs/diff.rs
+++ b/lib/validator/dbs/diff.rs
@@ -94,7 +94,7 @@ impl Diff for AckSidechain {
         } else {
             dbs.proposal_id_to_sidechain.get(rwtxn, &self.id)?
         };
-        sidechain.status.vote_count -= 1;
+        sidechain.status.vote_count = sidechain.status.vote_count.saturating_sub(1);
         dbs.proposal_id_to_sidechain
             .put(rwtxn, &self.id, &sidechain)?;
         Ok(())
@@ -186,7 +186,8 @@ impl Diff for AckBundles {
                         rwtxn,
                         sidechain_number,
                         |pending_withdrawals| {
-                            pending_withdrawals[m6id].vote_count -= 1;
+                            pending_withdrawals[m6id].vote_count =
+                                pending_withdrawals[m6id].vote_count.saturating_sub(1);
                         },
                     )?;
                 }
@@ -511,5 +512,233 @@ where
         let () = diff.apply(self.rwtxn, self.dbs, self.height)?;
         self.diffs.push(diff);
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{HashMap, HashSet};
+
+    use bitcoin::{Txid, hashes::Hash as _};
+
+    use super::*;
+    use crate::{
+        types::{M6id, SidechainNumber},
+        validator::test_utils::{create_test_dbs, test_sidechain},
+    };
+
+    fn test_m6id(byte: u8) -> M6id {
+        M6id(Txid::from_byte_array([byte; 32]))
+    }
+
+    #[test]
+    fn ack_sidechain_apply_undo_roundtrip_and_saturating_undo() {
+        let (_dir, dbs) = create_test_dbs();
+        let mut rwtxn = dbs.write_txn().unwrap();
+
+        let sidechain = test_sidechain(1, 100);
+        let proposal_id = sidechain.proposal.compute_id();
+        dbs.proposal_id_to_sidechain
+            .put(&mut rwtxn, &proposal_id, &sidechain)
+            .unwrap();
+
+        let diff = AckSidechain {
+            id: proposal_id,
+            activated: false,
+        };
+
+        // Apply: 0 → 1
+        diff.apply(&mut rwtxn, &dbs, 101).unwrap();
+        let s = dbs
+            .proposal_id_to_sidechain
+            .get(&rwtxn, &proposal_id)
+            .unwrap();
+        assert_eq!(s.status.vote_count, 1);
+
+        // Undo: 1 → 0
+        diff.undo(&mut rwtxn, &dbs).unwrap();
+        let s = dbs
+            .proposal_id_to_sidechain
+            .get(&rwtxn, &proposal_id)
+            .unwrap();
+        assert_eq!(s.status.vote_count, 0);
+
+        // Undo again at 0: should saturate, not panic
+        diff.undo(&mut rwtxn, &dbs).unwrap();
+        let s = dbs
+            .proposal_id_to_sidechain
+            .get(&rwtxn, &proposal_id)
+            .unwrap();
+        assert_eq!(s.status.vote_count, 0);
+    }
+
+    #[test]
+    fn ack_bundles_upvote_apply_undo_roundtrip() {
+        let (_dir, dbs) = create_test_dbs();
+        let mut rwtxn = dbs.write_txn().unwrap();
+
+        let sc = SidechainNumber(1);
+        dbs.active_sidechains
+            .put_sidechain(&mut rwtxn, &sc, &test_sidechain(1, 0))
+            .unwrap();
+
+        let m6id = test_m6id(0xBB);
+        dbs.active_sidechains
+            .put_pending_m6id(&mut rwtxn, &sc, m6id, 0)
+            .unwrap();
+
+        let diff = AckBundles({
+            let mut map = HashMap::new();
+            map.insert(sc, AckBundleAction::Upvote { m6id });
+            map
+        });
+
+        diff.apply(&mut rwtxn, &dbs.active_sidechains, 1).unwrap();
+        let pending = dbs
+            .active_sidechains
+            .pending_m6ids()
+            .get(&rwtxn, &sc)
+            .unwrap();
+        assert_eq!(pending[&m6id].vote_count, 1);
+
+        diff.undo(&mut rwtxn, &dbs.active_sidechains).unwrap();
+        let pending = dbs
+            .active_sidechains
+            .pending_m6ids()
+            .get(&rwtxn, &sc)
+            .unwrap();
+        assert_eq!(pending[&m6id].vote_count, 0);
+    }
+
+    #[test]
+    fn ack_bundles_alarm_apply_undo_roundtrip() {
+        let (_dir, dbs) = create_test_dbs();
+        let mut rwtxn = dbs.write_txn().unwrap();
+
+        let sc = SidechainNumber(1);
+        dbs.active_sidechains
+            .put_sidechain(&mut rwtxn, &sc, &test_sidechain(1, 0))
+            .unwrap();
+
+        let m6id_a = test_m6id(0xAA);
+        let m6id_b = test_m6id(0xBB);
+        dbs.active_sidechains
+            .put_pending_m6id(&mut rwtxn, &sc, m6id_a, 0)
+            .unwrap();
+        dbs.active_sidechains
+            .put_pending_m6id(&mut rwtxn, &sc, m6id_b, 0)
+            .unwrap();
+
+        // Set initial vote counts
+        for (m6id, count) in [(m6id_a, 3u16), (m6id_b, 1)] {
+            dbs.active_sidechains
+                .with_pending_withdrawal_entry(&mut rwtxn, &sc, m6id, |entry| {
+                    if let ordermap::map::Entry::Occupied(mut e) = entry {
+                        e.get_mut().vote_count = count;
+                    }
+                })
+                .unwrap();
+        }
+
+        let diff = AckBundles({
+            let mut map = HashMap::new();
+            map.insert(
+                sc,
+                AckBundleAction::Alarm {
+                    positive_votes_proposals: HashSet::from([m6id_a, m6id_b]),
+                },
+            );
+            map
+        });
+
+        // Apply alarm: 3→2, 1→0
+        diff.apply(&mut rwtxn, &dbs.active_sidechains, 1).unwrap();
+        let p = dbs
+            .active_sidechains
+            .pending_m6ids()
+            .get(&rwtxn, &sc)
+            .unwrap();
+        assert_eq!(p[&m6id_a].vote_count, 2);
+        assert_eq!(p[&m6id_b].vote_count, 0);
+
+        // Undo: 2→3, 0→1
+        diff.undo(&mut rwtxn, &dbs.active_sidechains).unwrap();
+        let p = dbs
+            .active_sidechains
+            .pending_m6ids()
+            .get(&rwtxn, &sc)
+            .unwrap();
+        assert_eq!(p[&m6id_a].vote_count, 3);
+        assert_eq!(p[&m6id_b].vote_count, 1);
+    }
+
+    #[test]
+    fn upvote_then_alarm_then_undo_upvote_does_not_crash() {
+        let (_dir, dbs) = create_test_dbs();
+        let mut rwtxn = dbs.write_txn().unwrap();
+
+        let sc = SidechainNumber(1);
+        dbs.active_sidechains
+            .put_sidechain(&mut rwtxn, &sc, &test_sidechain(1, 0))
+            .unwrap();
+
+        let m6id = test_m6id(0xCC);
+        dbs.active_sidechains
+            .put_pending_m6id(&mut rwtxn, &sc, m6id, 0)
+            .unwrap();
+
+        // Upvote: 0 → 1
+        let upvote_diff = AckBundles({
+            let mut map = HashMap::new();
+            map.insert(sc, AckBundleAction::Upvote { m6id });
+            map
+        });
+        upvote_diff
+            .apply(&mut rwtxn, &dbs.active_sidechains, 1)
+            .unwrap();
+        assert_eq!(
+            dbs.active_sidechains
+                .pending_m6ids()
+                .get(&rwtxn, &sc)
+                .unwrap()[&m6id]
+                .vote_count,
+            1
+        );
+
+        // Alarm: 1 → 0
+        let alarm_diff = AckBundles({
+            let mut map = HashMap::new();
+            map.insert(
+                sc,
+                AckBundleAction::Alarm {
+                    positive_votes_proposals: HashSet::from([m6id]),
+                },
+            );
+            map
+        });
+        alarm_diff
+            .apply(&mut rwtxn, &dbs.active_sidechains, 2)
+            .unwrap();
+        assert_eq!(
+            dbs.active_sidechains
+                .pending_m6ids()
+                .get(&rwtxn, &sc)
+                .unwrap()[&m6id]
+                .vote_count,
+            0
+        );
+
+        // Undo upvote at vote_count=0: saturates to 0 instead of panic
+        upvote_diff
+            .undo(&mut rwtxn, &dbs.active_sidechains)
+            .unwrap();
+        assert_eq!(
+            dbs.active_sidechains
+                .pending_m6ids()
+                .get(&rwtxn, &sc)
+                .unwrap()[&m6id]
+                .vote_count,
+            0
+        );
     }
 }

--- a/lib/validator/dbs/diff.rs
+++ b/lib/validator/dbs/diff.rs
@@ -45,16 +45,9 @@ pub(in crate::validator) trait Diff {
 pub(in crate::validator) enum UndoError {
     #[error(transparent)]
     Db(Box<db::Error>),
-    #[error(
-        "vote count underflow on undo for sidechain proposal slot `{}`",
-        .sidechain_number.0
-    )]
+    #[error("vote count underflow on undo for sidechain proposal slot `{sidechain_number}`")]
     SidechainVoteCountUnderflow { sidechain_number: SidechainNumber },
-    #[error(
-        "vote count underflow on undo for sidechain `{}` m6id `{}`",
-        .sidechain_number.0,
-        .m6id.0
-    )]
+    #[error("vote count underflow on undo for sidechain `{sidechain_number}` m6id `{m6id}`")]
     BundleVoteCountUnderflow {
         sidechain_number: SidechainNumber,
         m6id: M6id,
@@ -241,7 +234,7 @@ impl Diff for AckBundles {
                     )?;
                 }
                 AckBundleAction::Upvote { m6id } => {
-                    let undo_result = dbs.with_pending_withdrawals(
+                    let () = dbs.with_pending_withdrawals(
                         rwtxn,
                         sidechain_number,
                         |pending_withdrawals| -> Result<(), UndoError> {
@@ -254,8 +247,7 @@ impl Diff for AckBundles {
                             )?;
                             Ok(())
                         },
-                    )?;
-                    undo_result?;
+                    )??;
                 }
             }
         }

--- a/lib/validator/mod.rs
+++ b/lib/validator/mod.rs
@@ -29,6 +29,8 @@ mod dbs;
 pub mod main_rest_client;
 pub mod parse_block_files;
 mod task;
+#[cfg(test)]
+mod test_utils;
 
 use self::dbs::{Dbs, PendingM6ids};
 

--- a/lib/validator/task/error.rs
+++ b/lib/validator/task/error.rs
@@ -293,6 +293,8 @@ pub(in crate::validator) enum DisconnectBlock {
         block_hash: bitcoin::BlockHash,
         tip_hash: bitcoin::BlockHash,
     },
+    #[error(transparent)]
+    Undo(#[from] dbs::diff::UndoError),
 }
 
 impl From<db::Error> for DisconnectBlock {

--- a/lib/validator/task/error.rs
+++ b/lib/validator/task/error.rs
@@ -129,6 +129,7 @@ pub(in crate::validator) enum HandleM4AckBundles {
 #[derive(Transitive)]
 #[fatality(splitable)]
 #[transitive(
+    from(db::error::Get, db::Error),
     from(db::error::IterInit, db::Error),
     from(db::error::IterItem, db::Error),
     from(db::error::TryGet, db::Error)

--- a/lib/validator/task/mod.rs
+++ b/lib/validator/task/mod.rs
@@ -1450,6 +1450,7 @@ mod tests {
     };
     use fatality::Fatality as _;
     use hashlink::LinkedHashMap;
+    use miette::{IntoDiagnostic, Result};
 
     use super::*;
     use crate::{
@@ -1527,13 +1528,14 @@ mod tests {
     // ── handle_m8 ──
 
     #[test]
-    fn handle_m8_non_m8_tx_returns_false() {
+    fn handle_m8_non_m8_tx_returns_false() -> Result<()> {
         let prev_hash = dummy_block_hash(0xAA);
-        assert!(!handle_m8(&build_plain_tx(), None, &prev_hash).unwrap());
+        assert!(!handle_m8(&build_plain_tx(), None, &prev_hash).into_diagnostic()?);
+        Ok(())
     }
 
     #[test]
-    fn handle_m8_valid_request_accepted() {
+    fn handle_m8_valid_request_accepted() -> Result<()> {
         let sc = SidechainNumber(1);
         let prev_hash = dummy_block_hash(0xAA);
         let tx = build_m8_tx(sc, [0x42; 32], prev_hash);
@@ -1541,7 +1543,8 @@ mod tests {
         let mut accepted: BmmCommitments = LinkedHashMap::new();
         accepted.insert(sc, BmmCommitment([0x42; 32]));
 
-        assert!(handle_m8(&tx, Some(&accepted), &prev_hash).unwrap());
+        assert!(handle_m8(&tx, Some(&accepted), &prev_hash).into_diagnostic()?);
+        Ok(())
     }
 
     #[test]
@@ -1550,47 +1553,45 @@ mod tests {
         let prev_hash = dummy_block_hash(0xAA);
         let tx = build_m8_tx(sc, [0x42; 32], prev_hash);
 
-        // Not in accepted list → NotAcceptedByMiners
         let empty: BmmCommitments = LinkedHashMap::new();
-        let err = handle_m8(&tx, Some(&empty), &prev_hash).unwrap_err();
+        let err =
+            handle_m8(&tx, Some(&empty), &prev_hash).expect_err("empty accepted list must reject");
         assert!(matches!(err, error::HandleM8::NotAcceptedByMiners));
         assert!(!err.is_fatal());
 
-        // Wrong commitment hash → NotAcceptedByMiners
         let mut wrong: BmmCommitments = LinkedHashMap::new();
         wrong.insert(sc, BmmCommitment([0xFF; 32]));
-        let err = handle_m8(&tx, Some(&wrong), &prev_hash).unwrap_err();
+        let err =
+            handle_m8(&tx, Some(&wrong), &prev_hash).expect_err("wrong commitment must reject");
         assert!(matches!(err, error::HandleM8::NotAcceptedByMiners));
 
-        // Wrong prev_hash → BmmRequestExpired
-        let err = handle_m8(&tx, None, &dummy_block_hash(0xBB)).unwrap_err();
+        let err =
+            handle_m8(&tx, None, &dummy_block_hash(0xBB)).expect_err("wrong prev_hash must reject");
         assert!(matches!(err, error::HandleM8::BmmRequestExpired));
         assert!(!err.is_fatal());
     }
 
     #[test]
-    fn handle_m8_none_accepted_only_checks_expiry() {
+    fn handle_m8_none_accepted_only_checks_expiry() -> Result<()> {
         let sc = SidechainNumber(1);
         let prev_hash = dummy_block_hash(0xAA);
         let tx = build_m8_tx(sc, [0x42; 32], prev_hash);
 
-        // Matching prev_hash, no accepted list → Ok(true)
-        assert!(handle_m8(&tx, None, &prev_hash).unwrap());
-        // Wrong prev_hash → expired
+        assert!(handle_m8(&tx, None, &prev_hash).into_diagnostic()?);
         assert!(handle_m8(&tx, None, &dummy_block_hash(0xBB)).is_err());
+        Ok(())
     }
 
     // ── handle_transaction ──
 
     #[test]
-    fn handle_transaction_m8_errors_propagate_as_non_fatal() {
-        let (_dir, dbs) = create_test_dbs();
-        let rotxn = dbs.read_txn().unwrap();
+    fn handle_transaction_m8_errors_propagate_as_non_fatal() -> Result<()> {
+        let (_dir, dbs) = create_test_dbs()?;
+        let rotxn = dbs.read_txn().into_diagnostic()?;
         let sc = SidechainNumber(1);
         let prev_hash = dummy_block_hash(0xAA);
         let tx = build_m8_tx(sc, [0x42; 32], prev_hash);
 
-        // Not accepted → non-fatal error
         let empty: BmmCommitments = LinkedHashMap::new();
         let err = handle_transaction(
             &rotxn,
@@ -1599,10 +1600,9 @@ mod tests {
             &prev_hash,
             &tx,
         )
-        .unwrap_err();
+        .expect_err("not-accepted M8 must error");
         assert!(!err.is_fatal());
 
-        // Expired → non-fatal error
         let err = handle_transaction(
             &rotxn,
             &dbs.active_sidechains,
@@ -1610,14 +1610,15 @@ mod tests {
             &dummy_block_hash(0xBB),
             &tx,
         )
-        .unwrap_err();
+        .expect_err("expired M8 must error");
         assert!(!err.is_fatal());
+        Ok(())
     }
 
     #[test]
-    fn handle_transaction_valid_m8_returns_none() {
-        let (_dir, dbs) = create_test_dbs();
-        let rotxn = dbs.read_txn().unwrap();
+    fn handle_transaction_valid_m8_returns_none() -> Result<()> {
+        let (_dir, dbs) = create_test_dbs()?;
+        let rotxn = dbs.read_txn().into_diagnostic()?;
         let sc = SidechainNumber(1);
         let prev_hash = dummy_block_hash(0xAA);
         let tx = build_m8_tx(sc, [0x42; 32], prev_hash);
@@ -1632,8 +1633,9 @@ mod tests {
             &prev_hash,
             &tx,
         )
-        .unwrap();
+        .into_diagnostic()?;
         assert!(result.is_none(), "valid M8 should not produce a tx event");
+        Ok(())
     }
 
     // ── connect_block ──
@@ -1670,9 +1672,9 @@ mod tests {
     }
 
     #[test]
-    fn connect_block_skips_non_fatal_tx_errors() {
-        let (_dir, dbs) = create_test_dbs();
-        let mut rwtxn = dbs.write_txn().unwrap();
+    fn connect_block_skips_non_fatal_tx_errors() -> Result<()> {
+        let (_dir, dbs) = create_test_dbs()?;
+        let mut rwtxn = dbs.write_txn().into_diagnostic()?;
         let prev_hash = BlockHash::all_zeros();
 
         // M8 request with no matching M7 in coinbase → non-fatal error
@@ -1681,74 +1683,80 @@ mod tests {
 
         dbs.block_hashes
             .put_headers(&mut rwtxn, &[(block.header, 0)])
-            .unwrap();
+            .into_diagnostic()?;
 
         assert!(
             connect_block(&mut rwtxn, &dbs, &block).is_ok(),
             "connect_block should succeed despite non-fatal M8 error"
         );
+        Ok(())
     }
 
     #[test]
-    fn connect_then_disconnect_restores_db_state() {
-        let (_dir, dbs) = create_test_dbs();
-        let mut rwtxn = dbs.write_txn().unwrap();
+    fn connect_then_disconnect_restores_db_state() -> Result<()> {
+        let (_dir, dbs) = create_test_dbs()?;
+        let mut rwtxn = dbs.write_txn().into_diagnostic()?;
         let prev_hash = BlockHash::all_zeros();
         let block = build_test_block(prev_hash, vec![]);
         let block_hash = block.header.block_hash();
 
         dbs.block_hashes
             .put_headers(&mut rwtxn, &[(block.header, 0)])
-            .unwrap();
+            .into_diagnostic()?;
         assert!(
             dbs.current_chain_tip
                 .try_get(&rwtxn, &())
-                .unwrap()
+                .into_diagnostic()?
                 .is_none()
         );
 
         let (event_tx, _) = async_broadcast::broadcast(16);
-        let _event = connect_block(&mut rwtxn, &dbs, &block).unwrap();
+        let _event = connect_block(&mut rwtxn, &dbs, &block).into_diagnostic()?;
         assert_eq!(
-            dbs.current_chain_tip.try_get(&rwtxn, &()).unwrap(),
+            dbs.current_chain_tip
+                .try_get(&rwtxn, &())
+                .into_diagnostic()?,
             Some(block_hash)
         );
 
-        disconnect_block(&mut rwtxn, &dbs, &event_tx, block_hash).unwrap();
+        disconnect_block(&mut rwtxn, &dbs, &event_tx, block_hash).into_diagnostic()?;
         assert!(
             dbs.current_chain_tip
                 .try_get(&rwtxn, &())
-                .unwrap()
+                .into_diagnostic()?
                 .is_none()
         );
+        Ok(())
     }
 
     // ── handle_m5_m6 ──
 
     #[test]
-    fn handle_m5_m6_plain_tx_returns_none() {
-        let (_dir, dbs) = create_test_dbs();
-        let rotxn = dbs.read_txn().unwrap();
+    fn handle_m5_m6_plain_tx_returns_none() -> Result<()> {
+        let (_dir, dbs) = create_test_dbs()?;
+        let rotxn = dbs.read_txn().into_diagnostic()?;
         assert!(
             handle_m5_m6(
                 &rotxn,
                 &dbs.active_sidechains,
                 Cow::Borrowed(&build_plain_tx())
             )
-            .unwrap()
+            .into_diagnostic()?
             .is_none()
         );
+        Ok(())
     }
 
     #[test]
-    fn handle_m5_m6_deposit_no_existing_ctip() {
-        let (_dir, dbs) = create_test_dbs();
-        let rotxn = dbs.read_txn().unwrap();
+    fn handle_m5_m6_deposit_no_existing_ctip() -> Result<()> {
+        let (_dir, dbs) = create_test_dbs()?;
+        let rotxn = dbs.read_txn().into_diagnostic()?;
         let sc = SidechainNumber(1);
         let deposit_amount = Amount::from_sat(10_000);
         let tx = build_m5_deposit_tx(sc, OutPoint::default(), Amount::ZERO, deposit_amount);
 
-        let result = handle_m5_m6(&rotxn, &dbs.active_sidechains, Cow::Borrowed(&tx)).unwrap();
+        let result =
+            handle_m5_m6(&rotxn, &dbs.active_sidechains, Cow::Borrowed(&tx)).into_diagnostic()?;
         let Some((Either::Left(deposit), diff)) = result else {
             panic!("expected M5 deposit");
         };
@@ -1757,12 +1765,13 @@ mod tests {
         assert_eq!(deposit.value, deposit_amount);
         assert_eq!(deposit.address, b"sidechain_address");
         assert_eq!(diff.new_ctip.value, deposit_amount);
+        Ok(())
     }
 
     #[test]
-    fn handle_m5_m6_deposit_with_existing_ctip() {
-        let (_dir, dbs) = create_test_dbs();
-        let mut rwtxn = dbs.write_txn().unwrap();
+    fn handle_m5_m6_deposit_with_existing_ctip() -> Result<()> {
+        let (_dir, dbs) = create_test_dbs()?;
+        let mut rwtxn = dbs.write_txn().into_diagnostic()?;
         let sc = SidechainNumber(1);
         let old_outpoint = OutPoint {
             txid: Txid::from_byte_array([0x11; 32]),
@@ -1778,24 +1787,25 @@ mod tests {
                     value: old_value,
                 },
             )
-            .unwrap();
+            .into_diagnostic()?;
 
         let deposit_amount = Amount::from_sat(3_000);
         let tx = build_m5_deposit_tx(sc, old_outpoint, old_value, deposit_amount);
 
         let Some((Either::Left(deposit), diff)) =
-            handle_m5_m6(&rwtxn, &dbs.active_sidechains, Cow::Borrowed(&tx)).unwrap()
+            handle_m5_m6(&rwtxn, &dbs.active_sidechains, Cow::Borrowed(&tx)).into_diagnostic()?
         else {
             panic!("expected M5 deposit");
         };
         assert_eq!(deposit.value, deposit_amount);
         assert_eq!(diff.new_ctip.value, old_value + deposit_amount);
+        Ok(())
     }
 
     #[test]
-    fn handle_m5_m6_old_ctip_unspent() {
-        let (_dir, dbs) = create_test_dbs();
-        let mut rwtxn = dbs.write_txn().unwrap();
+    fn handle_m5_m6_old_ctip_unspent() -> Result<()> {
+        let (_dir, dbs) = create_test_dbs()?;
+        let mut rwtxn = dbs.write_txn().into_diagnostic()?;
         let sc = SidechainNumber(1);
         dbs.active_sidechains
             .put_ctip(
@@ -1809,60 +1819,59 @@ mod tests {
                     value: Amount::from_sat(5_000),
                 },
             )
-            .unwrap();
+            .into_diagnostic()?;
 
-        // Tx spends a different outpoint → error
         let tx = build_m5_deposit_tx(
             sc,
             OutPoint::default(),
             Amount::from_sat(5_000),
             Amount::from_sat(1_000),
         );
-        let err = handle_m5_m6(&rwtxn, &dbs.active_sidechains, Cow::Borrowed(&tx)).unwrap_err();
+        let err = handle_m5_m6(&rwtxn, &dbs.active_sidechains, Cow::Borrowed(&tx))
+            .expect_err("spending wrong outpoint must error");
         assert!(matches!(err, error::HandleM5M6::OldCtipUnspent { .. }));
+        Ok(())
     }
 
     // ── handle_m1 ──
 
     #[test]
-    fn handle_m1_new_and_duplicate() {
-        let (_dir, dbs) = create_test_dbs();
-        let mut rwtxn = dbs.write_txn().unwrap();
+    fn handle_m1_new_and_duplicate() -> Result<()> {
+        let (_dir, dbs) = create_test_dbs()?;
+        let mut rwtxn = dbs.write_txn().into_diagnostic()?;
 
         let proposal = SidechainProposal {
             sidechain_number: SidechainNumber(1),
             description: SidechainDescription(vec![0x00, 0x01, b'x']),
         };
 
-        // New proposal → produces diff
         let diff = handle_m1_propose_sidechain(&rwtxn, &dbs, proposal.clone(), 100)
-            .unwrap()
+            .into_diagnostic()?
             .expect("new proposal should produce a diff");
         assert_eq!(diff.sidechain.proposal, proposal);
         assert_eq!(diff.sidechain.status.proposal_height, 100);
 
-        // Store it, then propose same again → ignored
         dbs.proposal_id_to_sidechain
             .put(&mut rwtxn, &diff.id, &diff.sidechain)
-            .unwrap();
-        let result = handle_m1_propose_sidechain(&rwtxn, &dbs, proposal, 200).unwrap();
+            .into_diagnostic()?;
+        let result = handle_m1_propose_sidechain(&rwtxn, &dbs, proposal, 200).into_diagnostic()?;
         assert!(result.is_none(), "duplicate proposal should be ignored");
+        Ok(())
     }
 
     // ── handle_m2 ──
 
     #[test]
-    fn handle_m2_activation_thresholds() {
-        let (_dir, dbs) = create_test_dbs();
-        let mut rwtxn = dbs.write_txn().unwrap();
+    fn handle_m2_activation_thresholds() -> Result<()> {
+        let (_dir, dbs) = create_test_dbs()?;
+        let mut rwtxn = dbs.write_txn().into_diagnostic()?;
 
         let mut sidechain = test_sidechain(1, 100);
         let proposal_id = sidechain.proposal.compute_id();
 
-        // 1 vote: should not activate
         dbs.proposal_id_to_sidechain
             .put(&mut rwtxn, &proposal_id, &sidechain)
-            .unwrap();
+            .into_diagnostic()?;
         let diff = handle_m2_ack_sidechain(
             &rwtxn,
             &dbs,
@@ -1870,14 +1879,13 @@ mod tests {
             proposal_id.sidechain_number,
             proposal_id.description_hash,
         )
-        .unwrap();
+        .into_diagnostic()?;
         assert!(!diff.activated, "1 vote should not activate");
 
-        // At threshold: should activate (vote_count will become threshold + 1)
         sidechain.status.vote_count = UNUSED_SIDECHAIN_SLOT_ACTIVATION_THRESHOLD;
         dbs.proposal_id_to_sidechain
             .put(&mut rwtxn, &proposal_id, &sidechain)
-            .unwrap();
+            .into_diagnostic()?;
         let diff = handle_m2_ack_sidechain(
             &rwtxn,
             &dbs,
@@ -1885,16 +1893,15 @@ mod tests {
             proposal_id.sidechain_number,
             proposal_id.description_hash,
         )
-        .unwrap();
+        .into_diagnostic()?;
         assert!(
             diff.activated,
             "vote_count > threshold within max age should activate"
         );
 
-        // Same vote count but too old: should NOT activate
         dbs.proposal_id_to_sidechain
             .put(&mut rwtxn, &proposal_id, &sidechain)
-            .unwrap();
+            .into_diagnostic()?;
         let diff = handle_m2_ack_sidechain(
             &rwtxn,
             &dbs,
@@ -1902,17 +1909,18 @@ mod tests {
             proposal_id.sidechain_number,
             proposal_id.description_hash,
         )
-        .unwrap();
+        .into_diagnostic()?;
         assert!(
             !diff.activated,
             "proposal exceeding max age should not activate"
         );
+        Ok(())
     }
 
     #[test]
-    fn handle_m2_missing_proposal() {
-        let (_dir, dbs) = create_test_dbs();
-        let rotxn = dbs.read_txn().unwrap();
+    fn handle_m2_missing_proposal() -> Result<()> {
+        let (_dir, dbs) = create_test_dbs()?;
+        let rotxn = dbs.read_txn().into_diagnostic()?;
         let err = handle_m2_ack_sidechain(
             &rotxn,
             &dbs,
@@ -1920,73 +1928,75 @@ mod tests {
             SidechainNumber(99),
             bitcoin::hashes::sha256d::Hash::all_zeros(),
         )
-        .unwrap_err();
+        .expect_err("missing proposal must error");
         assert!(matches!(
             err,
             error::HandleM2AckSidechain::MissingProposal { .. }
         ));
+        Ok(())
     }
 
     // ── handle_m4_votes ──
 
     #[test]
-    fn handle_m4_votes_abstain_and_upvote() {
-        let (_dir, dbs) = create_test_dbs();
-        let mut rwtxn = dbs.write_txn().unwrap();
+    fn handle_m4_votes_abstain_and_upvote() -> Result<()> {
+        let (_dir, dbs) = create_test_dbs()?;
+        let mut rwtxn = dbs.write_txn().into_diagnostic()?;
         let sc = SidechainNumber(1);
         dbs.active_sidechains
             .put_sidechain(&mut rwtxn, &sc, &test_sidechain(1, 0))
-            .unwrap();
+            .into_diagnostic()?;
 
-        // ABSTAIN → no actions
-        let diff = handle_m4_votes(&rwtxn, &dbs, &[M4AckBundles::ABSTAIN_TWO_BYTES]).unwrap();
+        let diff =
+            handle_m4_votes(&rwtxn, &dbs, &[M4AckBundles::ABSTAIN_TWO_BYTES]).into_diagnostic()?;
         assert!(diff.0.is_empty());
 
-        // Add pending M6id, upvote it
         let m6id = M6id(Txid::from_byte_array([0xAA; 32]));
         dbs.active_sidechains
             .put_pending_m6id(&mut rwtxn, &sc, m6id, 0)
-            .unwrap();
-        let diff = handle_m4_votes(&rwtxn, &dbs, &[0]).unwrap();
+            .into_diagnostic()?;
+        let diff = handle_m4_votes(&rwtxn, &dbs, &[0]).into_diagnostic()?;
         assert!(diff.0.contains_key(&sc));
+        Ok(())
     }
 
     #[test]
-    fn handle_m4_votes_alarm() {
-        let (_dir, dbs) = create_test_dbs();
-        let mut rwtxn = dbs.write_txn().unwrap();
+    fn handle_m4_votes_alarm() -> Result<()> {
+        let (_dir, dbs) = create_test_dbs()?;
+        let mut rwtxn = dbs.write_txn().into_diagnostic()?;
         let sc = SidechainNumber(1);
         dbs.active_sidechains
             .put_sidechain(&mut rwtxn, &sc, &test_sidechain(1, 0))
-            .unwrap();
+            .into_diagnostic()?;
 
         let m6id = M6id(Txid::from_byte_array([0xAA; 32]));
         dbs.active_sidechains
             .put_pending_m6id(&mut rwtxn, &sc, m6id, 0)
-            .unwrap();
+            .into_diagnostic()?;
         dbs.active_sidechains
             .with_pending_withdrawal_entry(&mut rwtxn, &sc, m6id, |entry| {
                 if let ordermap::map::Entry::Occupied(mut e) = entry {
                     e.get_mut().vote_count = 3;
                 }
             })
-            .unwrap();
+            .into_diagnostic()?;
 
-        let diff = handle_m4_votes(&rwtxn, &dbs, &[M4AckBundles::ALARM_TWO_BYTES]).unwrap();
+        let diff =
+            handle_m4_votes(&rwtxn, &dbs, &[M4AckBundles::ALARM_TWO_BYTES]).into_diagnostic()?;
         assert!(diff.0.contains_key(&sc));
+        Ok(())
     }
 
     #[test]
-    fn handle_m4_votes_errors() {
-        let (_dir, dbs) = create_test_dbs();
-        let mut rwtxn = dbs.write_txn().unwrap();
+    fn handle_m4_votes_errors() -> Result<()> {
+        let (_dir, dbs) = create_test_dbs()?;
+        let mut rwtxn = dbs.write_txn().into_diagnostic()?;
         let sc = SidechainNumber(1);
         dbs.active_sidechains
             .put_sidechain(&mut rwtxn, &sc, &test_sidechain(1, 0))
-            .unwrap();
+            .into_diagnostic()?;
 
-        // Wrong number of votes
-        let err = handle_m4_votes(&rwtxn, &dbs, &[0, 0]).unwrap_err();
+        let err = handle_m4_votes(&rwtxn, &dbs, &[0, 0]).expect_err("wrong vote count must error");
         assert!(matches!(
             err,
             error::HandleM4Votes::InvalidVotes {
@@ -1995,8 +2005,9 @@ mod tests {
             }
         ));
 
-        // Out-of-bounds index (no pending M6ids)
-        let err = handle_m4_votes(&rwtxn, &dbs, &[0]).unwrap_err();
+        let err =
+            handle_m4_votes(&rwtxn, &dbs, &[0]).expect_err("upvote with no pending must error");
         assert!(matches!(err, error::HandleM4Votes::UpvoteFailed { .. }));
+        Ok(())
     }
 }

--- a/lib/validator/task/mod.rs
+++ b/lib/validator/task/mod.rs
@@ -309,18 +309,11 @@ fn handle_failed_m6ids(
     for sidechain_number in active_sidechains {
         // Invariant: `put_sidechain` always creates a corresponding
         // `pending_m6ids` entry, so every active sidechain must have one.
-        // Missing entry indicates DB corruption (partial write, external
-        // tampering, etc.) and is unrecoverable without resyncing.
+        // A missing entry indicates DB corruption and is unrecoverable without resyncing.
         let pending_m6ids = dbs
             .active_sidechains
             .pending_m6ids()
-            .try_get(rotxn, &sidechain_number)?
-            .unwrap_or_else(|| {
-                panic!(
-                    "DB corruption: active sidechain {sidechain_number} has no \
-                     pending_m6ids entry (violates put_sidechain invariant)"
-                )
-            });
+            .get(rotxn, &sidechain_number)?;
         let failed = pending_m6ids
             .into_iter()
             .enumerate()

--- a/lib/validator/task/mod.rs
+++ b/lib/validator/task/mod.rs
@@ -307,11 +307,20 @@ fn handle_failed_m6ids(
     let mut failed_m6ids = HashMap::<_, BTreeMap<_, _>>::new();
 
     for sidechain_number in active_sidechains {
+        // Invariant: `put_sidechain` always creates a corresponding
+        // `pending_m6ids` entry, so every active sidechain must have one.
+        // Missing entry indicates DB corruption (partial write, external
+        // tampering, etc.) and is unrecoverable without resyncing.
         let pending_m6ids = dbs
             .active_sidechains
             .pending_m6ids()
             .try_get(rotxn, &sidechain_number)?
-            .expect("active sidechain should exist as key");
+            .unwrap_or_else(|| {
+                panic!(
+                    "DB corruption: active sidechain {sidechain_number} has no \
+                     pending_m6ids entry (violates put_sidechain invariant)"
+                )
+            });
         let failed = pending_m6ids
             .into_iter()
             .enumerate()
@@ -402,7 +411,16 @@ fn handle_m5_m6(
             }
             let (m6id, sidechain_number_, info) =
                 handle_m6(rotxn, dbs, transaction.into_owned(), old_treasury_value)?;
-            assert_eq!(sidechain_number, sidechain_number_);
+            // `handle_m6` → `compute_m6id` parses the same first-output script
+            // that we already parsed above. Mismatch would mean the parser is
+            // non-deterministic (impossible) or the transaction was mutated
+            // between the two parses — both indicate a serious invariant
+            // violation.
+            assert_eq!(
+                sidechain_number, sidechain_number_,
+                "invariant violation: parse_op_drivechain returned different \
+                 sidechain numbers for the same output",
+            );
             let sequence_number = dbs
                 .treasury_utxo_count
                 .try_get(rotxn, &sidechain_number)?
@@ -1421,4 +1439,564 @@ where
     )
     .await?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::borrow::Cow;
+
+    use bitcoin::{
+        Amount, BlockHash, OutPoint, ScriptBuf, Transaction, TxIn, TxOut, Txid, hashes::Hash as _,
+    };
+    use fatality::Fatality as _;
+    use hashlink::LinkedHashMap;
+
+    use super::*;
+    use crate::{
+        messages::{M4AckBundles, M8BmmRequest, create_m5_deposit_output},
+        types::{
+            BmmCommitment, BmmCommitments, Ctip, M6id, SidechainDescription, SidechainNumber,
+            SidechainProposal,
+        },
+        validator::test_utils::{create_test_dbs, test_sidechain},
+    };
+
+    fn build_m8_tx(
+        sidechain_number: SidechainNumber,
+        sidechain_block_hash: [u8; 32],
+        prev_mainchain_block_hash: BlockHash,
+    ) -> Transaction {
+        let script_pubkey = M8BmmRequest::script_pubkey(
+            sidechain_number,
+            BmmCommitment(sidechain_block_hash),
+            prev_mainchain_block_hash,
+        )
+        .expect("failed to build M8 script");
+        Transaction {
+            version: bitcoin::transaction::Version::TWO,
+            lock_time: bitcoin::locktime::absolute::LockTime::ZERO,
+            input: vec![TxIn::default()],
+            output: vec![TxOut {
+                script_pubkey,
+                value: Amount::ZERO,
+            }],
+        }
+    }
+
+    fn build_plain_tx() -> Transaction {
+        Transaction {
+            version: bitcoin::transaction::Version::TWO,
+            lock_time: bitcoin::locktime::absolute::LockTime::ZERO,
+            input: vec![TxIn::default()],
+            output: vec![TxOut {
+                script_pubkey: ScriptBuf::new(),
+                value: Amount::from_sat(1000),
+            }],
+        }
+    }
+
+    fn build_m5_deposit_tx(
+        sidechain_number: SidechainNumber,
+        old_ctip_outpoint: OutPoint,
+        old_ctip_value: Amount,
+        deposit_amount: Amount,
+    ) -> Transaction {
+        let treasury_output =
+            create_m5_deposit_output(sidechain_number, old_ctip_value, deposit_amount);
+        let address_output = TxOut {
+            script_pubkey: ScriptBuf::new_op_return(
+                bitcoin::script::PushBytesBuf::try_from(b"sidechain_address".to_vec()).unwrap(),
+            ),
+            value: Amount::ZERO,
+        };
+        Transaction {
+            version: bitcoin::transaction::Version::TWO,
+            lock_time: bitcoin::locktime::absolute::LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: old_ctip_outpoint,
+                ..TxIn::default()
+            }],
+            output: vec![treasury_output, address_output],
+        }
+    }
+
+    fn dummy_block_hash(byte: u8) -> BlockHash {
+        BlockHash::from_byte_array([byte; 32])
+    }
+
+    // ── handle_m8 ──
+
+    #[test]
+    fn handle_m8_non_m8_tx_returns_false() {
+        let prev_hash = dummy_block_hash(0xAA);
+        assert!(!handle_m8(&build_plain_tx(), None, &prev_hash).unwrap());
+    }
+
+    #[test]
+    fn handle_m8_valid_request_accepted() {
+        let sc = SidechainNumber(1);
+        let prev_hash = dummy_block_hash(0xAA);
+        let tx = build_m8_tx(sc, [0x42; 32], prev_hash);
+
+        let mut accepted: BmmCommitments = LinkedHashMap::new();
+        accepted.insert(sc, BmmCommitment([0x42; 32]));
+
+        assert!(handle_m8(&tx, Some(&accepted), &prev_hash).unwrap());
+    }
+
+    #[test]
+    fn handle_m8_rejection_cases_are_non_fatal() {
+        let sc = SidechainNumber(1);
+        let prev_hash = dummy_block_hash(0xAA);
+        let tx = build_m8_tx(sc, [0x42; 32], prev_hash);
+
+        // Not in accepted list → NotAcceptedByMiners
+        let empty: BmmCommitments = LinkedHashMap::new();
+        let err = handle_m8(&tx, Some(&empty), &prev_hash).unwrap_err();
+        assert!(matches!(err, error::HandleM8::NotAcceptedByMiners));
+        assert!(!err.is_fatal());
+
+        // Wrong commitment hash → NotAcceptedByMiners
+        let mut wrong: BmmCommitments = LinkedHashMap::new();
+        wrong.insert(sc, BmmCommitment([0xFF; 32]));
+        let err = handle_m8(&tx, Some(&wrong), &prev_hash).unwrap_err();
+        assert!(matches!(err, error::HandleM8::NotAcceptedByMiners));
+
+        // Wrong prev_hash → BmmRequestExpired
+        let err = handle_m8(&tx, None, &dummy_block_hash(0xBB)).unwrap_err();
+        assert!(matches!(err, error::HandleM8::BmmRequestExpired));
+        assert!(!err.is_fatal());
+    }
+
+    #[test]
+    fn handle_m8_none_accepted_only_checks_expiry() {
+        let sc = SidechainNumber(1);
+        let prev_hash = dummy_block_hash(0xAA);
+        let tx = build_m8_tx(sc, [0x42; 32], prev_hash);
+
+        // Matching prev_hash, no accepted list → Ok(true)
+        assert!(handle_m8(&tx, None, &prev_hash).unwrap());
+        // Wrong prev_hash → expired
+        assert!(handle_m8(&tx, None, &dummy_block_hash(0xBB)).is_err());
+    }
+
+    // ── handle_transaction ──
+
+    #[test]
+    fn handle_transaction_m8_errors_propagate_as_non_fatal() {
+        let (_dir, dbs) = create_test_dbs();
+        let rotxn = dbs.read_txn().unwrap();
+        let sc = SidechainNumber(1);
+        let prev_hash = dummy_block_hash(0xAA);
+        let tx = build_m8_tx(sc, [0x42; 32], prev_hash);
+
+        // Not accepted → non-fatal error
+        let empty: BmmCommitments = LinkedHashMap::new();
+        let err = handle_transaction(
+            &rotxn,
+            &dbs.active_sidechains,
+            Some(&empty),
+            &prev_hash,
+            &tx,
+        )
+        .unwrap_err();
+        assert!(!err.is_fatal());
+
+        // Expired → non-fatal error
+        let err = handle_transaction(
+            &rotxn,
+            &dbs.active_sidechains,
+            None,
+            &dummy_block_hash(0xBB),
+            &tx,
+        )
+        .unwrap_err();
+        assert!(!err.is_fatal());
+    }
+
+    #[test]
+    fn handle_transaction_valid_m8_returns_none() {
+        let (_dir, dbs) = create_test_dbs();
+        let rotxn = dbs.read_txn().unwrap();
+        let sc = SidechainNumber(1);
+        let prev_hash = dummy_block_hash(0xAA);
+        let tx = build_m8_tx(sc, [0x42; 32], prev_hash);
+
+        let mut accepted: BmmCommitments = LinkedHashMap::new();
+        accepted.insert(sc, BmmCommitment([0x42; 32]));
+
+        let result = handle_transaction(
+            &rotxn,
+            &dbs.active_sidechains,
+            Some(&accepted),
+            &prev_hash,
+            &tx,
+        )
+        .unwrap();
+        assert!(result.is_none(), "valid M8 should not produce a tx event");
+    }
+
+    // ── connect_block ──
+
+    fn build_test_block(prev_hash: BlockHash, extra_txs: Vec<Transaction>) -> Block {
+        let coinbase_tx = Transaction {
+            version: bitcoin::transaction::Version::TWO,
+            lock_time: bitcoin::locktime::absolute::LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint {
+                    txid: Txid::all_zeros(),
+                    vout: 0xFFFFFFFF,
+                },
+                ..TxIn::default()
+            }],
+            output: vec![TxOut {
+                script_pubkey: ScriptBuf::new(),
+                value: Amount::from_sat(50_0000_0000),
+            }],
+        };
+        let mut txdata = vec![coinbase_tx];
+        txdata.extend(extra_txs);
+        Block {
+            header: bitcoin::block::Header {
+                version: bitcoin::block::Version::TWO,
+                prev_blockhash: prev_hash,
+                merkle_root: bitcoin::TxMerkleNode::all_zeros(),
+                time: 0,
+                bits: bitcoin::CompactTarget::from_consensus(0x2000_0000),
+                nonce: 0,
+            },
+            txdata,
+        }
+    }
+
+    #[test]
+    fn connect_block_skips_non_fatal_tx_errors() {
+        let (_dir, dbs) = create_test_dbs();
+        let mut rwtxn = dbs.write_txn().unwrap();
+        let prev_hash = BlockHash::all_zeros();
+
+        // M8 request with no matching M7 in coinbase → non-fatal error
+        let m8_tx = build_m8_tx(SidechainNumber(1), [0x42; 32], prev_hash);
+        let block = build_test_block(prev_hash, vec![m8_tx]);
+
+        dbs.block_hashes
+            .put_headers(&mut rwtxn, &[(block.header, 0)])
+            .unwrap();
+
+        assert!(
+            connect_block(&mut rwtxn, &dbs, &block).is_ok(),
+            "connect_block should succeed despite non-fatal M8 error"
+        );
+    }
+
+    #[test]
+    fn connect_then_disconnect_restores_db_state() {
+        let (_dir, dbs) = create_test_dbs();
+        let mut rwtxn = dbs.write_txn().unwrap();
+        let prev_hash = BlockHash::all_zeros();
+        let block = build_test_block(prev_hash, vec![]);
+        let block_hash = block.header.block_hash();
+
+        dbs.block_hashes
+            .put_headers(&mut rwtxn, &[(block.header, 0)])
+            .unwrap();
+        assert!(
+            dbs.current_chain_tip
+                .try_get(&rwtxn, &())
+                .unwrap()
+                .is_none()
+        );
+
+        let (event_tx, _) = async_broadcast::broadcast(16);
+        let _event = connect_block(&mut rwtxn, &dbs, &block).unwrap();
+        assert_eq!(
+            dbs.current_chain_tip.try_get(&rwtxn, &()).unwrap(),
+            Some(block_hash)
+        );
+
+        disconnect_block(&mut rwtxn, &dbs, &event_tx, block_hash).unwrap();
+        assert!(
+            dbs.current_chain_tip
+                .try_get(&rwtxn, &())
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    // ── handle_m5_m6 ──
+
+    #[test]
+    fn handle_m5_m6_plain_tx_returns_none() {
+        let (_dir, dbs) = create_test_dbs();
+        let rotxn = dbs.read_txn().unwrap();
+        assert!(
+            handle_m5_m6(
+                &rotxn,
+                &dbs.active_sidechains,
+                Cow::Borrowed(&build_plain_tx())
+            )
+            .unwrap()
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn handle_m5_m6_deposit_no_existing_ctip() {
+        let (_dir, dbs) = create_test_dbs();
+        let rotxn = dbs.read_txn().unwrap();
+        let sc = SidechainNumber(1);
+        let deposit_amount = Amount::from_sat(10_000);
+        let tx = build_m5_deposit_tx(sc, OutPoint::default(), Amount::ZERO, deposit_amount);
+
+        let result = handle_m5_m6(&rotxn, &dbs.active_sidechains, Cow::Borrowed(&tx)).unwrap();
+        let Some((Either::Left(deposit), diff)) = result else {
+            panic!("expected M5 deposit");
+        };
+
+        assert_eq!(deposit.sidechain_id, sc);
+        assert_eq!(deposit.value, deposit_amount);
+        assert_eq!(deposit.address, b"sidechain_address");
+        assert_eq!(diff.new_ctip.value, deposit_amount);
+    }
+
+    #[test]
+    fn handle_m5_m6_deposit_with_existing_ctip() {
+        let (_dir, dbs) = create_test_dbs();
+        let mut rwtxn = dbs.write_txn().unwrap();
+        let sc = SidechainNumber(1);
+        let old_outpoint = OutPoint {
+            txid: Txid::from_byte_array([0x11; 32]),
+            vout: 0,
+        };
+        let old_value = Amount::from_sat(5_000);
+        dbs.active_sidechains
+            .put_ctip(
+                &mut rwtxn,
+                sc,
+                &Ctip {
+                    outpoint: old_outpoint,
+                    value: old_value,
+                },
+            )
+            .unwrap();
+
+        let deposit_amount = Amount::from_sat(3_000);
+        let tx = build_m5_deposit_tx(sc, old_outpoint, old_value, deposit_amount);
+
+        let Some((Either::Left(deposit), diff)) =
+            handle_m5_m6(&rwtxn, &dbs.active_sidechains, Cow::Borrowed(&tx)).unwrap()
+        else {
+            panic!("expected M5 deposit");
+        };
+        assert_eq!(deposit.value, deposit_amount);
+        assert_eq!(diff.new_ctip.value, old_value + deposit_amount);
+    }
+
+    #[test]
+    fn handle_m5_m6_old_ctip_unspent() {
+        let (_dir, dbs) = create_test_dbs();
+        let mut rwtxn = dbs.write_txn().unwrap();
+        let sc = SidechainNumber(1);
+        dbs.active_sidechains
+            .put_ctip(
+                &mut rwtxn,
+                sc,
+                &Ctip {
+                    outpoint: OutPoint {
+                        txid: Txid::from_byte_array([0x11; 32]),
+                        vout: 0,
+                    },
+                    value: Amount::from_sat(5_000),
+                },
+            )
+            .unwrap();
+
+        // Tx spends a different outpoint → error
+        let tx = build_m5_deposit_tx(
+            sc,
+            OutPoint::default(),
+            Amount::from_sat(5_000),
+            Amount::from_sat(1_000),
+        );
+        let err = handle_m5_m6(&rwtxn, &dbs.active_sidechains, Cow::Borrowed(&tx)).unwrap_err();
+        assert!(matches!(err, error::HandleM5M6::OldCtipUnspent { .. }));
+    }
+
+    // ── handle_m1 ──
+
+    #[test]
+    fn handle_m1_new_and_duplicate() {
+        let (_dir, dbs) = create_test_dbs();
+        let mut rwtxn = dbs.write_txn().unwrap();
+
+        let proposal = SidechainProposal {
+            sidechain_number: SidechainNumber(1),
+            description: SidechainDescription(vec![0x00, 0x01, b'x']),
+        };
+
+        // New proposal → produces diff
+        let diff = handle_m1_propose_sidechain(&rwtxn, &dbs, proposal.clone(), 100)
+            .unwrap()
+            .expect("new proposal should produce a diff");
+        assert_eq!(diff.sidechain.proposal, proposal);
+        assert_eq!(diff.sidechain.status.proposal_height, 100);
+
+        // Store it, then propose same again → ignored
+        dbs.proposal_id_to_sidechain
+            .put(&mut rwtxn, &diff.id, &diff.sidechain)
+            .unwrap();
+        let result = handle_m1_propose_sidechain(&rwtxn, &dbs, proposal, 200).unwrap();
+        assert!(result.is_none(), "duplicate proposal should be ignored");
+    }
+
+    // ── handle_m2 ──
+
+    #[test]
+    fn handle_m2_activation_thresholds() {
+        let (_dir, dbs) = create_test_dbs();
+        let mut rwtxn = dbs.write_txn().unwrap();
+
+        let mut sidechain = test_sidechain(1, 100);
+        let proposal_id = sidechain.proposal.compute_id();
+
+        // 1 vote: should not activate
+        dbs.proposal_id_to_sidechain
+            .put(&mut rwtxn, &proposal_id, &sidechain)
+            .unwrap();
+        let diff = handle_m2_ack_sidechain(
+            &rwtxn,
+            &dbs,
+            101,
+            proposal_id.sidechain_number,
+            proposal_id.description_hash,
+        )
+        .unwrap();
+        assert!(!diff.activated, "1 vote should not activate");
+
+        // At threshold: should activate (vote_count will become threshold + 1)
+        sidechain.status.vote_count = UNUSED_SIDECHAIN_SLOT_ACTIVATION_THRESHOLD;
+        dbs.proposal_id_to_sidechain
+            .put(&mut rwtxn, &proposal_id, &sidechain)
+            .unwrap();
+        let diff = handle_m2_ack_sidechain(
+            &rwtxn,
+            &dbs,
+            105,
+            proposal_id.sidechain_number,
+            proposal_id.description_hash,
+        )
+        .unwrap();
+        assert!(
+            diff.activated,
+            "vote_count > threshold within max age should activate"
+        );
+
+        // Same vote count but too old: should NOT activate
+        dbs.proposal_id_to_sidechain
+            .put(&mut rwtxn, &proposal_id, &sidechain)
+            .unwrap();
+        let diff = handle_m2_ack_sidechain(
+            &rwtxn,
+            &dbs,
+            111,
+            proposal_id.sidechain_number,
+            proposal_id.description_hash,
+        )
+        .unwrap();
+        assert!(
+            !diff.activated,
+            "proposal exceeding max age should not activate"
+        );
+    }
+
+    #[test]
+    fn handle_m2_missing_proposal() {
+        let (_dir, dbs) = create_test_dbs();
+        let rotxn = dbs.read_txn().unwrap();
+        let err = handle_m2_ack_sidechain(
+            &rotxn,
+            &dbs,
+            100,
+            SidechainNumber(99),
+            bitcoin::hashes::sha256d::Hash::all_zeros(),
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            error::HandleM2AckSidechain::MissingProposal { .. }
+        ));
+    }
+
+    // ── handle_m4_votes ──
+
+    #[test]
+    fn handle_m4_votes_abstain_and_upvote() {
+        let (_dir, dbs) = create_test_dbs();
+        let mut rwtxn = dbs.write_txn().unwrap();
+        let sc = SidechainNumber(1);
+        dbs.active_sidechains
+            .put_sidechain(&mut rwtxn, &sc, &test_sidechain(1, 0))
+            .unwrap();
+
+        // ABSTAIN → no actions
+        let diff = handle_m4_votes(&rwtxn, &dbs, &[M4AckBundles::ABSTAIN_TWO_BYTES]).unwrap();
+        assert!(diff.0.is_empty());
+
+        // Add pending M6id, upvote it
+        let m6id = M6id(Txid::from_byte_array([0xAA; 32]));
+        dbs.active_sidechains
+            .put_pending_m6id(&mut rwtxn, &sc, m6id, 0)
+            .unwrap();
+        let diff = handle_m4_votes(&rwtxn, &dbs, &[0]).unwrap();
+        assert!(diff.0.contains_key(&sc));
+    }
+
+    #[test]
+    fn handle_m4_votes_alarm() {
+        let (_dir, dbs) = create_test_dbs();
+        let mut rwtxn = dbs.write_txn().unwrap();
+        let sc = SidechainNumber(1);
+        dbs.active_sidechains
+            .put_sidechain(&mut rwtxn, &sc, &test_sidechain(1, 0))
+            .unwrap();
+
+        let m6id = M6id(Txid::from_byte_array([0xAA; 32]));
+        dbs.active_sidechains
+            .put_pending_m6id(&mut rwtxn, &sc, m6id, 0)
+            .unwrap();
+        dbs.active_sidechains
+            .with_pending_withdrawal_entry(&mut rwtxn, &sc, m6id, |entry| {
+                if let ordermap::map::Entry::Occupied(mut e) = entry {
+                    e.get_mut().vote_count = 3;
+                }
+            })
+            .unwrap();
+
+        let diff = handle_m4_votes(&rwtxn, &dbs, &[M4AckBundles::ALARM_TWO_BYTES]).unwrap();
+        assert!(diff.0.contains_key(&sc));
+    }
+
+    #[test]
+    fn handle_m4_votes_errors() {
+        let (_dir, dbs) = create_test_dbs();
+        let mut rwtxn = dbs.write_txn().unwrap();
+        let sc = SidechainNumber(1);
+        dbs.active_sidechains
+            .put_sidechain(&mut rwtxn, &sc, &test_sidechain(1, 0))
+            .unwrap();
+
+        // Wrong number of votes
+        let err = handle_m4_votes(&rwtxn, &dbs, &[0, 0]).unwrap_err();
+        assert!(matches!(
+            err,
+            error::HandleM4Votes::InvalidVotes {
+                expected: 1,
+                len: 2
+            }
+        ));
+
+        // Out-of-bounds index (no pending M6ids)
+        let err = handle_m4_votes(&rwtxn, &dbs, &[0]).unwrap_err();
+        assert!(matches!(err, error::HandleM4Votes::UpvoteFailed { .. }));
+    }
 }

--- a/lib/validator/test_utils.rs
+++ b/lib/validator/test_utils.rs
@@ -1,15 +1,17 @@
 //! Shared test utilities for `crate::validator` tests.
 //! This module is gated behind `#[cfg(test)]` in the parent module.
 
+use miette::IntoDiagnostic;
+
 use super::dbs::Dbs;
 use crate::types::{
     Sidechain, SidechainDescription, SidechainNumber, SidechainProposal, SidechainProposalStatus,
 };
 
-pub fn create_test_dbs() -> (temp_dir::TempDir, Dbs) {
-    let dir = temp_dir::TempDir::new().expect("failed to create temp dir");
-    let dbs = Dbs::new(dir.path(), bitcoin::Network::Regtest).expect("failed to create test dbs");
-    (dir, dbs)
+pub fn create_test_dbs() -> miette::Result<(temp_dir::TempDir, Dbs)> {
+    let dir = temp_dir::TempDir::new().into_diagnostic()?;
+    let dbs = Dbs::new(dir.path(), bitcoin::Network::Regtest).into_diagnostic()?;
+    Ok((dir, dbs))
 }
 
 pub fn test_sidechain(sidechain_number: u8, proposal_height: u32) -> Sidechain {

--- a/lib/validator/test_utils.rs
+++ b/lib/validator/test_utils.rs
@@ -1,0 +1,27 @@
+//! Shared test utilities for `crate::validator` tests.
+//! This module is gated behind `#[cfg(test)]` in the parent module.
+
+use super::dbs::Dbs;
+use crate::types::{
+    Sidechain, SidechainDescription, SidechainNumber, SidechainProposal, SidechainProposalStatus,
+};
+
+pub fn create_test_dbs() -> (temp_dir::TempDir, Dbs) {
+    let dir = temp_dir::TempDir::new().expect("failed to create temp dir");
+    let dbs = Dbs::new(dir.path(), bitcoin::Network::Regtest).expect("failed to create test dbs");
+    (dir, dbs)
+}
+
+pub fn test_sidechain(sidechain_number: u8, proposal_height: u32) -> Sidechain {
+    Sidechain {
+        proposal: SidechainProposal {
+            sidechain_number: SidechainNumber(sidechain_number),
+            description: SidechainDescription(vec![0x00, sidechain_number]),
+        },
+        status: SidechainProposalStatus {
+            vote_count: 0,
+            proposal_height,
+            activation_height: None,
+        },
+    }
+}

--- a/lib/wallet/mod.rs
+++ b/lib/wallet/mod.rs
@@ -1950,15 +1950,11 @@ impl Wallet {
         prev_mainchain_block_hash: bdk_wallet::bitcoin::BlockHash,
         sidechain_block_hash: BmmCommitment,
     ) -> Result<bdk_wallet::bitcoin::ScriptBuf, bitcoin::script::PushBytesError> {
-        let message = [
-            &M8BmmRequest::TAG[..],
-            &[sidechain_number.into()],
-            sidechain_block_hash.0.as_slice(),
-            &prev_mainchain_block_hash.to_byte_array(),
-        ]
-        .concat();
-        let bytes = bdk_wallet::bitcoin::script::PushBytesBuf::try_from(message)?;
-        Ok(bdk_wallet::bitcoin::ScriptBuf::new_op_return(&bytes))
+        M8BmmRequest::script_pubkey(
+            sidechain_number,
+            sidechain_block_hash,
+            prev_mainchain_block_hash,
+        )
     }
 
     #[allow(


### PR DESCRIPTION
Fix two bugs related to underflowing on votes going negative. Make two invariant assertions clearer: they're not left over dev-code not suitable in prod code, but invariant violations that indicate corrupted DB state.

Also throw in a bunch of small unit tests.