### PR TITLE
multi: integration test cleanups, add e2e for block invalidation, wallet sync bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 bip300301_enforcer.mdb
 datadir
 sync_analysis
+integrationtests.env

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -479,6 +479,7 @@ dependencies = [
  "libtest-mimic",
  "parking_lot",
  "reserve-port",
+ "serde",
  "serde_json",
  "strum 0.28.0",
  "temp-dir",

--- a/Justfile
+++ b/Justfile
@@ -16,5 +16,5 @@ fmt:
 test-it *args='':
     #!/usr/bin/env bash
     cargo build
-    env BIP300301_ENFORCER_INTEGRATION_TEST_ENV='{{ justfile_directory() }}/integrationstests.env' \
+    env BIP300301_ENFORCER_INTEGRATION_TEST_ENV='{{ justfile_directory() }}/integrationtests.env' \
         cargo run --example integration_tests -- {{ args }}

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -31,6 +31,7 @@ tracing = { workspace = true }
 tracing-indicatif = "0.3.14"
 tokio-stream = { workspace = true }
 parking_lot = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 clap = { workspace = true }

--- a/integration_tests/integration_test.rs
+++ b/integration_tests/integration_test.rs
@@ -685,6 +685,17 @@ pub fn tests(
         },
         crate::test_file_based_block_parser::test_file_based_block_parser,
     )]);
+    async_trials.push(new_trial_with_setup(
+        "invalid_block".to_string(),
+        TestSetupComponents {
+            bin_paths: bin_paths.clone(),
+            network: Network::Regtest,
+            mode: Mode::NoMempool,
+            file_registry: file_registry.clone(),
+            failure_collector: failure_collector.clone(),
+        },
+        crate::test_invalid_block::test_invalid_block,
+    ));
 
     async_trials
 }

--- a/integration_tests/lib.rs
+++ b/integration_tests/lib.rs
@@ -2,6 +2,7 @@ pub mod integration_test;
 pub mod mine;
 pub mod setup;
 mod test_file_based_block_parser;
+mod test_invalid_block;
 mod test_peer_bmm_request;
 mod test_unconfirmed_transactions;
 pub mod util;

--- a/integration_tests/main.rs
+++ b/integration_tests/main.rs
@@ -119,16 +119,17 @@ async fn run() -> anyhow::Result<std::process::ExitCode> {
     let file_registry = TestFileRegistry::new();
     let failure_collector = TestFailureCollector::new();
 
+    // Binary paths are resolved lazily on first access for tests or
+    // subcommands that need them, pushing out any errors until
+    // they're actually necessary
+    let bin_paths = BinPaths::new();
+
     // Create a list of tests
     let mut tests = Vec::<libtest_mimic::Trial>::new();
     tests.extend(
-        integration_test::tests(
-            &BinPaths::from_env()?,
-            file_registry,
-            failure_collector.clone(),
-        )
-        .into_iter()
-        .map(|trial| trial.run_blocking(rt_handle.clone())),
+        integration_test::tests(&bin_paths, file_registry, failure_collector.clone())
+            .into_iter()
+            .map(|trial| trial.run_blocking(rt_handle.clone())),
     );
 
     // Run all tests and collect the exit code

--- a/integration_tests/main.rs
+++ b/integration_tests/main.rs
@@ -84,7 +84,20 @@ fn set_tracing_subscriber(log_level: tracing::Level) -> anyhow::Result<()> {
 }
 
 #[tokio::main]
-async fn main() -> anyhow::Result<std::process::ExitCode> {
+async fn main() -> std::process::ExitCode {
+    match run().await {
+        Ok(code) => code,
+        Err(err) => {
+            #[allow(clippy::print_stderr)]
+            {
+                eprintln!("Error: {err:#}");
+            }
+            std::process::ExitCode::from(1)
+        }
+    }
+}
+
+async fn run() -> anyhow::Result<std::process::ExitCode> {
     // Parse command line arguments
     let args = Cli::parse();
     let () = set_tracing_subscriber(tracing::Level::DEBUG)?;

--- a/integration_tests/setup.rs
+++ b/integration_tests/setup.rs
@@ -1,12 +1,6 @@
 //! Setup for an integration test
 
-use std::{
-    collections::HashMap,
-    ffi::OsStr,
-    future::Future,
-    net::SocketAddr,
-    path::{Path, PathBuf},
-};
+use std::{collections::HashMap, ffi::OsStr, future::Future, net::SocketAddr, path::PathBuf};
 
 use anyhow::anyhow;
 use bip300301_enforcer_lib::{
@@ -381,10 +375,13 @@ pub enum BitcoindKind {
     Unpatched,
 }
 
-fn bitcoind_path(bin_paths: &BinPaths, bitcoind_kind: BitcoindKind) -> &Path {
+fn bitcoind_path(
+    bin_paths: &BinPaths,
+    bitcoind_kind: BitcoindKind,
+) -> Result<PathBuf, crate::util::VarError> {
     match bitcoind_kind {
-        BitcoindKind::Patched => &bin_paths.bitcoind,
-        BitcoindKind::Unpatched => &bin_paths.bitcoind_unpatched,
+        BitcoindKind::Patched => bin_paths.bitcoind(),
+        BitcoindKind::Unpatched => bin_paths.bitcoind_unpatched(),
     }
 }
 
@@ -452,7 +449,7 @@ impl PostSetup {
 
         tracing::debug!("Starting bitcoin node");
         let bitcoind = new_bitcoind(
-            bitcoind_path(&bin_paths, opts.bitcoind_kind).to_owned(),
+            bitcoind_path(&bin_paths, opts.bitcoind_kind)?,
             dirs.bitcoin_dir.clone(),
             &reserved_ports,
             network,
@@ -468,7 +465,7 @@ impl PostSetup {
         // wait for startup
         sleep(std::time::Duration::from_secs(1)).await;
         // Create a wallet and initialize it
-        let mut bitcoin_cli = bitcoind.new_bitcoin_cli(bin_paths.bitcoin_cli.clone());
+        let mut bitcoin_cli = bitcoind.new_bitcoin_cli(bin_paths.bitcoin_cli()?);
         tracing::debug!("Creating wallet");
         let _create_wallet_output = bitcoin_cli
             .command::<String, _, _, _, _>([], "createwallet", ["integration-test"])
@@ -505,9 +502,9 @@ impl PostSetup {
         };
 
         let mut signet_miner = bins::SignetMiner {
-            path: bin_paths.signet_miner.clone(),
+            path: bin_paths.signet_miner()?,
             bitcoin_cli: bitcoin_cli.clone(),
-            bitcoin_util: bin_paths.bitcoin_util.clone(),
+            bitcoin_util: bin_paths.bitcoin_util()?,
             block_interval: None,
             coinbase_recipient: Some(mining_address.clone()),
             debug: false,
@@ -549,7 +546,7 @@ impl PostSetup {
         // Start electrs
         tracing::debug!("Starting electrs");
         let electrs = Electrs {
-            path: bin_paths.electrs.clone(),
+            path: bin_paths.electrs()?,
             db_dir: dirs.electrs_dir.clone(),
             auth: ("drivechain".to_owned(), "integrationtesting".to_owned()),
             daemon_dir: bitcoind.data_dir.join("path"),
@@ -571,7 +568,7 @@ impl PostSetup {
         // Start BIP300301 Enforcer
         tracing::debug!("Starting bip300301_enforcer");
         let enforcer = Enforcer {
-            path: bin_paths.bip300301_enforcer.clone(),
+            path: bin_paths.bip300301_enforcer()?,
             data_dir: dirs.enforcer_dir.clone(),
             enable_mempool: mode.enable_mempool(),
             enable_wallet: true,
@@ -631,7 +628,7 @@ impl PostSetup {
             mode,
             bitcoin_cli,
             bitcoin_util: bins::BitcoinUtil {
-                path: bin_paths.bitcoin_util.clone(),
+                path: bin_paths.bitcoin_util()?,
                 network: bitcoind.network,
             },
             tasks,

--- a/integration_tests/test_file_based_block_parser.rs
+++ b/integration_tests/test_file_based_block_parser.rs
@@ -17,7 +17,7 @@ pub async fn test_file_based_block_parser(setup: PreSetup) -> anyhow::Result<()>
     let (res_tx, _) = mpsc::unbounded::<anyhow::Result<()>>();
 
     let bitcoind = new_bitcoind(
-        setup.bin_paths.bitcoind,
+        setup.bin_paths.bitcoind()?,
         setup.directories.bitcoin_dir.clone(),
         &setup.reserved_ports,
         setup.network,
@@ -36,7 +36,7 @@ pub async fn test_file_based_block_parser(setup: PreSetup) -> anyhow::Result<()>
     // wait for startup
     sleep(std::time::Duration::from_secs(1)).await;
 
-    let bitcoin_cli = bitcoind.new_bitcoin_cli(setup.bin_paths.bitcoin_cli.clone());
+    let bitcoin_cli = bitcoind.new_bitcoin_cli(setup.bin_paths.bitcoin_cli()?);
 
     tracing::info!("Generating blocks");
     // just generate to a random regtest address. we don't actually need the coins!
@@ -72,7 +72,7 @@ pub async fn test_file_based_block_parser(setup: PreSetup) -> anyhow::Result<()>
     sleep(std::time::Duration::from_secs(1)).await;
 
     let enforcer = Enforcer {
-        path: setup.bin_paths.bip300301_enforcer.clone(),
+        path: setup.bin_paths.bip300301_enforcer()?,
         data_dir: setup.directories.enforcer_dir.clone(),
         enable_mempool: false,
         enable_wallet: false,

--- a/integration_tests/test_invalid_block.rs
+++ b/integration_tests/test_invalid_block.rs
@@ -1,0 +1,266 @@
+//! Verifies that the enforcer rejects a block whose coinbase carries a
+//! BIP-300 rule violation. Specifically: two M4 (ack-bundles) messages,
+//! which `CoinbaseMessages::push` rejects with `DuplicateM4`.
+
+use std::time::Duration;
+
+use bip300301_enforcer_lib::{bins::CommandExt as _, messages::M4AckBundles};
+use bitcoin::{
+    Amount, Block, BlockHash, CompactTarget, OutPoint, ScriptBuf, Sequence, Transaction, TxIn,
+    TxMerkleNode, TxOut, Witness,
+    block::Header,
+    consensus::encode::{deserialize_hex, serialize_hex},
+    hashes::Hash as _,
+    script::{Builder as ScriptBuilder, PushBytesBuf},
+    transaction::Version,
+};
+use futures::channel::mpsc;
+use serde::Deserialize;
+use tokio::time::sleep;
+
+use crate::{
+    integration_test::{activate_sidechain, fund_enforcer, propose_sidechain},
+    setup::{DummySidechain, PostSetup, Sidechain},
+};
+
+pub async fn test_invalid_block(mut post_setup: PostSetup) -> anyhow::Result<()> {
+    let (sidechain_res_tx, _sidechain_res_rx) = mpsc::unbounded();
+    let mut _sidechain = DummySidechain::setup((), &post_setup, sidechain_res_tx).await?;
+
+    propose_sidechain::<DummySidechain>(&mut post_setup).await?;
+    activate_sidechain::<DummySidechain>(&mut post_setup).await?;
+    fund_enforcer::<DummySidechain>(&mut post_setup).await?;
+    // `fund_enforcer` mines 100 blocks in a burst; their timestamps end up
+    // ahead of wall clock, so a block mined now would be rejected as
+    // `time-too-old`. Wait until wall clock surpasses median-time-past.
+    wait_past_mtp(&post_setup).await?;
+
+    let pre_mine_tip: BlockHash = post_setup
+        .bitcoin_cli
+        .command::<String, _, String, _, _>([], "getbestblockhash", [])
+        .run_utf8()
+        .await?
+        .parse()?;
+    tracing::info!(%pre_mine_tip, "pre-mine tip");
+
+    let bad_block_hash = mine_block_with_duplicate_m4(&post_setup).await?;
+    tracing::info!(%bad_block_hash, "submitted block with duplicate M4");
+
+    poll_until_tip(&post_setup, pre_mine_tip, Duration::from_secs(10)).await?;
+
+    let chaintips_json = post_setup
+        .bitcoin_cli
+        .command::<String, _, String, _, _>([], "getchaintips", [])
+        .run_utf8()
+        .await?;
+    let chaintips: Vec<serde_json::Value> = serde_json::from_str(&chaintips_json)?;
+    let bad_tip_status = chaintips
+        .iter()
+        .find(|tip| {
+            tip.get("hash")
+                .and_then(|h| h.as_str())
+                .and_then(|h| h.parse::<BlockHash>().ok())
+                == Some(bad_block_hash)
+        })
+        .and_then(|tip| tip.get("status"))
+        .and_then(|s| s.as_str());
+    anyhow::ensure!(
+        bad_tip_status == Some("invalid"),
+        "expected bad block status `invalid`, got {bad_tip_status:?}"
+    );
+
+    // `tracing` writes to stdout in the integration-test enforcer config.
+    let stdout_path = post_setup.directories.enforcer_dir.join("stdout.txt");
+    let stdout_contents = std::fs::read_to_string(&stdout_path)?;
+    anyhow::ensure!(
+        stdout_contents.contains("rejecting block: M4 already included at index"),
+        "enforcer stdout at `{}` did not contain the duplicate-M4 rejection log",
+        stdout_path.display()
+    );
+
+    Ok(())
+}
+
+/// Block-template fields we read from bitcoind's `getblocktemplate`. The test
+/// talks to bitcoind directly (not via the enforcer's GBT proxy) because the
+/// proxy is disabled in `Mode::NoMempool`.
+#[derive(Deserialize)]
+struct BlockTemplate {
+    previousblockhash: BlockHash,
+    version: i32,
+    #[serde(deserialize_with = "deserialize_bits")]
+    bits: CompactTarget,
+    height: u32,
+    coinbasevalue: u64,
+    mintime: u32,
+    curtime: u32,
+    #[serde(default)]
+    transactions: Vec<serde_json::Value>,
+}
+
+fn deserialize_bits<'de, D: serde::Deserializer<'de>>(de: D) -> Result<CompactTarget, D::Error> {
+    let hex = String::deserialize(de)?;
+    u32::from_str_radix(&hex, 16)
+        .map(CompactTarget::from_consensus)
+        .map_err(serde::de::Error::custom)
+}
+
+/// Build a block with a hand-rolled coinbase containing two M4 OP_RETURN
+/// outputs, grind its PoW, and submit it. Returns the block hash bitcoind
+/// accepted at consensus (the enforcer should subsequently invalidate).
+async fn mine_block_with_duplicate_m4(post_setup: &PostSetup) -> anyhow::Result<BlockHash> {
+    let template_json = post_setup
+        .bitcoin_cli
+        .command::<String, _, _, _, _>([], "getblocktemplate", [r#"{"rules":["segwit"]}"#])
+        .run_utf8()
+        .await?;
+    let template: BlockTemplate = serde_json::from_str(&template_json)?;
+    anyhow::ensure!(
+        template.transactions.is_empty(),
+        "test assumes empty mempool for witness-commitment shortcut; \
+         got {} extra tx(s) in template",
+        template.transactions.len()
+    );
+
+    const WITNESS_RESERVED_VALUE: [u8; 32] = [0; 32];
+    let coinbase_input = TxIn {
+        previous_output: OutPoint::null(),
+        script_sig: ScriptBuilder::new()
+            .push_int(template.height as i64)
+            .into_script(),
+        sequence: Sequence::MAX,
+        witness: Witness::from_slice(&[WITNESS_RESERVED_VALUE]),
+    };
+
+    // All-zero witness merkle root because the coinbase wtxid is 0x00..00 (BIP141).
+    let witness_commitment = Block::compute_witness_commitment(
+        &bitcoin::WitnessMerkleNode::all_zeros(),
+        &WITNESS_RESERVED_VALUE,
+    );
+    let witness_commit_script = {
+        const WITNESS_COMMITMENT_HEADER: [u8; 4] = [0xaa, 0x21, 0xa9, 0xed];
+        let mut payload = PushBytesBuf::from(WITNESS_COMMITMENT_HEADER);
+        payload.extend_from_slice(witness_commitment.as_byte_array())?;
+        ScriptBuf::new_op_return(payload)
+    };
+
+    // Two M4 OP_RETURN outputs with different upvote payloads — the second
+    // hits `CoinbaseMessages::push`'s `DuplicateM4` check (lib/messages.rs:506)
+    // regardless of contents.
+    let m4_a: ScriptBuf = M4AckBundles::OneByte {
+        upvotes: vec![0x00],
+    }
+    .try_into()?;
+    let m4_b: ScriptBuf = M4AckBundles::OneByte {
+        upvotes: vec![0x01],
+    }
+    .try_into()?;
+
+    let coinbase = Transaction {
+        version: Version::TWO,
+        lock_time: bitcoin::locktime::absolute::LockTime::ZERO,
+        input: vec![coinbase_input],
+        output: vec![
+            TxOut {
+                script_pubkey: post_setup.mining_address.script_pubkey(),
+                value: Amount::from_sat(template.coinbasevalue),
+            },
+            TxOut {
+                script_pubkey: witness_commit_script,
+                value: Amount::ZERO,
+            },
+            TxOut {
+                script_pubkey: m4_a,
+                value: Amount::ZERO,
+            },
+            TxOut {
+                script_pubkey: m4_b,
+                value: Amount::ZERO,
+            },
+        ],
+    };
+
+    let merkle_root = TxMerkleNode::from(coinbase.compute_txid().to_raw_hash());
+    let header = Header {
+        version: bitcoin::block::Version::from_consensus(template.version),
+        prev_blockhash: template.previousblockhash,
+        merkle_root,
+        time: std::cmp::max(template.curtime, template.mintime),
+        bits: template.bits,
+        nonce: 0,
+    };
+    let header_hex = post_setup
+        .bitcoin_util
+        .command::<String, _, _, _, _>([], "grind", [serialize_hex(&header)])
+        .run_utf8()
+        .await?;
+    let header: Header = deserialize_hex(header_hex.trim())?;
+
+    let block = Block {
+        header,
+        txdata: vec![coinbase],
+    };
+    let block_hash = block.block_hash();
+    let block_hex = serialize_hex(&block);
+    let submit_resp = post_setup
+        .bitcoin_cli
+        .command::<String, _, _, _, _>([], "submitblock", [block_hex])
+        .run_utf8()
+        .await?;
+    anyhow::ensure!(
+        submit_resp.is_empty(),
+        "submitblock unexpectedly rejected: `{submit_resp}`"
+    );
+
+    Ok(block_hash)
+}
+
+async fn wait_past_mtp(post_setup: &PostSetup) -> anyhow::Result<()> {
+    let tip_hash = post_setup
+        .bitcoin_cli
+        .command::<String, _, String, _, _>([], "getbestblockhash", [])
+        .run_utf8()
+        .await?;
+    let tip_json = post_setup
+        .bitcoin_cli
+        .command::<String, _, _, _, _>([], "getblock", [tip_hash])
+        .run_utf8()
+        .await?;
+    let mediantime = serde_json::from_str::<serde_json::Value>(&tip_json)?["mediantime"]
+        .as_u64()
+        .ok_or_else(|| anyhow::anyhow!("getblock response missing mediantime"))?;
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)?
+        .as_secs();
+    if mediantime >= now {
+        let wait = Duration::from_secs(mediantime - now + 1);
+        tracing::info!(?wait, mediantime, now, "waiting for wall clock to pass MTP");
+        sleep(wait).await;
+    }
+    Ok(())
+}
+
+async fn poll_until_tip(
+    post_setup: &PostSetup,
+    expected: BlockHash,
+    timeout: Duration,
+) -> anyhow::Result<()> {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        let tip: BlockHash = post_setup
+            .bitcoin_cli
+            .command::<String, _, String, _, _>([], "getbestblockhash", [])
+            .run_utf8()
+            .await?
+            .parse()?;
+        if tip == expected {
+            return Ok(());
+        }
+        if tokio::time::Instant::now() >= deadline {
+            anyhow::bail!(
+                "timed out waiting for tip to revert to `{expected}`; current tip is `{tip}`"
+            );
+        }
+        sleep(Duration::from_millis(200)).await;
+    }
+}

--- a/integration_tests/util.rs
+++ b/integration_tests/util.rs
@@ -107,33 +107,40 @@ pub fn get_env_var_or<K: AsRef<OsStr>>(key: K, default: &str) -> Result<String, 
     }
 }
 
-#[derive(Clone, Debug)]
-pub struct BinPaths {
-    pub bitcoind: PathBuf,
-    pub bitcoind_unpatched: PathBuf,
-    pub bitcoin_cli: PathBuf,
-    pub bitcoin_util: PathBuf,
-    pub bip300301_enforcer: PathBuf,
-    pub electrs: PathBuf,
-    pub signet_miner: PathBuf,
-}
+#[derive(Clone, Debug, Default)]
+pub struct BinPaths;
 
 impl BinPaths {
-    /// Read from environment variables
-    pub fn from_env() -> Result<Self, VarError> {
-        Ok(Self {
-            bitcoind: get_env_var("BITCOIND")?.into(),
-            bitcoind_unpatched: get_env_var("BITCOIND_UNPATCHED")?.into(),
-            bitcoin_cli: get_env_var("BITCOIN_CLI")?.into(),
-            bitcoin_util: get_env_var("BITCOIN_UTIL")?.into(),
-            bip300301_enforcer: get_env_var_or(
-                "BIP300301_ENFORCER",
-                "./target/debug/bip300301_enforcer",
-            )?
-            .into(),
-            electrs: get_env_var("ELECTRS")?.into(),
-            signet_miner: get_env_var("SIGNET_MINER")?.into(),
-        })
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub fn bitcoind(&self) -> Result<PathBuf, VarError> {
+        Ok(get_env_var("BITCOIND")?.into())
+    }
+
+    pub fn bitcoind_unpatched(&self) -> Result<PathBuf, VarError> {
+        Ok(get_env_var("BITCOIND_UNPATCHED")?.into())
+    }
+
+    pub fn bitcoin_cli(&self) -> Result<PathBuf, VarError> {
+        Ok(get_env_var("BITCOIN_CLI")?.into())
+    }
+
+    pub fn bitcoin_util(&self) -> Result<PathBuf, VarError> {
+        Ok(get_env_var("BITCOIN_UTIL")?.into())
+    }
+
+    pub fn bip300301_enforcer(&self) -> Result<PathBuf, VarError> {
+        Ok(get_env_var_or("BIP300301_ENFORCER", "./target/debug/bip300301_enforcer")?.into())
+    }
+
+    pub fn electrs(&self) -> Result<PathBuf, VarError> {
+        Ok(get_env_var("ELECTRS")?.into())
+    }
+
+    pub fn signet_miner(&self) -> Result<PathBuf, VarError> {
+        Ok(get_env_var("SIGNET_MINER")?.into())
     }
 }
 

--- a/integration_tests/util.rs
+++ b/integration_tests/util.rs
@@ -6,7 +6,6 @@ use std::{
     sync::Arc,
 };
 
-use futures::TryFutureExt as _;
 use thiserror::Error;
 use tokio::task::JoinHandle;
 
@@ -271,26 +270,17 @@ impl<Fut> AsyncTrial<Fut> {
                 // Use spawn_blocking to avoid nested runtime issues
                 std::thread::spawn(move || {
                     rt_handle.block_on(async {
-                        let result = self.test.map_err(libtest_mimic::Failed::from).await;
-
-                        // Collect failure information instead of immediately printing
-                        if result.is_err() {
-                            let files = file_registry.get_files(&test_name);
-
-                            let error_message = match &result {
-                                Err(failed) => format!("{failed:?}"),
-                                Ok(_) => "Unknown error".to_string(),
-                            };
-
-                            let failure = TestFailure {
+                        let result = self.test.await;
+                        if let Err(err) = &result {
+                            // Alternate Display gives anyhow's chained
+                            // "top: cause: root" form without a backtrace.
+                            failure_collector.add_failure(TestFailure {
                                 test_name: test_name.clone(),
-                                error_message,
-                                output_files: files,
-                            };
-
-                            failure_collector.add_failure(failure);
+                                error_message: format!("{err:#}"),
+                                output_files: file_registry.get_files(&test_name),
+                            });
                         }
-                        result
+                        result.map_err(libtest_mimic::Failed::from)
                     })
                 })
                 .join()

--- a/lib/validator/task/mod.rs
+++ b/lib/validator/task/mod.rs
@@ -52,8 +52,11 @@ const UNUSED_SIDECHAIN_SLOT_ACTIVATION_MAX_FAILS: u16 = 5;
 const UNUSED_SIDECHAIN_SLOT_ACTIVATION_THRESHOLD: u16 =
     UNUSED_SIDECHAIN_SLOT_PROPOSAL_MAX_AGE - UNUSED_SIDECHAIN_SLOT_ACTIVATION_MAX_FAILS;
 
-/// Returns `Some` if the sidechain proposal does not already exist
-// See https://github.com/LayerTwo-Labs/bip300_bip301_specifications/blob/master/bip300.md#m1-1
+/// BIP 300 M1 (Propose New Sidechain). Returns `Some` if the proposal is
+/// novel; re-proposals of an existing `(slot, description_hash)` are ignored
+/// so miners cannot reset vote counts.
+///
+/// <https://github.com/LayerTwo-Labs/bip300_bip301_specifications/blob/master/bip300.md#m1-propose-new-sidechain>
 fn handle_m1_propose_sidechain(
     rotxn: &RoTxn,
     dbs: &Dbs,
@@ -92,7 +95,10 @@ fn handle_m1_propose_sidechain(
     Ok(Some(diff))
 }
 
-// See https://github.com/LayerTwo-Labs/bip300_bip301_specifications/blob/master/bip300.md#m2-1
+/// BIP 300 M2 (ACK Proposal). Increments the proposal's vote count and
+/// activates it if it has crossed the threshold within the age window.
+///
+/// <https://github.com/LayerTwo-Labs/bip300_bip301_specifications/blob/master/bip300.md#m2-ack-proposal>
 fn handle_m2_ack_sidechain(
     rotxn: &RoTxn,
     dbs: &Dbs,
@@ -146,6 +152,10 @@ fn handle_m2_ack_sidechain(
     Ok(diff)
 }
 
+/// BIP 300 M2 failure path: removes sidechain proposals whose age has
+/// exceeded the max proposal age.
+///
+/// <https://github.com/LayerTwo-Labs/bip300_bip301_specifications/blob/master/bip300.md#m2-ack-proposal>
 fn handle_failed_sidechain_proposals(
     rotxn: &RoTxn,
     dbs: &Dbs,
@@ -176,6 +186,10 @@ fn handle_failed_sidechain_proposals(
     Ok(diff::FailedProposals(failed_proposals))
 }
 
+/// BIP 300 M3 (Propose Bundle). Adds a new pending withdrawal bundle for an
+/// active sidechain; rejects proposals for inactive slots.
+///
+/// <https://github.com/LayerTwo-Labs/bip300_bip301_specifications/blob/master/bip300.md#m3-propose-bundle>
 fn handle_m3_propose_bundle(
     rotxn: &RoTxn,
     dbs: &Dbs,
@@ -197,6 +211,10 @@ fn handle_m3_propose_bundle(
     }
 }
 
+/// Core M4 upvote resolver: for each active sidechain, interprets the vote
+/// value (index into pending bundles, ABSTAIN `0xFFFF`, or ALARM `0xFFFE`).
+///
+/// <https://github.com/LayerTwo-Labs/bip300_bip301_specifications/blob/master/bip300.md#m4-ack-bundle>
 fn handle_m4_votes(
     rotxn: &RoTxn,
     dbs: &Dbs,
@@ -261,6 +279,11 @@ fn handle_m4_votes(
     Ok(diff)
 }
 
+/// BIP 300 M4 (ACK Bundle) dispatcher across the four encoding versions:
+/// OneByte (0x01), TwoBytes (0x02), LeadingBy50 (0x03), RepeatPrevious
+/// (0x00).
+///
+/// <https://github.com/LayerTwo-Labs/bip300_bip301_specifications/blob/master/bip300.md#m4-ack-bundle>
 fn handle_m4_ack_bundles(
     rotxn: &RoTxn,
     dbs: &Dbs,
@@ -290,7 +313,10 @@ fn handle_m4_ack_bundles(
     }
 }
 
-/// Returns failed M6IDs with sidechain numbers
+/// BIP 300 M6 failure path: removes pending withdrawal bundles whose age
+/// has exceeded `WITHDRAWAL_BUNDLE_MAX_AGE`.
+///
+/// <https://github.com/LayerTwo-Labs/bip300_bip301_specifications/blob/master/bip300.md#m6-withdrawal-bundle>
 fn handle_failed_m6ids(
     rotxn: &RoTxn,
     dbs: &Dbs,
@@ -333,7 +359,10 @@ fn handle_failed_m6ids(
 /// Deposit or (sidechain_id, m6id, sequence_number)
 type DepositOrSuccessfulWithdrawal = Either<Deposit, (SidechainNumber, M6id, u64)>;
 
-/// Returns (sidechain_id, m6id, info) for the withdrawal
+/// BIP 300 M6 (Withdrawal Bundle): validates that the tx matches an approved
+/// pending bundle with sufficient vote count and returns its metadata.
+///
+/// <https://github.com/LayerTwo-Labs/bip300_bip301_specifications/blob/master/bip300.md#m6-withdrawal-bundle>
 fn handle_m6(
     rotxn: &RoTxn,
     dbs: &ActiveSidechainDbs,
@@ -356,6 +385,13 @@ fn handle_m6(
     }
 }
 
+/// BIP 300 M5 (Deposit) / M6 (Withdrawal Bundle) dispatcher. A tx whose
+/// first output is an OP_DRIVECHAIN treasury UTXO is classified by
+/// comparing the new treasury value to the previous one: a larger value
+/// is an M5 deposit, a smaller value is an M6 withdrawal bundle.
+///
+/// <https://github.com/LayerTwo-Labs/bip300_bip301_specifications/blob/master/bip300.md#m5-deposit>
+/// <https://github.com/LayerTwo-Labs/bip300_bip301_specifications/blob/master/bip300.md#m6-withdrawal-bundle>
 fn handle_m5_m6(
     rotxn: &RoTxn,
     dbs: &ActiveSidechainDbs,
@@ -462,9 +498,14 @@ fn handle_m5_m6(
     }
 }
 
-/// Handles a (potential) M8 BMM request.
-/// Returns `true` if this is a valid BMM request, `HandleM8Error::Jfyi` if
-/// this is an invalid BMM request, and `false` if this is not a BMM request.
+/// BIP 301 M8 (BMM Request). Validates that an M8 transaction matches an
+/// accepted BMM commitment (via M7) and references the current mainchain
+/// tip as its `prev_mainchain_block_hash`.
+///
+/// Returns `true` if the tx is a valid BMM request, a non-fatal
+/// `HandleM8` error if invalid, and `false` if the tx is not an M8 at all.
+///
+/// <https://github.com/LayerTwo-Labs/bip300_bip301_specifications/blob/master/bip301.md#m8-bmm-request>
 fn handle_m8(
     transaction: &Transaction,
     accepted_bmm_requests: Option<&BmmCommitments>,
@@ -492,6 +533,11 @@ enum CoinbaseMessageEvent {
     WithdrawalBundle(WithdrawalBundleEvent),
 }
 
+/// Dispatches a single coinbase OP_RETURN message to its handler. M1/M2/M3/M4
+/// are BIP 300; M7 is BIP 301.
+///
+/// <https://github.com/LayerTwo-Labs/bip300_bip301_specifications/blob/master/bip300.md>
+/// <https://github.com/LayerTwo-Labs/bip300_bip301_specifications/blob/master/bip301.md#m7-bmm-accept>
 fn handle_coinbase_message(
     rotxn: &RoTxn,
     dbs: &Dbs,

--- a/lib/wallet/cusf_block_producer.rs
+++ b/lib/wallet/cusf_block_producer.rs
@@ -205,7 +205,14 @@ impl CusfEnforcer for Wallet {
         // First, connect the block to the validator.
         let res = self.inner.validator.clone().connect_block(block).await?;
         tracing::trace!("validator finished processing block");
-        let () = sync_wallet_to_tip(self, block.block_hash(), Some(block)).await?;
+        // Skip wallet sync if the validator rejected the block. The validator
+        // aborts the child rwtxn on `Reject`, so block info is not persisted —
+        // `sync_wallet_to_tip` would fail in `get_block_infos` and bubble an
+        // error up that prevents the standalone driver from issuing
+        // `invalidateblock` to bitcoind.
+        if matches!(res, ConnectBlockAction::Accept { .. }) {
+            let () = sync_wallet_to_tip(self, block.block_hash(), Some(block)).await?;
+        }
         Ok(res)
     }
 


### PR DESCRIPTION
Add a unit test for e2e validation of blocks being rejected via `cusf-enforcer-mempool`. This also surfaced a bug where an eager sync of the wallet for a just-invalidated block would crash us, which is fixed in 6f004253b5e67a1b483fb073fb81caa94c5c58e8