### PR TITLE
dev: migrate clippy directives from allow -> expect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -572,7 +572,6 @@ dependencies = [
  "transitive",
  "url",
  "uuid",
- "zeromq",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,6 +108,7 @@ rev = "ea82b33947f60c511dac6eb3815b6af3f6c3f555"
 
 [workspace.lints.clippy]
 all = { level = "deny", priority = -1 }
+allow_attributes = "deny"
 assertions_on_result_states = "allow"
 let_unit_value = "allow"
 print_stderr = "deny"
@@ -118,6 +119,7 @@ wildcard_imports = "deny"
 
 [workspace.lints.rust]
 let_underscore_drop = "deny"
+unfulfilled_lint_expectations = "deny"
 
 [patch.crates-io.bitcoin-send-tx-p2p]
 git = "https://github.com/Ash-L2L/bitcoin-send-tx-p2p.git"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,6 @@ tracing-subscriber = "0.3.23"
 transitive = "1.2.0"
 url = "2.5.8"
 uuid = "1.23.1"
-zeromq = "0.6.0"
 
 [workspace.dependencies.bitcoin-jsonrpsee]
 git = "https://github.com/LayerTwo-Labs/bitcoin-jsonrpsee.git"

--- a/integration_tests/integration_test.rs
+++ b/integration_tests/integration_test.rs
@@ -522,7 +522,6 @@ where
     Ok(())
 }
 
-#[allow(clippy::significant_drop_tightening, reason = "false positive")]
 pub async fn deposit_withdraw_roundtrip_task<S>(
     post_setup: &mut PostSetup,
     res_tx: mpsc::UnboundedSender<anyhow::Result<()>>,

--- a/integration_tests/main.rs
+++ b/integration_tests/main.rs
@@ -88,7 +88,7 @@ async fn main() -> std::process::ExitCode {
     match run().await {
         Ok(code) => code,
         Err(err) => {
-            #[allow(clippy::print_stderr)]
+            #[expect(clippy::print_stderr)]
             {
                 eprintln!("Error: {err:#}");
             }

--- a/integration_tests/setup.rs
+++ b/integration_tests/setup.rs
@@ -810,7 +810,6 @@ impl DummySidechain {
     }
 
     /// Extract withdrawal bundle events from block info events
-    #[allow(clippy::result_large_err)]
     fn extract_withdrawal_bundle_event(
         block_event: proto::mainchain::block_info::Event,
     ) -> Result<Option<proto::mainchain::WithdrawalBundleEvent>, tonic::Status> {

--- a/integration_tests/util.rs
+++ b/integration_tests/util.rs
@@ -41,7 +41,7 @@ impl TestFailureCollector {
     }
 
     /// Format and display all collected failures
-    #[allow(clippy::print_stderr)]
+    #[expect(clippy::print_stderr)]
     pub fn display_all_failures(&self) {
         let failures = self.get_failures();
         if failures.is_empty() {

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -68,7 +68,6 @@ tracing-subscriber = { workspace = true, features = ["json"] }
 transitive = { workspace = true }
 url = { workspace = true }
 uuid = { workspace = true }
-zeromq = { workspace = true }
 
 [features]
 default = ["rustls"]

--- a/lib/proto.rs
+++ b/lib/proto.rs
@@ -231,7 +231,6 @@ pub mod common {
         }
 
         /// Variant of [`Self::decode`] that returns a `tonic::Status` error
-        #[allow(clippy::result_large_err)]
         pub fn decode_tonic<Message, T>(self, field_name: &str) -> Result<T, tonic::Status>
         where
             Message: prost::Name,
@@ -270,7 +269,6 @@ pub mod common {
         }
 
         /// Variant of [`Self::decode`] that returns a `tonic::Status` error
-        #[allow(clippy::result_large_err)]
         pub fn decode_tonic<Message, T>(self, field_name: &str) -> Result<T, tonic::Status>
         where
             Message: prost::Name,
@@ -313,7 +311,6 @@ pub mod common {
         }
 
         /// Variant of [`Self::decode`] that returns a `tonic::Status` error
-        #[allow(clippy::result_large_err)]
         pub fn decode_tonic<Message, T>(self, field_name: &str) -> Result<T, tonic::Status>
         where
             Message: prost::Name,
@@ -341,10 +338,12 @@ pub mod common {
     }
 }
 
+#[expect(clippy::allow_attributes, reason = "generated code uses #[allow]")]
 pub mod crypto {
     tonic::include_proto!("cusf.crypto.v1");
 }
 
+#[expect(clippy::allow_attributes, reason = "generated code uses #[allow]")]
 pub mod mainchain {
     use crate::{
         messages::{
@@ -356,7 +355,6 @@ pub mod mainchain {
 
     tonic::include_proto!("cusf.mainchain.v1");
 
-    #[allow(unused_imports)]
     pub use self::{
         subscribe_events_response::event::{ConnectBlock, DisconnectBlock},
         validator_service_server::{
@@ -982,6 +980,7 @@ pub mod mainchain {
     }
 }
 
+#[expect(clippy::allow_attributes, reason = "generated code uses #[allow]")]
 pub mod sidechain {
     tonic::include_proto!("cusf.sidechain.v1");
 }

--- a/lib/types.rs
+++ b/lib/types.rs
@@ -672,7 +672,6 @@ pub struct BlindedM6<'a> {
     tx: Cow<'a, bitcoin::Transaction>,
 }
 
-#[allow(dead_code, reason = "will be used later for M4/M6")]
 impl<'a> BlindedM6<'a> {
     pub fn fee(&self) -> &Amount {
         &self.fee

--- a/lib/validator/dbs/block_hashes.rs
+++ b/lib/validator/dbs/block_hashes.rs
@@ -37,7 +37,6 @@ pub mod error {
         pub(super) prev_block_hash: BlockHash,
     }
 
-    #[allow(clippy::duplicated_attributes)]
     #[derive(Debug, Error, Transitive)]
     #[transitive(from(db::error::Put, db::Error), from(db::error::TryGet, db::Error))]
     pub(in crate::validator::dbs::block_hashes) enum PutBlockInfoInner {
@@ -68,7 +67,6 @@ pub mod error {
         }
     }
 
-    #[allow(clippy::duplicated_attributes)]
     #[derive(Debug, Error, Transitive)]
     #[transitive(from(db::error::Get, db::Error), from(db::error::TryGet, db::Error))]
     pub(crate) enum LastCommonAncestor {
@@ -151,7 +149,7 @@ pub struct BlockHashDbs {
     // Used for determining conflicts for mempool txs.
     // Maps block hash and sidechain number to a set of txids and their h*
     // commitments.
-    #[allow(clippy::type_complexity)]
+    #[expect(clippy::type_complexity)]
     seen_bmm_request_txs: DatabaseDup<
         SerdeBincode<(BlockHash, SidechainNumber)>,
         SerdeBincode<(Txid, BmmCommitment)>,

--- a/lib/validator/dbs/diff.rs
+++ b/lib/validator/dbs/diff.rs
@@ -35,7 +35,6 @@ pub(in crate::validator) trait Diff {
 /// A `VoteCountUnderflow` indicates the block being disconnected — or some
 /// inconsistency between the block and the state — would have driven a
 /// vote count below zero. Treat as an invalid block, not corrupt state.
-#[allow(clippy::duplicated_attributes)]
 #[derive(Debug, Error, Transitive)]
 #[transitive(
     from(db::error::Delete, db::Error),

--- a/lib/validator/dbs/mod.rs
+++ b/lib/validator/dbs/mod.rs
@@ -289,7 +289,6 @@ impl ActiveSidechainDbs {
     }
 }
 
-#[allow(clippy::duplicated_attributes)]
 #[derive(transitive::Transitive, Debug, Error)]
 #[transitive(
     from(env::error::CreateDb, env::Error),

--- a/lib/validator/task/error.rs
+++ b/lib/validator/task/error.rs
@@ -22,7 +22,6 @@ pub(in crate::validator) enum HandleM1ProposeSidechain {
     DbTryGet(#[from] db::error::TryGet),
 }
 
-#[allow(clippy::duplicated_attributes)]
 #[derive(Debug, Error, Fatality, Split, Transitive)]
 #[split(attrs(derive(Debug, Error)))]
 #[transitive(
@@ -48,7 +47,6 @@ impl From<db::Error> for HandleM2AckSidechain {
     }
 }
 
-#[allow(clippy::duplicated_attributes)]
 #[derive(Debug, Error, Fatality, Split, Transitive)]
 #[split(attrs(derive(Debug, Error)))]
 #[transitive(
@@ -89,7 +87,6 @@ impl From<db::Error> for HandleM3ProposeBundle {
     }
 }
 
-#[allow(clippy::duplicated_attributes)]
 #[derive(Debug, Error, Fatality, Split, Transitive)]
 #[split(attrs(derive(Debug, Error)))]
 #[transitive(
@@ -122,7 +119,6 @@ impl From<db::Error> for HandleM4Votes {
     }
 }
 
-#[allow(clippy::duplicated_attributes)]
 #[derive(Debug, Error, Fatality, Split, Transitive)]
 #[split(attrs(derive(Debug, Error)))]
 #[transitive(from(db::error::Get, db::Error), from(db::error::TryGet, db::Error))]
@@ -149,7 +145,6 @@ impl From<db::Error> for HandleM4AckBundles {
     }
 }
 
-#[allow(clippy::duplicated_attributes)]
 #[derive(Debug, Error, Fatality, Split, Transitive)]
 #[split(attrs(derive(Debug, Error)))]
 #[transitive(
@@ -218,7 +213,6 @@ pub(in crate::validator) enum HandleTransaction {
     M8(#[from] HandleM8),
 }
 
-#[allow(clippy::duplicated_attributes)]
 #[derive(Debug, Error, Transitive)]
 #[transitive(from(db::error::Get, db::Error), from(db::error::TryGet, db::Error))]
 pub(in crate::validator::task) enum ValidateTransactionInner {
@@ -252,7 +246,6 @@ where
     }
 }
 
-#[allow(clippy::duplicated_attributes)]
 #[derive(Debug, Error, Fatality, Split, Transitive)]
 #[split(attrs(derive(Debug, Error)))]
 #[transitive(
@@ -312,7 +305,6 @@ impl From<db::Error> for ConnectBlock {
     }
 }
 
-#[allow(clippy::duplicated_attributes)]
 #[derive(Debug, Error, Transitive)]
 #[transitive(
     from(db::error::Delete, db::Error),
@@ -340,7 +332,6 @@ impl From<db::Error> for DisconnectBlock {
     }
 }
 
-#[allow(clippy::duplicated_attributes)]
 #[derive(Debug, Error, Fatality, Split, Transitive)]
 #[split(attrs(derive(Debug, Error)))]
 #[transitive(
@@ -419,33 +410,5 @@ pub(in crate::validator) enum Sync {
 impl From<ConnectBlock> for Sync {
     fn from(err: ConnectBlock) -> Self {
         Self::ConnectBlock(Box::new(Splittable(err)))
-    }
-}
-
-#[derive(Debug, Error)]
-pub(in crate::validator::task) enum FatalInner {
-    #[error(transparent)]
-    DisconnectBlock(#[from] DisconnectBlock),
-    #[error(transparent)]
-    Sync(#[from] <Sync as Split>::Fatal),
-    #[error(transparent)]
-    WriteTxn(#[from] env::error::WriteTxn),
-    #[error(transparent)]
-    Zmq(#[from] zeromq::ZmqError),
-    #[error(transparent)]
-    ZmqSequenceStream(#[from] cusf_enforcer_mempool::zmq::SequenceStreamError),
-}
-
-#[allow(dead_code)]
-#[derive(Debug, Error)]
-#[error(transparent)]
-pub struct Fatal(FatalInner);
-
-impl<E> From<E> for Fatal
-where
-    FatalInner: From<E>,
-{
-    fn from(err: E) -> Self {
-        Self(err.into())
     }
 }

--- a/lib/wallet/cusf_block_producer.rs
+++ b/lib/wallet/cusf_block_producer.rs
@@ -137,10 +137,6 @@ async fn sync_wallet_to_tip(
 impl CusfEnforcer for Wallet {
     type SyncError = error::InitialSync;
 
-    #[allow(
-        clippy::significant_drop_tightening,
-        reason = "false positive, sync_write is consumed by commit()"
-    )]
     #[instrument(skip_all, fields(tip_hash))]
     // TODO: this is confusing. This function is called multiple times? I want an easy
     // way to run a initial full scan after the validator has synced to the tip.

--- a/lib/wallet/error.rs
+++ b/lib/wallet/error.rs
@@ -23,7 +23,6 @@ use crate::{
 #[error("electrum error `{code}`: `{message}`")]
 pub struct Electrum {
     code: i32,
-    #[allow(unused_assignments)]
     message: String,
 }
 

--- a/lib/wallet/mod.rs
+++ b/lib/wallet/mod.rs
@@ -391,7 +391,6 @@ impl WalletInner {
     /// Warn if lock takes this long to acquire
     const LOCK_WARN_DURATION: Duration = Duration::from_secs(1);
 
-    #[allow(clippy::significant_drop_in_scrutinee, reason = "false positive")]
     async fn read_wallet(&self) -> Result<RwLockReadGuardSome<'_, BdkWallet>, error::NotUnlocked> {
         use futures::future::{Either, select};
         tracing::trace!("wallet: acquiring read lock");
@@ -414,7 +413,6 @@ impl WalletInner {
     }
 
     /// Obtain an upgradable read lock on the inner wallet
-    #[allow(clippy::significant_drop_in_scrutinee, reason = "false positive")]
     async fn read_wallet_upgradable(
         &self,
     ) -> Result<RwLockUpgradableReadGuardSome<'_, BdkWallet>, error::NotUnlocked> {
@@ -438,7 +436,6 @@ impl WalletInner {
         RwLockUpgradableReadGuardSome::new(read_guard).ok_or(error::NotUnlocked)
     }
 
-    #[allow(clippy::significant_drop_in_scrutinee, reason = "false positive")]
     async fn write_wallet(
         &self,
     ) -> Result<RwLockWriteGuardSome<'_, BdkWallet>, error::NotUnlocked> {
@@ -817,7 +814,6 @@ impl Wallet {
         }
     }
 
-    #[allow(clippy::result_large_err)]
     pub(crate) fn parse_checked_address(
         &self,
         address: &str,
@@ -1217,10 +1213,6 @@ impl Wallet {
         }
     }
 
-    #[allow(
-        clippy::significant_drop_tightening,
-        reason = "false positive for `bitcoin_wallet`"
-    )]
     async fn create_deposit_psbt(
         &self,
         op_drivechain_output: bdk_wallet::bitcoin::TxOut,
@@ -1437,7 +1429,7 @@ impl Wallet {
         Ok((balance, has_synced))
     }
 
-    #[allow(
+    #[expect(
         clippy::significant_drop_tightening,
         reason = "false positive for `bitcoin_wallet`"
     )]
@@ -1678,10 +1670,6 @@ impl Wallet {
             .collect()
     }
 
-    #[allow(
-        clippy::significant_drop_tightening,
-        reason = "false positive for `bitcoin_wallet`"
-    )]
     async fn create_send_psbt(
         &self,
         destinations: HashMap<bitcoin::Address, Amount>,
@@ -1844,7 +1832,7 @@ impl Wallet {
         Ok(convert::bdk_txid_to_bitcoin_txid(txid))
     }
 
-    #[allow(
+    #[expect(
         clippy::significant_drop_tightening,
         reason = "false positive for `bitcoin_wallet`"
     )]
@@ -1883,7 +1871,7 @@ impl Wallet {
         Ok(())
     }
 
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     async fn get_sidechain_ctip(
         &self,
         sidechain_number: SidechainNumber,
@@ -1957,10 +1945,6 @@ impl Wallet {
         )
     }
 
-    #[allow(
-        clippy::significant_drop_tightening,
-        reason = "false positive for `bitcoin_wallet`"
-    )]
     async fn build_bmm_tx(
         &self,
         sidechain_number: SidechainNumber,
@@ -2133,7 +2117,7 @@ impl Wallet {
         })
     }
 
-    #[allow(clippy::significant_drop_tightening)]
+    #[expect(clippy::significant_drop_tightening)]
     pub async fn get_new_address(
         &self,
     ) -> Result<bdk_wallet::bitcoin::Address, error::GetNewAddress> {

--- a/lib/wallet/sync.rs
+++ b/lib/wallet/sync.rs
@@ -115,7 +115,6 @@ impl WalletInner {
     /// Sync the wallet, returning a write guard on last_sync, wallet, and database
     /// if wallet was not locked.
     /// Does not commit changes.
-    #[allow(clippy::significant_drop_in_scrutinee, reason = "false positive")]
     pub(in crate::wallet) async fn sync_lock(
         &self,
     ) -> Result<Option<SyncWriteGuard<'_>>, error::WalletSync> {
@@ -259,7 +258,7 @@ impl WalletInner {
     }
 
     // TODO: is this actually correct? Need help from the Rust grownups!
-    #[allow(clippy::significant_drop_tightening, reason = "false positive")]
+    #[expect(clippy::significant_drop_tightening, reason = "false positive")]
     pub(in crate::wallet) async fn full_scan(
         &self,
     ) -> miette::Result<bdk_wallet::bitcoin::BlockHash, error::FullScan> {
@@ -388,7 +387,6 @@ impl WalletInner {
     }
 
     /// Sync the wallet if the wallet is not locked, committing changes
-    #[allow(clippy::significant_drop_in_scrutinee, reason = "false positive")]
     pub(in crate::wallet) async fn sync(&self) -> Result<(), error::WalletSync> {
         match self.sync_lock().await? {
             Some(sync_write) => {

--- a/lib/wallet/util.rs
+++ b/lib/wallet/util.rs
@@ -1,7 +1,7 @@
 //! Miscellaneous utility functions and types
 
-#[allow(clippy::mut_from_ref, reason = "False positive")]
-#[allow(clippy::significant_drop_tightening, reason = "False positive")]
+#[expect(clippy::mut_from_ref, reason = "False positive")]
+#[expect(clippy::significant_drop_tightening, reason = "False positive")]
 mod rwlock_write_guard_some {
     /// Write guard over values of `Option<T>` that are guaranteed to be `Some`
     #[ouroboros::self_referencing]
@@ -56,7 +56,7 @@ mod rwlock_write_guard_some {
 
 pub(in crate::wallet) use self::rwlock_write_guard_some::RwLockWriteGuardSome;
 
-#[allow(clippy::significant_drop_tightening, reason = "False positive")]
+#[expect(clippy::significant_drop_tightening, reason = "False positive")]
 mod rwlock_upgradable_read_guard_some {
     use async_lock::RwLockUpgradableReadGuard;
 
@@ -106,7 +106,7 @@ mod rwlock_upgradable_read_guard_some {
 
 pub(in crate::wallet) use self::rwlock_upgradable_read_guard_some::RwLockUpgradableReadGuardSome;
 
-#[allow(clippy::significant_drop_tightening, reason = "False positive")]
+#[expect(clippy::significant_drop_tightening, reason = "False positive")]
 mod rwlock_read_guard_some {
     use async_lock::RwLockReadGuard;
 


### PR DESCRIPTION
`expect` gives us an error if there actually wasn't any clippy issue being affected. Using `allow` leads to rot over time, where we have meaningless directives all over the code base.