### PR TITLE
deps: bump BDK crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -398,9 +398,9 @@ dependencies = [
 
 [[package]]
 name = "bdk_wallet"
-version = "2.3.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b03f1e31ccc562f600981f747d2262b84428cbff52c9c9cdf14d15fb15bd2286"
+checksum = "67f3c4f9526d22374fca5b7ff1d6bf8d921ab56db2dac8df66a2c5561b31d4ef"
 dependencies = [
  "bdk_chain",
  "bip39",
@@ -1705,16 +1705,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
  "hashbrown 0.14.5",
-]
-
-[[package]]
-name = "hashlink"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
-dependencies = [
- "hashbrown 0.15.5",
- "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ publish = false
 version = "0.3.4"
 
 [workspace.dependencies]
-bdk_wallet = { version = "2.1.0" }
+bdk_wallet = { version = "3.0.0" }
 bitcoin = "0.32.6"
 clap = { version = "4.5.60", default-features = false }
 either = "1.13.0"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -16,9 +16,9 @@ aes-gcm = { version = "0.10.3", features = ["std"] }
 argon2 = { version = "0.5.3", features = ["std"] }
 async-broadcast = "0.7.1"
 async-lock = "3.4.0"
-bdk_chain = "0.23.1"
-bdk_electrum = { version = "0.23.1", default-features = false }
-bdk_esplora = { version = "0.22.1", default-features = false, features = [
+bdk_chain = "0.23.3"
+bdk_electrum = { version = "0.23.2", default-features = false }
+bdk_esplora = { version = "0.22.2", default-features = false, features = [
     "tokio",
     "async-https-rustls",
 ] }

--- a/lib/wallet/mod.rs
+++ b/lib/wallet/mod.rs
@@ -280,7 +280,7 @@ impl WalletInner {
         let extended_key: ExtendedKey = mnemonic.clone().into_extended_key()?;
 
         let xpriv = extended_key
-            .into_xprv(network)
+            .into_xprv(network.into())
             .ok_or(error::InitWalletFromMnemonic::DeriveXpriv)?;
 
         // Create a BDK wallet structure using BIP 84 descriptor ("m/84h/1h/0h/0" and "m/84h/1h/0h/1")


### PR DESCRIPTION
- bdk_wallet 2.1.0 -> 3.0.0
- bdk_chain 0.23.1 -> 0.23.3
- bdk_electrum 0.23.1 -> 0.23.2
- bdk_esplora 0.22.1 -> 0.22.2

bdk_wallet 3.0 has four breaking changes per its CHANGELOG — three are API removals we never used (`Wallet::cancel_tx`, `TxBuilder::include_output_ redeem_witness_script`, `ApplyBlockError`), and the fourth is the `ExtendedKey::into_xprv` signature now taking `NetworkKind` instead of `Network`.

TODO:
- [x] tested locally
- [x] tested on the signet server