### PR TITLE
Resolve cusf_sidechain_proto paths from manifest in lib/build.rs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ unsupported Bitcoin Core version. The supported set lives in
 Building/running:
 
 ```bash
-# Check out git submodules
+# Check out git submodules (includes cusf_sidechain_proto for .proto sources)
 $ git submodule update --init --recursive
 # Compiles the project
 $ cargo build
@@ -42,6 +42,11 @@ $ buf curl  --http2-prior-knowledge --protocol grpc \
   "network": "NETWORK_SIGNET"
 }
 ```
+
+## Follow-ups (maintainers)
+
+- **Push:** Use a GitHub account with write access to **LayerTwo-Labs**; a `403` on `git push` is a credentials or remote URL issue.
+- **Protos:** After moving the **`cusf_sidechain_proto`** submodule forward, run **`cargo test --workspace --all-features`** (or the same checks CI runs) before merging.
 
 # Interacting with the enforcer
 

--- a/lib/build.rs
+++ b/lib/build.rs
@@ -53,40 +53,61 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    const COMMON_PROTO: &str = "../cusf_sidechain_proto/proto/cusf/common/v1/common.proto";
-    const CRYPTO_PROTO: &str = "../cusf_sidechain_proto/proto/cusf/crypto/v1/crypto.proto";
-    const MAINCHAIN_COMMON_PROTO: &str =
-        "../cusf_sidechain_proto/proto/cusf/mainchain/v1/common.proto";
-    const SIDECHAIN_PROTO: &str = "../cusf_sidechain_proto/proto/cusf/sidechain/v1/sidechain.proto";
-    const VALIDATOR_PROTO: &str = "../cusf_sidechain_proto/proto/cusf/mainchain/v1/validator.proto";
-    const WALLET_PROTO: &str = "../cusf_sidechain_proto/proto/cusf/mainchain/v1/wallet.proto";
-    const ALL_PROTOS: &[&str] = &[
-        COMMON_PROTO,
-        CRYPTO_PROTO,
-        MAINCHAIN_COMMON_PROTO,
-        SIDECHAIN_PROTO,
-        VALIDATOR_PROTO,
-        WALLET_PROTO,
+    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR")?);
+    let workspace_root = manifest_dir
+        .parent()
+        .expect("lib crate must live under bip300301_enforcer workspace root");
+    let proto_include = [
+        workspace_root.join("cusf_sidechain_proto/proto"),
+        workspace_root.join("../cusf_sidechain_proto/proto"),
+    ]
+    .into_iter()
+    .find(|p| p.join("cusf/common/v1/common.proto").is_file())
+    .expect(
+        "cusf_sidechain_proto/proto not found; run `git submodule update --init --recursive` \
+         or place cusf_sidechain_proto next to the workspace root",
+    );
+    let proto = |rel: &str| proto_include.join(rel);
+    let common_proto = proto("cusf/common/v1/common.proto");
+    let crypto_proto = proto("cusf/crypto/v1/crypto.proto");
+    let mainchain_common_proto = proto("cusf/mainchain/v1/common.proto");
+    let sidechain_proto = proto("cusf/sidechain/v1/sidechain.proto");
+    let validator_proto = proto("cusf/mainchain/v1/validator.proto");
+    let wallet_proto = proto("cusf/mainchain/v1/wallet.proto");
+    let all_protos: Vec<PathBuf> = vec![
+        common_proto.clone(),
+        crypto_proto.clone(),
+        mainchain_common_proto.clone(),
+        sidechain_proto.clone(),
+        validator_proto.clone(),
+        wallet_proto.clone(),
     ];
-    const INCLUDES: &[&str] = &["../cusf_sidechain_proto/proto"];
-    let file_descriptors = protox::compile(ALL_PROTOS, INCLUDES)?;
+    let includes: [&Path; 1] = [proto_include.as_path()];
+    let file_descriptors = protox::compile(
+        &all_protos.iter().map(|p| p.as_path()).collect::<Vec<_>>(),
+        &includes,
+    )?;
     let file_descriptor_path =
         PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR environment variable not set"))
             .join("file_descriptor_set.bin");
     fs::write(&file_descriptor_path, file_descriptors.encode_to_vec())?;
 
-    let () =
-        compile_protos_with_config(&file_descriptor_path, &[COMMON_PROTO], INCLUDES, |_| Ok(()))?;
+    let () = compile_protos_with_config(
+        &file_descriptor_path,
+        &[common_proto.as_path()],
+        &includes,
+        |_| Ok(()),
+    )?;
     let () = compile_protos_with_config(
         &file_descriptor_path,
         &[
-            CRYPTO_PROTO,
-            MAINCHAIN_COMMON_PROTO,
-            SIDECHAIN_PROTO,
-            VALIDATOR_PROTO,
-            WALLET_PROTO,
+            crypto_proto.as_path(),
+            mainchain_common_proto.as_path(),
+            sidechain_proto.as_path(),
+            validator_proto.as_path(),
+            wallet_proto.as_path(),
         ],
-        INCLUDES,
+        &includes,
         |config| {
             config.extern_path(".cusf.common.v1", "crate::proto::common");
             Ok(())


### PR DESCRIPTION
## Summary

Makes **`lib/build.rs`** resolve **`cusf_sidechain_proto`** from **manifest-relative paths** (workspace root and **`../`**), so `cargo` works whether the submodule lives at **`cusf_sidechain_proto/`** next to **`lib/`** or the workspace root matches your checkout layout.

### Changes

- **`lib/build.rs`**: robust proto root discovery (no brittle single relative path).
- **`README.md`**: submodule comment + **maintainer follow-ups** (push access; run tests after bumping **`cusf_sidechain_proto`**).

### Related PRs

**bip300301_wallet**, **cusf_sidechain**, **coinshift-rs**.

## Test plan

- [ ] `git submodule update --init --recursive`
- [ ] `cargo test --workspace --all-features` (or CI-equivalent)
