### PR TITLE
validator: verify required M6 IDs, simplify integration tests

### DIFF
--- a/.github/workflows/check_lint_build_release.yaml
+++ b/.github/workflows/check_lint_build_release.yaml
@@ -154,6 +154,7 @@ jobs:
       format('Bitcoin Core {0}', matrix.version) }})
     needs: compute-integration-matrix
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.compute-integration-matrix.outputs.matrix) }}

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,5 @@ target
 
 # git submodule
 cusf_sidechain_proto
+
+.worktrees

--- a/integration_tests/integration_test.rs
+++ b/integration_tests/integration_test.rs
@@ -462,9 +462,9 @@ pub async fn withdraw_succeed(
         bitcoin::Amount::from_str_in(&receive_addr_balance_str, bitcoin::Denomination::Bitcoin)?;
     anyhow::ensure!(receive_addr_balance == bitcoin::Amount::ZERO);
     tracing::debug!("Mining blocks until withdrawal success");
-    let () = mine_check_block_events(post_setup, 7, Some(true), |seq, block_info| {
+    let () = mine_check_block_events(post_setup, 6, Some(true), |seq, block_info| {
         match (seq, block_info.events.as_slice()) {
-            (6, [event]) => {
+            (5, [event]) => {
                 let (event_m6id, event) = expect_withdrawal_bundle_event(event)?;
                 let withdrawal_bundle_event::event::Event::Succeeded(
                     withdrawal_bundle_event::event::Succeeded {
@@ -478,11 +478,10 @@ pub async fn withdraw_succeed(
                 anyhow::ensure!(*event_m6id == ConsensusHex::encode(&m6id.0));
                 Ok(())
             }
-            (6, events) => {
-                anyhow::bail!("Expected withdrawal bundle success event, found `{events:?}`")
-            }
             (_, []) => Ok(()),
-            (_, events) => anyhow::bail!("Expected no events, found `{events:?}`"),
+            (seq, events) => {
+                anyhow::bail!("Unexpected events at seq {seq}: `{events:?}`")
+            }
         }
     })
     .await?;
@@ -660,6 +659,21 @@ pub fn tests(
             failure_collector: failure_collector.clone(),
         },
         crate::test_invalid_block::test_invalid_block,
+    ));
+
+    // needs enforcer-driven mining to inject M3 + M4 upvotes for setup,
+    // so this trial runs under `Mode::Mempool` (separate from the case-table
+    // `invalid_block` trial above, which is stateless and uses NoMempool).
+    async_trials.push(new_trial_with_setup(
+        "block_missing_required_m6".to_string(),
+        TestSetupComponents {
+            bin_paths: bin_paths.clone(),
+            network: Network::Regtest,
+            mode: Mode::Mempool,
+            file_registry: file_registry.clone(),
+            failure_collector: failure_collector.clone(),
+        },
+        crate::test_invalid_block::test_block_missing_required_m6,
     ));
 
     async_trials

--- a/integration_tests/integration_test.rs
+++ b/integration_tests/integration_test.rs
@@ -20,9 +20,7 @@ use tracing::Instrument as _;
 
 use crate::{
     mine::{mine, mine_check_block_events, mine_signet_check},
-    setup::{
-        Directories, DummySidechain, MiningMode, Mode, Network, PostSetup, PreSetup, Sidechain,
-    },
+    setup::{Directories, DummySidechain, MiningMode, Mode, Network, PostSetup, PreSetup},
     test_peer_bmm_request, test_unconfirmed_transactions,
     util::{AsyncTrial, BinPaths, FileDumpConfig, TestFailureCollector, TestFileRegistry},
 };
@@ -133,10 +131,7 @@ where
     )
 }
 
-pub async fn propose_sidechain<S>(post_setup: &mut PostSetup) -> anyhow::Result<()>
-where
-    S: Sidechain,
-{
+pub async fn propose_sidechain(post_setup: &mut PostSetup) -> anyhow::Result<()> {
     tracing::info!("Proposing sidechain");
     let create_sidechain_proposal_request = {
         let sidechain_declaration =
@@ -152,7 +147,7 @@ where
             sidechain_declaration: Some(sidechain_declaration),
         };
         CreateSidechainProposalRequest {
-            sidechain_id: Some(S::SIDECHAIN_NUMBER.0.into()),
+            sidechain_id: Some(DummySidechain::SIDECHAIN_NUMBER.0.into()),
             declaration: Some(declaration),
         }
     };
@@ -164,7 +159,7 @@ where
     // Wait before mining
     sleep(std::time::Duration::from_secs(1)).await;
     tracing::debug!("Mining 1 block");
-    let () = mine::<S>(post_setup, 1, Some(true)).await?;
+    let () = mine(post_setup, 1, Some(true)).await?;
     let Some(_) = create_sidechain_proposal_resp.try_next().await? else {
         anyhow::bail!("Expected response when proposing sidechain");
     };
@@ -181,10 +176,7 @@ where
     Ok(())
 }
 
-pub async fn activate_sidechain<S>(post_setup: &mut PostSetup) -> anyhow::Result<()>
-where
-    S: Sidechain,
-{
+pub async fn activate_sidechain(post_setup: &mut PostSetup) -> anyhow::Result<()> {
     tracing::info!("Activating sidechain");
     tracing::debug!("Checking that 0 sidechains are active");
     let sidechains_resp = post_setup
@@ -197,8 +189,7 @@ where
     };
     let blocks_to_mine = 6;
     tracing::debug!("Mining {blocks_to_mine} blocks");
-    let _ = mine_check_block_events::<_, S>(post_setup, blocks_to_mine, Some(true), |_, _| Ok(()))
-        .await?;
+    let _ = mine_check_block_events(post_setup, blocks_to_mine, Some(true), |_, _| Ok(())).await?;
     tracing::debug!("Checking that exactly 1 sidechain is active");
     let sidechains_resp = post_setup
         .validator_service_client
@@ -232,10 +223,7 @@ pub async fn wait_for_wallet_sync() -> anyhow::Result<()> {
     Ok(())
 }
 
-pub async fn fund_enforcer<S>(post_setup: &mut PostSetup) -> anyhow::Result<()>
-where
-    S: Sidechain,
-{
+pub async fn fund_enforcer(post_setup: &mut PostSetup) -> anyhow::Result<()> {
     use std::convert::Infallible;
     const BLOCKS: u32 = 100;
     let progress_bar = indicatif::ProgressBar::new(BLOCKS as u64).with_style(
@@ -262,7 +250,7 @@ where
                 .await?;
         }
         Network::Signet => {
-            mine_signet_check::<_, Infallible, S>(post_setup, BLOCKS, |_| {
+            mine_signet_check::<_, Infallible>(post_setup, BLOCKS, |_| {
                 progress_bar.inc(1);
                 Ok(())
             })
@@ -274,19 +262,26 @@ where
     Ok(())
 }
 
+/// Propose a sidechain via M1, ack it over `USED_SIDECHAIN_SLOT_ACTIVATION_THRESHOLD`
+/// blocks until activation, then top up the enforcer wallet with UTXOs to mine
+/// with. The standard prelude for tests that need an active sidechain.
+pub async fn setup_active_sidechain(post_setup: &mut PostSetup) -> anyhow::Result<()> {
+    propose_sidechain(post_setup).await?;
+    activate_sidechain(post_setup).await?;
+    fund_enforcer(post_setup).await?;
+    Ok(())
+}
+
 const DEPOSIT_AMOUNT: bitcoin::Amount = bitcoin::Amount::from_sat(21_000_000);
 const DEPOSIT_FEE: bitcoin::Amount = bitcoin::Amount::from_sat(1_000_000);
 
-pub async fn deposit<S>(
+pub async fn deposit(
     post_setup: &mut PostSetup,
-    sidechain: &mut S,
+    sidechain: &mut DummySidechain,
     sidechain_address: &str,
     deposit_amount: bitcoin::Amount,
     deposit_fee: bitcoin::Amount,
-) -> anyhow::Result<()>
-where
-    S: Sidechain,
-{
+) -> anyhow::Result<()> {
     tracing::info!(
         deposit_amount = %deposit_amount.display_dynamic(),
         deposit_fee = %deposit_fee.display_dynamic(),
@@ -295,7 +290,7 @@ where
     let deposit_txid: bitcoin::Txid = post_setup
         .wallet_service_client
         .create_deposit_transaction(CreateDepositTransactionRequest {
-            sidechain_id: Some(S::SIDECHAIN_NUMBER.0.into()),
+            sidechain_id: Some(DummySidechain::SIDECHAIN_NUMBER.0.into()),
             address: Some(sidechain_address.to_owned()),
             value_sats: Some(deposit_amount.to_sat()),
             fee_sats: Some(deposit_fee.to_sat()),
@@ -309,21 +304,18 @@ where
     // Wait for deposit tx to enter mempool
     sleep(std::time::Duration::from_secs(1)).await;
     tracing::debug!("Mining 1 sidechain block");
-    let () = mine_check_block_events::<_, S>(post_setup, 1, None, |_, block_info| match block_info
-        .events
-        .as_slice()
-    {
-        [
-            block_info::Event {
-                event: Some(block_info::event::Event::Deposit(_)),
-            },
-        ] => Ok(()),
-        events => anyhow::bail!("Expected deposit event, found `{events:?}`"),
+    let () = mine_check_block_events(post_setup, 1, None, |_, block_info| {
+        match block_info.events.as_slice() {
+            [
+                block_info::Event {
+                    event: Some(block_info::event::Event::Deposit(_)),
+                },
+            ] => Ok(()),
+            events => anyhow::bail!("Expected deposit event, found `{events:?}`"),
+        }
     })
     .await?;
-    let () = sidechain
-        .confirm_deposit(post_setup, sidechain_address, deposit_amount, deposit_txid)
-        .await?;
+    sidechain.confirm_deposit(post_setup, sidechain_address, deposit_amount, deposit_txid);
     Ok(())
 }
 
@@ -354,15 +346,12 @@ const WITHDRAW_AMOUNT_1: Amount = Amount::from_sat(18_000_000);
 const WITHDRAW_FEE_1: Amount = Amount::from_sat(1_000_000);
 
 // Create a withdrawal, and let it expire
-async fn withdraw_expire<S>(
+async fn withdraw_expire(
     post_setup: &mut PostSetup,
-    sidechain: &mut S,
+    sidechain: &mut DummySidechain,
     withdraw_amount: Amount,
     withdraw_fee: Amount,
-) -> anyhow::Result<()>
-where
-    S: Sidechain,
-{
+) -> anyhow::Result<()> {
     tracing::info!(
         value = %withdraw_amount.display_dynamic(),
         fee = %withdraw_fee.display_dynamic(),
@@ -378,28 +367,27 @@ where
         )
         .await?;
     tracing::debug!("Mining 1 block to include M3 for withdrawal bundle");
-    let () = mine_check_block_events::<_, S>(post_setup, 1, None, |_, block_info| match block_info
-        .events
-        .as_slice()
-    {
-        [event] => {
-            let (event_m6id, event) = expect_withdrawal_bundle_event(event)?;
-            let withdrawal_bundle_event::event::Event::Submitted(
-                withdrawal_bundle_event::event::Submitted {},
-            ) = event
-            else {
-                anyhow::bail!("Expected withdrawal bundle submitted event, found `{event:?}`")
-            };
-            anyhow::ensure!(*event_m6id == ConsensusHex::encode(&m6id.0));
-            Ok(())
-        }
-        events => {
-            anyhow::bail!("Expected withdrawal bundle submitted event, found `{events:?}`")
+    let () = mine_check_block_events(post_setup, 1, None, |_, block_info| {
+        match block_info.events.as_slice() {
+            [event] => {
+                let (event_m6id, event) = expect_withdrawal_bundle_event(event)?;
+                let withdrawal_bundle_event::event::Event::Submitted(
+                    withdrawal_bundle_event::event::Submitted {},
+                ) = event
+                else {
+                    anyhow::bail!("Expected withdrawal bundle submitted event, found `{event:?}`")
+                };
+                anyhow::ensure!(*event_m6id == ConsensusHex::encode(&m6id.0));
+                Ok(())
+            }
+            events => {
+                anyhow::bail!("Expected withdrawal bundle submitted event, found `{events:?}`")
+            }
         }
     })
     .await?;
     tracing::debug!("Mining blocks until withdrawal bundle failure due to expiry");
-    let () = mine_check_block_events::<_, S>(post_setup, 11, None, |seq, block_info| {
+    let () = mine_check_block_events(post_setup, 11, None, |seq, block_info| {
         match (seq, block_info.events.as_slice()) {
             (10, [event]) => {
                 let (event_m6id, event) = expect_withdrawal_bundle_event(event)?;
@@ -424,16 +412,13 @@ where
 }
 
 // Upvote the next withdrawal bundle so that it succeeds
-pub async fn withdraw_succeed<S>(
+pub async fn withdraw_succeed(
     post_setup: &mut PostSetup,
-    sidechain: &mut S,
+    sidechain: &mut DummySidechain,
     withdraw_amount: Amount,
     withdraw_fee: Amount,
     pending_withdrawal_value: Amount,
-) -> anyhow::Result<()>
-where
-    S: Sidechain,
-{
+) -> anyhow::Result<()> {
     tracing::info!(
         value = %withdraw_amount.display_dynamic(),
         fee = %withdraw_fee.display_dynamic(),
@@ -444,23 +429,22 @@ where
         .create_withdrawal(post_setup, &receive_address, withdraw_amount, withdraw_fee)
         .await?;
     tracing::debug!("Mining 1 block to include M3 for withdrawal bundle");
-    let () = mine_check_block_events::<_, S>(post_setup, 1, None, |_, block_info| match block_info
-        .events
-        .as_slice()
-    {
-        [event] => {
-            let (event_m6id, event) = expect_withdrawal_bundle_event(event)?;
-            let withdrawal_bundle_event::event::Event::Submitted(
-                withdrawal_bundle_event::event::Submitted {},
-            ) = event
-            else {
-                anyhow::bail!("Expected withdrawal bundle submitted event, found `{event:?}`")
-            };
-            anyhow::ensure!(*event_m6id == ConsensusHex::encode(&m6id.0));
-            Ok(())
-        }
-        events => {
-            anyhow::bail!("Expected withdrawal bundle submitted event, found `{events:?}`")
+    let () = mine_check_block_events(post_setup, 1, None, |_, block_info| {
+        match block_info.events.as_slice() {
+            [event] => {
+                let (event_m6id, event) = expect_withdrawal_bundle_event(event)?;
+                let withdrawal_bundle_event::event::Event::Submitted(
+                    withdrawal_bundle_event::event::Submitted {},
+                ) = event
+                else {
+                    anyhow::bail!("Expected withdrawal bundle submitted event, found `{event:?}`")
+                };
+                anyhow::ensure!(*event_m6id == ConsensusHex::encode(&m6id.0));
+                Ok(())
+            }
+            events => {
+                anyhow::bail!("Expected withdrawal bundle submitted event, found `{events:?}`")
+            }
         }
     })
     .await?;
@@ -478,7 +462,7 @@ where
         bitcoin::Amount::from_str_in(&receive_addr_balance_str, bitcoin::Denomination::Bitcoin)?;
     anyhow::ensure!(receive_addr_balance == bitcoin::Amount::ZERO);
     tracing::debug!("Mining blocks until withdrawal success");
-    let () = mine_check_block_events::<_, S>(post_setup, 7, Some(true), |seq, block_info| {
+    let () = mine_check_block_events(post_setup, 7, Some(true), |seq, block_info| {
         match (seq, block_info.events.as_slice()) {
             (6, [event]) => {
                 let (event_m6id, event) = expect_withdrawal_bundle_event(event)?;
@@ -522,23 +506,14 @@ where
     Ok(())
 }
 
-pub async fn deposit_withdraw_roundtrip_task<S>(
+pub async fn deposit_withdraw_roundtrip_task(
     post_setup: &mut PostSetup,
-    res_tx: mpsc::UnboundedSender<anyhow::Result<()>>,
-    sidechain_init: S::Init,
-) -> anyhow::Result<S>
-where
-    S: Sidechain,
-{
-    let mut sidechain = S::setup(sidechain_init, post_setup, res_tx).await?;
+) -> anyhow::Result<DummySidechain> {
+    let mut sidechain = DummySidechain::setup(post_setup).await?;
     tracing::info!("Setup successfully");
-    let () = propose_sidechain::<S>(post_setup).await?;
-    tracing::info!("Proposed sidechain successfully");
-    let () = activate_sidechain::<S>(post_setup).await?;
-    tracing::info!("Activated sidechain successfully");
-    let () = fund_enforcer::<S>(post_setup).await?;
-    tracing::info!("Funded enforcer successfully");
-    let deposit_address = sidechain.get_deposit_address().await?;
+    let () = setup_active_sidechain(post_setup).await?;
+    tracing::info!("Active sidechain set up successfully");
+    let deposit_address = sidechain.get_deposit_address();
     let () = deposit(
         post_setup,
         &mut sidechain,
@@ -592,17 +567,8 @@ where
 /// * Creates two deposits
 /// * If mode is not GBT, creates a withdrawal that will be allowed to expire
 /// * Creates and handles a withdrawal
-pub async fn deposit_withdraw_roundtrip<S>(
-    mut post_setup: PostSetup,
-    sidechain_init: S::Init,
-) -> anyhow::Result<()>
-where
-    S: Sidechain + Send,
-    S::Init: Send + 'static,
-{
-    let (res_tx, _) = mpsc::unbounded();
-    let _sidechain: S =
-        deposit_withdraw_roundtrip_task::<S>(&mut post_setup, res_tx, sidechain_init).await?;
+pub async fn deposit_withdraw_roundtrip(mut post_setup: PostSetup) -> anyhow::Result<()> {
+    let _sidechain = deposit_withdraw_roundtrip_task(&mut post_setup).await?;
     Ok(())
 }
 
@@ -628,7 +594,7 @@ pub fn tests(
                 file_registry: file_registry.clone(),
                 failure_collector: failure_collector.clone(),
             },
-            |post_setup| deposit_withdraw_roundtrip::<DummySidechain>(post_setup, ()),
+            deposit_withdraw_roundtrip,
         )
     });
 

--- a/integration_tests/main.rs
+++ b/integration_tests/main.rs
@@ -133,7 +133,20 @@ async fn run() -> anyhow::Result<std::process::ExitCode> {
     );
 
     // Run all tests and collect the exit code
-    let exit_code = libtest_mimic::run(&args.test_args, tests).exit_code();
+    let filter_provided = args.test_args.filter.is_some();
+    let conclusion = libtest_mimic::run(&args.test_args, tests);
+    let nothing_ran = conclusion.num_passed
+        + conclusion.num_failed
+        + conclusion.num_ignored
+        + conclusion.num_measured
+        == 0;
+    if filter_provided && nothing_ran {
+        anyhow::bail!(
+            "no integration test matched the provided filter `{}`",
+            args.test_args.filter.as_deref().unwrap_or("")
+        );
+    }
+    let exit_code = conclusion.exit_code();
 
     // Display all collected failures at the end
     failure_collector.display_all_failures();

--- a/integration_tests/mine.rs
+++ b/integration_tests/mine.rs
@@ -19,7 +19,7 @@ use futures::TryStreamExt as _;
 use thiserror::Error;
 
 use crate::{
-    setup::{MiningMode, Network, PostSetup, Sidechain},
+    setup::{DummySidechain, MiningMode, Network, PostSetup},
     util::VarError,
 };
 
@@ -149,14 +149,13 @@ pub enum MineSignetError {
 }
 
 // Mine blocks, running a check after each block
-pub async fn mine_signet_check<F, Err, S>(
+pub async fn mine_signet_check<F, Err>(
     post_setup: &mut PostSetup,
     blocks: u32,
     mut check: F,
 ) -> Result<(), Either<MineSignetError, Err>>
 where
     F: FnMut(bitcoin::BlockHash) -> Result<(), Err>,
-    S: Sidechain,
 {
     use proto::mainchain::subscribe_events_response::event::Event;
     let signet_miner = post_setup
@@ -166,7 +165,7 @@ where
     let mut stream = post_setup
         .validator_service_client
         .subscribe_events(SubscribeEventsRequest {
-            sidechain_id: Some(S::SIDECHAIN_NUMBER.0.into()),
+            sidechain_id: Some(DummySidechain::SIDECHAIN_NUMBER.0.into()),
         })
         .await
         .map_err(|err| Either::Left(err.into()))?
@@ -212,20 +211,19 @@ where
 }
 
 // Mine blocks, running a check after each block
-pub async fn mine_gbt_check<F, Err, S>(
+pub async fn mine_gbt_check<F, Err>(
     post_setup: &mut PostSetup,
     blocks: u32,
     mut check: F,
 ) -> Result<(), Either<MineGbtError, Err>>
 where
     F: FnMut(bitcoin::BlockHash) -> Result<(), Err>,
-    S: Sidechain,
 {
     use proto::mainchain::subscribe_events_response::event::Event;
     let mut stream = post_setup
         .validator_service_client
         .subscribe_events(SubscribeEventsRequest {
-            sidechain_id: Some(S::SIDECHAIN_NUMBER.0.into()),
+            sidechain_id: Some(DummySidechain::SIDECHAIN_NUMBER.0.into()),
         })
         .await
         .map_err(|err| Either::Left(err.into()))?
@@ -312,14 +310,11 @@ pub enum MineError {
     SignetGenerateBlocks,
 }
 
-pub async fn mine<S>(
+pub async fn mine(
     post_setup: &mut PostSetup,
     blocks: u32,
     ack_all_proposals: Option<bool>,
-) -> Result<(), MineError>
-where
-    S: Sidechain,
-{
+) -> Result<(), MineError> {
     use std::convert::Infallible;
     match (post_setup.network, post_setup.mode.mining_mode()) {
         (Network::Regtest, MiningMode::GenerateBlocks) => {
@@ -332,14 +327,14 @@ where
             })
         }
         (Network::Regtest, MiningMode::GetBlockTemplate) => {
-            mine_gbt_check::<_, Infallible, S>(post_setup, blocks, |_| Ok(()))
+            mine_gbt_check::<_, Infallible>(post_setup, blocks, |_| Ok(()))
                 .await
                 .map_err(|err| match err {
                     Either::Left(err) => MineError::Gbt(err),
                 })
         }
         (Network::Signet, MiningMode::GetBlockTemplate) => {
-            mine_signet_check::<_, Infallible, S>(post_setup, blocks, |_| Ok(()))
+            mine_signet_check::<_, Infallible>(post_setup, blocks, |_| Ok(()))
                 .await
                 .map_err(|err| match err {
                     Either::Left(err) => MineError::Signet(err),
@@ -350,7 +345,7 @@ where
 }
 
 /// Mine blocks, and check the events for each block
-pub async fn mine_check_block_events<F, S>(
+pub async fn mine_check_block_events<F>(
     post_setup: &mut PostSetup,
     blocks: u32,
     ack_all_proposals: Option<bool>,
@@ -358,18 +353,17 @@ pub async fn mine_check_block_events<F, S>(
 ) -> anyhow::Result<()>
 where
     F: FnMut(u32, proto::mainchain::BlockInfo) -> anyhow::Result<()>,
-    S: Sidechain,
 {
     tracing::debug!("Mining {blocks} block(s)");
     let mut events = post_setup
         .validator_service_client
         .subscribe_events(SubscribeEventsRequest {
-            sidechain_id: Some(S::SIDECHAIN_NUMBER.0.into()),
+            sidechain_id: Some(DummySidechain::SIDECHAIN_NUMBER.0.into()),
         })
         .await?
         .into_inner();
     for blocks_mined in 0..blocks {
-        let () = mine::<S>(post_setup, 1, ack_all_proposals).await?;
+        let () = mine(post_setup, 1, ack_all_proposals).await?;
         let Some(event) = events
             .try_next()
             .await?

--- a/integration_tests/setup.rs
+++ b/integration_tests/setup.rs
@@ -331,6 +331,33 @@ pub async fn wait_for_port(
     }
 }
 
+/// Polls bitcoind via `getblockchaininfo` until it responds successfully.
+/// The RPC port opens before bitcoind is ready to serve commands, so a TCP
+/// probe alone is not enough.
+async fn wait_for_bitcoind_ready(bitcoin_cli: &bins::BitcoinCli) -> anyhow::Result<()> {
+    const TIMEOUT: Duration = Duration::from_secs(30);
+    const CHECK_INTERVAL: Duration = Duration::from_millis(200);
+    let task = async {
+        loop {
+            match bitcoin_cli
+                .clone()
+                .command::<String, _, String, _, _>([], "getblockchaininfo", [])
+                .run_utf8()
+                .await
+            {
+                Ok(_) => return,
+                Err(e) => {
+                    tracing::trace!("bitcoind not ready yet ({e}), waiting...");
+                    sleep(CHECK_INTERVAL).await;
+                }
+            }
+        }
+    };
+    timeout(TIMEOUT, task)
+        .await
+        .map_err(|_| anyhow!("Timeout waiting for bitcoind to become ready after {TIMEOUT:?}"))
+}
+
 /// Running tasks, aborted on drop
 pub struct Tasks {
     // MUST be dropped before electrs and bitcoind
@@ -477,9 +504,10 @@ impl PostSetup {
                 }
             });
         // wait for startup
-        sleep(std::time::Duration::from_secs(1)).await;
-        // Create a wallet and initialize it
         let mut bitcoin_cli = bitcoind.new_bitcoin_cli(bin_paths.bitcoin_cli()?.clone());
+        wait_for_bitcoind_ready(&bitcoin_cli).await?;
+
+        // Create a wallet and initialize it
         tracing::debug!("Creating wallet");
         let _create_wallet_output = bitcoin_cli
             .command::<String, _, _, _, _>([], "createwallet", ["integration-test"])

--- a/integration_tests/setup.rs
+++ b/integration_tests/setup.rs
@@ -4,7 +4,6 @@ use std::{
     borrow::Borrow,
     collections::HashMap,
     ffi::OsStr,
-    future::Future,
     net::SocketAddr,
     path::PathBuf,
     sync::{Arc, LazyLock},
@@ -24,7 +23,7 @@ use bip300301_enforcer_lib::{
     types::{BlindedM6, BlindedM6Error, M6id, SidechainNumber},
 };
 use bitcoin::{Address, Txid};
-use futures::{FutureExt as _, StreamExt, channel::mpsc, future};
+use futures::{FutureExt as _, StreamExt, channel::mpsc};
 use reserve_port::ReservedPort;
 use temp_dir::TempDir;
 use thiserror::Error;
@@ -707,48 +706,6 @@ impl<B> PreSetup<B> {
     }
 }
 
-pub trait Sidechain: Sized {
-    const SIDECHAIN_NUMBER: SidechainNumber;
-
-    type Init;
-
-    type SetupError: std::error::Error + Send + Sync + 'static;
-
-    fn setup(
-        init: Self::Init,
-        post_setup: &PostSetup,
-        res_tx: mpsc::UnboundedSender<anyhow::Result<()>>,
-    ) -> impl Future<Output = Result<Self, Self::SetupError>> + Send;
-
-    type GetDepositAddressError: std::error::Error + Send + Sync + 'static;
-
-    /// Get a sidechain address to deposit to
-    fn get_deposit_address(
-        &self,
-    ) -> impl Future<Output = Result<String, Self::GetDepositAddressError>> + Send;
-
-    type ConfirmDepositError: std::error::Error + Send + Sync + 'static;
-
-    fn confirm_deposit(
-        &mut self,
-        post_setup: &mut PostSetup,
-        address: &str,
-        value: bitcoin::Amount,
-        txid: bitcoin::Txid,
-    ) -> impl Future<Output = Result<(), Self::ConfirmDepositError>> + Send;
-
-    /// Create a withdrawal and broadcast the bundle
-    type CreateWithdrawalError: std::error::Error + Send + Sync + 'static;
-
-    fn create_withdrawal(
-        &mut self,
-        post_setup: &mut PostSetup,
-        receive_address: &bitcoin::Address,
-        value: bitcoin::Amount,
-        fee: bitcoin::Amount,
-    ) -> impl Future<Output = Result<M6id, Self::CreateWithdrawalError>> + Send;
-}
-
 #[derive(Debug, Error)]
 pub enum DummySidechainError {
     #[error(transparent)]
@@ -924,18 +881,10 @@ impl DummySidechain {
     }
 }
 
-impl Sidechain for DummySidechain {
-    const SIDECHAIN_NUMBER: SidechainNumber = SidechainNumber(0);
+impl DummySidechain {
+    pub const SIDECHAIN_NUMBER: SidechainNumber = SidechainNumber(0);
 
-    type Init = ();
-
-    type SetupError = tonic::Status;
-
-    async fn setup(
-        _: Self::Init,
-        post_setup: &PostSetup,
-        _: mpsc::UnboundedSender<anyhow::Result<()>>,
-    ) -> Result<Self, Self::SetupError> {
+    pub async fn setup(post_setup: &PostSetup) -> Result<Self, tonic::Status> {
         use bip300301_enforcer_lib::proto::mainchain::SubscribeEventsRequest;
         let subscribe_events_request = SubscribeEventsRequest {
             sidechain_id: Some(Self::SIDECHAIN_NUMBER.0.into()),
@@ -954,35 +903,26 @@ impl Sidechain for DummySidechain {
         })
     }
 
-    type GetDepositAddressError = std::convert::Infallible;
-
-    fn get_deposit_address(
-        &self,
-    ) -> impl Future<Output = Result<String, Self::GetDepositAddressError>> + Send {
-        future::ok("sidechain address".to_owned())
+    pub fn get_deposit_address(&self) -> String {
+        "sidechain address".to_owned()
     }
 
-    type ConfirmDepositError = std::convert::Infallible;
-
-    async fn confirm_deposit(
+    pub fn confirm_deposit(
         &mut self,
-        _: &mut PostSetup,
-        _: &str,
-        _: bitcoin::Amount,
-        _: bitcoin::Txid,
-    ) -> Result<(), Self::ConfirmDepositError> {
-        Ok(())
+        _post_setup: &mut PostSetup,
+        _address: &str,
+        _value: bitcoin::Amount,
+        _txid: bitcoin::Txid,
+    ) {
     }
 
-    type CreateWithdrawalError = DummySidechainError;
-
-    async fn create_withdrawal(
+    pub async fn create_withdrawal(
         &mut self,
         post_setup: &mut PostSetup,
         receive_address: &bitcoin::Address,
         mut value: bitcoin::Amount,
         mut fee: bitcoin::Amount,
-    ) -> Result<M6id, Self::CreateWithdrawalError> {
+    ) -> Result<M6id, DummySidechainError> {
         let () = self.update_from_events()?;
         value += self.pending_withdrawal_value;
         self.pending_withdrawal_value = bitcoin::Amount::ZERO;

--- a/integration_tests/test_invalid_block.rs
+++ b/integration_tests/test_invalid_block.rs
@@ -14,13 +14,12 @@ use bitcoin::{
     script::{Builder as ScriptBuilder, PushBytesBuf},
     transaction::Version,
 };
-use futures::channel::mpsc;
 use serde::Deserialize;
 use tokio::time::sleep;
 
 use crate::{
-    integration_test::{activate_sidechain, fund_enforcer, propose_sidechain},
-    setup::{DummySidechain, PostSetup, Sidechain},
+    integration_test::setup_active_sidechain,
+    setup::{DummySidechain, PostSetup},
 };
 
 struct BadBlockCase {
@@ -107,12 +106,9 @@ fn duplicate_m7_outputs() -> anyhow::Result<Vec<TxOut>> {
 }
 
 pub async fn test_invalid_block(mut post_setup: PostSetup) -> anyhow::Result<()> {
-    let (sidechain_res_tx, _sidechain_res_rx) = mpsc::unbounded();
-    let mut _sidechain = DummySidechain::setup((), &post_setup, sidechain_res_tx).await?;
+    let _sidechain = DummySidechain::setup(&post_setup).await?;
 
-    propose_sidechain::<DummySidechain>(&mut post_setup).await?;
-    activate_sidechain::<DummySidechain>(&mut post_setup).await?;
-    fund_enforcer::<DummySidechain>(&mut post_setup).await?;
+    setup_active_sidechain(&mut post_setup).await?;
     wait_past_mtp(&post_setup).await?;
 
     let stdout_path = post_setup.directories.enforcer_dir.join("stdout.txt");

--- a/integration_tests/test_invalid_block.rs
+++ b/integration_tests/test_invalid_block.rs
@@ -3,7 +3,7 @@ use std::{path::Path, time::Duration};
 use bip300301_enforcer_lib::{
     bins::CommandExt as _,
     messages::{M1ProposeSidechain, M2AckSidechain, M4AckBundles, M7BmmAccept},
-    types::{BmmCommitment, SidechainDescription},
+    types::{BmmCommitment, SidechainDescription, WITHDRAWAL_BUNDLE_INCLUSION_THRESHOLD},
 };
 use bitcoin::{
     Amount, Block, BlockHash, CompactTarget, OutPoint, ScriptBuf, Sequence, Transaction, TxIn,
@@ -18,7 +18,8 @@ use serde::Deserialize;
 use tokio::time::sleep;
 
 use crate::{
-    integration_test::setup_active_sidechain,
+    integration_test::{deposit, setup_active_sidechain},
+    mine::mine_check_block_events,
     setup::{DummySidechain, PostSetup},
 };
 
@@ -164,6 +165,16 @@ async fn submit_invalid_block(
     post_setup: &PostSetup,
     case: &BadBlockCase,
 ) -> anyhow::Result<BlockHash> {
+    submit_block_with_extra_coinbase_outputs(post_setup, (case.extra_coinbase_outputs)()?).await
+}
+
+/// Submit a block with `extra_outputs` appended to the coinbase, after the
+/// standard reward + witness-commitment outputs. Bypasses the enforcer's
+/// mining proxy by talking to bitcoind directly via `submitblock`.
+async fn submit_block_with_extra_coinbase_outputs(
+    post_setup: &PostSetup,
+    extra_outputs: Vec<TxOut>,
+) -> anyhow::Result<BlockHash> {
     let template_json = post_setup
         .bitcoin_cli
         .command::<String, _, _, _, _>([], "getblocktemplate", [r#"{"rules":["segwit"]}"#])
@@ -209,7 +220,7 @@ async fn submit_invalid_block(
             value: Amount::ZERO,
         },
     ];
-    outputs.extend((case.extra_coinbase_outputs)()?);
+    outputs.extend(extra_outputs);
     let coinbase = Transaction {
         version: Version::TWO,
         lock_time: bitcoin::locktime::absolute::LockTime::ZERO,
@@ -335,4 +346,79 @@ async fn poll_until_chaintip_invalid(
             _ => sleep(Duration::from_millis(200)).await,
         }
     }
+}
+
+/// BIP300 M4: once an `M6ID`'s vote count exceeds
+/// `WITHDRAWAL_BUNDLE_INCLUSION_THRESHOLD`, the block that pushes it over
+/// MUST include the corresponding M6 — otherwise the block is invalid.
+///
+/// This test drives the enforcer to vote_count == THRESHOLD (= 5 in this
+/// codebase), then hand-submits a block via `submitblock` that contains
+/// the next M4 OneByte upvote (which would push vote_count to 6) but
+/// omits the M6 from txdata. The enforcer must reject the block.
+pub async fn test_block_missing_required_m6(mut post_setup: PostSetup) -> anyhow::Result<()> {
+    let mut sidechain = DummySidechain::setup(&post_setup).await?;
+
+    setup_active_sidechain(&mut post_setup).await?;
+
+    // Treasury needs funds before a withdrawal bundle can be proposed.
+    let deposit_address = sidechain.get_deposit_address();
+    deposit(
+        &mut post_setup,
+        &mut sidechain,
+        &deposit_address,
+        Amount::from_btc(1.0)?,
+        Amount::from_sat(1_000),
+    )
+    .await?;
+
+    // Submit a withdrawal via the enforcer; M3 will be injected into the
+    // next coinbase mined through the enforcer's proxy.
+    let receive_address = post_setup.receive_address.clone();
+    let _m6id = sidechain
+        .create_withdrawal(
+            &mut post_setup,
+            &receive_address,
+            Amount::from_btc(0.5)?,
+            Amount::from_sat(1_000),
+        )
+        .await?;
+
+    // Block N: enforcer mines M3 (vote_count = 0 after this block).
+    mine_check_block_events(&mut post_setup, 1, None, |_, _| Ok(())).await?;
+    // Blocks N+1..N+5: enforcer mines 5 M4 OneByte upvotes for the pending
+    // bundle, bringing vote_count to THRESHOLD (5). The *next* upvote would
+    // push it past THRESHOLD and is the one that must be paired with M6.
+    mine_check_block_events(
+        &mut post_setup,
+        u32::from(WITHDRAWAL_BUNDLE_INCLUSION_THRESHOLD),
+        Some(true),
+        |_, _| Ok(()),
+    )
+    .await?;
+
+    wait_past_mtp(&post_setup).await?;
+
+    // Hand-craft the offending block: a single M4 OneByte upvote at index 0
+    // (chronologically-first pending M6ID for this sidechain), with no M6
+    // in txdata. Must be rejected.
+    let extra_outputs = vec![zero_value(
+        M4AckBundles::OneByte {
+            upvotes: vec![0x00],
+        }
+        .try_into()?,
+    )];
+    let bad_block_hash =
+        submit_block_with_extra_coinbase_outputs(&post_setup, extra_outputs).await?;
+    tracing::info!(%bad_block_hash, "submitted missing-M6 block");
+
+    poll_until_chaintip_invalid(&post_setup, bad_block_hash, Duration::from_secs(10)).await?;
+
+    let stdout_path = post_setup.directories.enforcer_dir.join("stdout.txt");
+    let stdout = std::fs::read_to_string(&stdout_path)?;
+    anyhow::ensure!(
+        stdout.contains("MissingRequiredM6") || stdout.contains("missing required M6"),
+        "enforcer log did not contain expected must-include-M6 rejection message"
+    );
+    Ok(())
 }

--- a/integration_tests/test_peer_bmm_request.rs
+++ b/integration_tests/test_peer_bmm_request.rs
@@ -15,9 +15,9 @@ use tokio::time::sleep;
 use tracing::Instrument as _;
 
 use crate::{
-    integration_test::{activate_sidechain, fund_enforcer, propose_sidechain},
+    integration_test::setup_active_sidechain,
     mine,
-    setup::{BitcoindKind, DummySidechain, Mode, Network, SetupOpts, Sidechain},
+    setup::{BitcoindKind, DummySidechain, Mode, Network, SetupOpts},
     util::{self, BinPaths, FileDumpConfig, TestFileRegistry},
 };
 
@@ -146,12 +146,8 @@ impl PreSetup {
 
 async fn test_peer_bmm_request_task(mut post_setup: PostSetup) -> anyhow::Result<()> {
     tracing::info!("Setup successfully");
-    let () = propose_sidechain::<DummySidechain>(&mut post_setup.miner).await?;
-    tracing::info!("Proposed sidechain successfully");
-    let () = activate_sidechain::<DummySidechain>(&mut post_setup.miner).await?;
-    tracing::info!("Activated sidechain successfully");
-    let () = fund_enforcer::<DummySidechain>(&mut post_setup.miner).await?;
-    tracing::info!("Funded enforcer successfully (miner)");
+    let () = setup_active_sidechain(&mut post_setup.miner).await?;
+    tracing::info!("Active sidechain set up successfully (miner)");
 
     let sender_addr = post_setup
         .sender
@@ -174,7 +170,7 @@ async fn test_peer_bmm_request_task(mut post_setup: PostSetup) -> anyhow::Result
     {
         anyhow::bail!("Failed to create a tx to fund sender wallet")
     };
-    let () = crate::mine::mine::<DummySidechain>(&mut post_setup.miner, 1, None).await?;
+    let () = crate::mine::mine(&mut post_setup.miner, 1, None).await?;
     // Wait for sender to receive block
     sleep(std::time::Duration::from_secs(1)).await;
     let sender_balance = post_setup
@@ -237,19 +233,14 @@ async fn test_peer_bmm_request_task(mut post_setup: PostSetup) -> anyhow::Result
         .await?;
     tracing::debug!(%mempool_entry);
     // Mine a block and check that the BMM request worked
-    let () = mine::mine_check_block_events::<_, DummySidechain>(
-        &mut post_setup.miner,
-        1,
-        None,
-        |_, block_info| {
-            let bmm_commitment = block_info
-                .bmm_commitment
-                .ok_or_else(|| anyhow::anyhow!("Expected a BMM commitment"))?;
-            let expected_bmm_commitment = ConsensusHex::encode(&sidechain_block_hash);
-            anyhow::ensure!(bmm_commitment == expected_bmm_commitment);
-            Ok(())
-        },
-    )
+    let () = mine::mine_check_block_events(&mut post_setup.miner, 1, None, |_, block_info| {
+        let bmm_commitment = block_info
+            .bmm_commitment
+            .ok_or_else(|| anyhow::anyhow!("Expected a BMM commitment"))?;
+        let expected_bmm_commitment = ConsensusHex::encode(&sidechain_block_hash);
+        anyhow::ensure!(bmm_commitment == expected_bmm_commitment);
+        Ok(())
+    })
     .await?;
     tracing::info!("Included BMM request tx successfully");
     tracing::info!(

--- a/integration_tests/test_unconfirmed_transactions.rs
+++ b/integration_tests/test_unconfirmed_transactions.rs
@@ -4,15 +4,12 @@ use bip300301_enforcer_lib::proto::mainchain::{
     ListTransactionsRequest, ListUnspentOutputsRequest, SendTransactionRequest,
 };
 
-use crate::{
-    integration_test,
-    setup::{DummySidechain, PostSetup},
-};
+use crate::{integration_test, setup::PostSetup};
 
 // Verify that unconfirmed transactions are immediately available when listing wallet
 // transactions.
 pub async fn test_unconfirmed_transactions(mut post_setup: PostSetup) -> anyhow::Result<()> {
-    integration_test::fund_enforcer::<DummySidechain>(&mut post_setup).await?;
+    integration_test::fund_enforcer(&mut post_setup).await?;
 
     let txs_pre = post_setup
         .wallet_service_client

--- a/integration_tests/util.rs
+++ b/integration_tests/util.rs
@@ -4,6 +4,7 @@ use std::{
     future::Future,
     path::PathBuf,
     sync::{Arc, OnceLock},
+    time::Duration,
 };
 
 use thiserror::Error;
@@ -334,6 +335,9 @@ impl<Fut> AsyncTrial<Fut> {
         Fut: Future<Output = Result<(), Err>> + Send + 'static,
         Err: std::fmt::Display,
     {
+        /// Global per-test cap
+        const TEST_TIMEOUT: Duration = Duration::from_secs(20 * 60);
+
         let span = tracing::info_span!("test", name = %self.name);
         let test_name = self.name.clone();
         let file_registry = self.file_registry;
@@ -344,17 +348,29 @@ impl<Fut> AsyncTrial<Fut> {
                 // Use spawn_blocking to avoid nested runtime issues
                 std::thread::spawn(move || {
                     rt_handle.block_on(async {
-                        let result = self.test.await;
-                        if let Err(err) = &result {
-                            // Alternate Display gives anyhow's chained
-                            // "top: cause: root" form without a backtrace.
+                        let record_failure = |error_message: String| {
                             failure_collector.add_failure(TestFailure {
                                 test_name: test_name.clone(),
-                                error_message: format!("{err:#}"),
+                                error_message,
                                 output_files: file_registry.get_files(&test_name),
                             });
+                        };
+                        match tokio::time::timeout(TEST_TIMEOUT, self.test).await {
+                            Ok(result) => {
+                                if let Err(err) = &result {
+                                    // Alternate Display gives anyhow's chained
+                                    // "top: cause: root" form without a backtrace.
+                                    record_failure(format!("{err:#}"));
+                                }
+                                result.map_err(libtest_mimic::Failed::from)
+                            }
+                            Err(_elapsed) => {
+                                let error_message =
+                                    format!("test `{test_name}` timed out after {TEST_TIMEOUT:?}");
+                                record_failure(error_message.clone());
+                                Err(error_message.into())
+                            }
                         }
-                        result.map_err(libtest_mimic::Failed::from)
                     })
                 })
                 .join()

--- a/lib/validator/task/error.rs
+++ b/lib/validator/task/error.rs
@@ -288,6 +288,16 @@ pub(in crate::validator) enum ConnectBlock {
     #[error("Error handling M4 (ack bundles)")]
     #[fatal(forward)]
     M4AckBundles(#[from] HandleM4AckBundles),
+    #[error(
+        "Missing required M6 for slot {}: M6ID `{m6id}` \
+         has vote count above withdrawal bundle inclusion threshold",
+        .sidechain_number.0
+    )]
+    #[fatal(false)]
+    MissingRequiredM6 {
+        sidechain_number: SidechainNumber,
+        m6id: M6id,
+    },
     #[error("Multiple blocks BMM'd in sidechain slot {}", .sidechain_number.0)]
     #[fatal(false)]
     MultipleBmmBlocks { sidechain_number: SidechainNumber },

--- a/lib/validator/task/mod.rs
+++ b/lib/validator/task/mod.rs
@@ -453,14 +453,31 @@ fn handle_m4_ack_bundles(
 /// has exceeded `WITHDRAWAL_BUNDLE_MAX_AGE`.
 ///
 /// <https://github.com/LayerTwo-Labs/bip300_bip301_specifications/blob/master/bip300.md#m6-withdrawal-bundle>
-fn handle_failed_m6ids(
+/// Result of a single pass over each active sidechain's pending M6IDs.
+struct PendingM6idScan {
+    /// Pending bundles whose age has exceeded `WITHDRAWAL_BUNDLE_MAX_AGE` and
+    /// must be expired this block.
+    failed: diff::FailedM6ids,
+    /// Pending bundles whose vote count has exceeded
+    /// `WITHDRAWAL_BUNDLE_INCLUSION_THRESHOLD`. Per BIP300 M4, the block
+    /// MUST include the corresponding M6 in its txdata for each of these.
+    must_include: Vec<(SidechainNumber, M6id, u16)>,
+}
+
+/// BIP 300 M4/M6 scan: walks every active sidechain's `pending_m6ids` once and
+/// classifies each entry as either expired (failed) or above the inclusion
+/// threshold (must include).
+///
+/// <https://github.com/LayerTwo-Labs/bip300_bip301_specifications/blob/master/bip300.md#m6-withdrawal-bundle>
+fn scan_pending_m6ids(
     rotxn: &RoTxn,
     dbs: &Dbs,
     block_height: u32,
-) -> Result<diff::FailedM6ids, error::HandleFailedM6Ids> {
+) -> Result<PendingM6idScan, error::HandleFailedM6Ids> {
     let active_sidechains = dbs.active_sidechains.numbers(rotxn)?;
 
     let mut failed_m6ids = HashMap::<_, BTreeMap<_, _>>::new();
+    let mut must_include = Vec::new();
 
     for sidechain_number in active_sidechains {
         // Invariant: `put_sidechain` always creates a corresponding
@@ -470,20 +487,26 @@ fn handle_failed_m6ids(
             .active_sidechains
             .pending_m6ids()
             .get(rotxn, &sidechain_number)?;
-        let failed = pending_m6ids
-            .into_iter()
-            .enumerate()
-            .filter(|(_, (_, info))| {
-                let age = block_height.saturating_sub(info.proposal_height);
-                age > WITHDRAWAL_BUNDLE_MAX_AGE as u32
-            })
-            .collect::<BTreeMap<_, _>>();
-        if !failed.is_empty() {
-            failed_m6ids.insert(sidechain_number, failed);
+        let mut failed_for_slot = BTreeMap::new();
+        for (idx, (m6id, info)) in pending_m6ids.into_iter().enumerate() {
+            let age = block_height.saturating_sub(info.proposal_height);
+            // Expired beats must-include: a bundle about to fail shouldn't
+            // simultaneously demand inclusion.
+            if age > WITHDRAWAL_BUNDLE_MAX_AGE as u32 {
+                failed_for_slot.insert(idx, (m6id, info));
+            } else if info.vote_count > WITHDRAWAL_BUNDLE_INCLUSION_THRESHOLD {
+                must_include.push((sidechain_number, m6id, info.vote_count));
+            }
+        }
+        if !failed_for_slot.is_empty() {
+            failed_m6ids.insert(sidechain_number, failed_for_slot);
         }
     }
 
-    Ok(diff::FailedM6ids(failed_m6ids))
+    Ok(PendingM6idScan {
+        failed: diff::FailedM6ids(failed_m6ids),
+        must_include,
+    })
 }
 
 /// Deposit or (sidechain_id, m6id, sequence_number)
@@ -955,7 +978,10 @@ pub(in crate::validator) fn connect_block(
     let coinbase_msg_diffs = coinbase_msg_diffs.diffs();
     let failed_sidechain_proposals_diff = handle_failed_sidechain_proposals(rwtxn, dbs, height)?;
     let () = failed_sidechain_proposals_diff.apply(rwtxn, &dbs.proposal_id_to_sidechain, height)?;
-    let failed_m6ids_diff = handle_failed_m6ids(rwtxn, dbs, height)?;
+    let PendingM6idScan {
+        failed: failed_m6ids_diff,
+        mut must_include,
+    } = scan_pending_m6ids(rwtxn, dbs, height)?;
     let () = failed_m6ids_diff.apply(rwtxn, &dbs.active_sidechains, height)?;
     events.extend(
         failed_m6ids_diff
@@ -1019,6 +1045,22 @@ pub(in crate::validator) fn connect_block(
     // Tx diffs are already applied
     let tx_diffs = tx_diffs.diffs();
     tracing::trace!("Handled block txs");
+
+    // BIP300 M4: any M6ID whose vote_count crossed the inclusion threshold
+    // in this block MUST have a
+    // matching M6 in txdata. Subtract the M6s that were actually removed
+    // from `pending_m6ids` by txdata; anything left is a violation.
+    for tx_diff in &tx_diffs {
+        if let Some((included_m6id, _)) = &tx_diff.removed_pending_withdrawal {
+            must_include.retain(|(_, pending_m6id, _)| pending_m6id != included_m6id);
+        }
+    }
+    if let Some((sidechain_number, m6id, _vote_count)) = must_include.into_iter().next() {
+        return Err(error::ConnectBlock::MissingRequiredM6 {
+            sidechain_number,
+            m6id,
+        });
+    }
     let block_info = BlockInfo {
         bmm_commitments: accepted_bmm_requests.into_iter().collect(),
         coinbase_txid: coinbase.compute_txid(),
@@ -2758,6 +2800,178 @@ mod tests {
             diff.0.get(&sc),
             Some(diff::AckBundleAction::Upvote { m6id, .. }) if *m6id == leader
         ));
+        Ok(())
+    }
+
+    // ── scan_pending_m6ids / connect_block: must-include-M6 enforcement ──
+
+    /// Helper: seed an active sidechain with a single pending m6id at
+    /// `vote_count` and `proposal_height`. Returns `(sc, m6id)`.
+    fn seed_pending(
+        rwtxn: &mut RwTxn,
+        dbs: &Dbs,
+        sc_num: u8,
+        vote_count: u16,
+        proposal_height: u32,
+    ) -> (SidechainNumber, M6id) {
+        let sc = SidechainNumber(sc_num);
+        let m6id = test_m6id(0xA0 ^ sc_num);
+        dbs.active_sidechains
+            .put_sidechain(rwtxn, &sc, &test_sidechain(sc_num, 0))
+            .unwrap();
+        dbs.active_sidechains
+            .put_pending_m6id(rwtxn, &sc, m6id, proposal_height)
+            .unwrap();
+        set_vote_count(rwtxn, dbs, &sc, m6id, vote_count);
+        (sc, m6id)
+    }
+
+    /// BIP300 M4 uses strict `>`, not `>=`. Walk the boundary: T-1, T, T+1.
+    /// Only T+1 must end up in `must_include`.
+    #[test]
+    fn scan_pending_m6ids_threshold_boundary() -> Result<()> {
+        const T: u16 = WITHDRAWAL_BUNDLE_INCLUSION_THRESHOLD;
+        for (vote_count, expect_in_must_include) in [(T - 1, false), (T, false), (T + 1, true)] {
+            let (_dir, dbs) = create_test_dbs()?;
+            let mut rwtxn = dbs.write_txn().into_diagnostic()?;
+            let (sc, m6id) = seed_pending(&mut rwtxn, &dbs, 1, vote_count, 0);
+            let scan = scan_pending_m6ids(&rwtxn, &dbs, 1).into_diagnostic()?;
+            assert!(scan.failed.0.is_empty(), "vote_count={vote_count}");
+            assert_eq!(
+                !scan.must_include.is_empty(),
+                expect_in_must_include,
+                "vote_count={vote_count}"
+            );
+            if expect_in_must_include {
+                assert_eq!(scan.must_include, vec![(sc, m6id, vote_count)]);
+            }
+        }
+        Ok(())
+    }
+
+    /// Load-bearing `else if`: a bundle that's both expired AND above
+    /// threshold goes to `failed`, not `must_include`. Otherwise a dying
+    /// bundle would erroneously trigger `MissingRequiredM6`.
+    #[test]
+    fn scan_pending_m6ids_expired_beats_must_include() -> Result<()> {
+        let (_dir, dbs) = create_test_dbs()?;
+        let mut rwtxn = dbs.write_txn().into_diagnostic()?;
+        let (sc, _) = seed_pending(
+            &mut rwtxn,
+            &dbs,
+            1,
+            WITHDRAWAL_BUNDLE_INCLUSION_THRESHOLD + 1,
+            0,
+        );
+        // age = MAX_AGE + 2 > MAX_AGE → expired
+        let scan = scan_pending_m6ids(&rwtxn, &dbs, WITHDRAWAL_BUNDLE_MAX_AGE as u32 + 2)
+            .into_diagnostic()?;
+        assert!(scan.must_include.is_empty());
+        assert!(scan.failed.0.contains_key(&sc));
+        Ok(())
+    }
+
+    /// Three sidechains, each in a different state, scanned in one pass:
+    /// above-threshold (non-expired) → `must_include`; below-threshold →
+    /// ignored; expired → `failed`.
+    #[test]
+    fn scan_pending_m6ids_multiple_sidechains_mixed_states() -> Result<()> {
+        const T: u16 = WITHDRAWAL_BUNDLE_INCLUSION_THRESHOLD;
+        let (_dir, dbs) = create_test_dbs()?;
+        let mut rwtxn = dbs.write_txn().into_diagnostic()?;
+        let scan_height = WITHDRAWAL_BUNDLE_MAX_AGE as u32 + 2;
+        // Non-expired (recent proposal) above / below threshold.
+        let (sc_high, m_high) = seed_pending(&mut rwtxn, &dbs, 1, T + 1, scan_height - 1);
+        let (sc_low, _) = seed_pending(&mut rwtxn, &dbs, 2, 0, scan_height - 1);
+        // Expired (proposed at height 0) above threshold — expiry wins.
+        let (sc_expired, _) = seed_pending(&mut rwtxn, &dbs, 3, T + 1, 0);
+
+        let scan = scan_pending_m6ids(&rwtxn, &dbs, scan_height).into_diagnostic()?;
+        assert_eq!(scan.must_include, vec![(sc_high, m_high, T + 1)]);
+        assert_eq!(scan.failed.0.len(), 1);
+        assert!(scan.failed.0.contains_key(&sc_expired));
+        assert!(!scan.failed.0.contains_key(&sc_low));
+        Ok(())
+    }
+
+    /// Helper: empty block + headers stored, ready for `connect_block`.
+    fn empty_block_with_header_stored(
+        rwtxn: &mut RwTxn,
+        dbs: &Dbs,
+    ) -> miette::Result<bitcoin::Block> {
+        let block = build_test_block(BlockHash::all_zeros(), vec![]);
+        dbs.block_hashes
+            .put_headers(rwtxn, &[(block.header, 0)])
+            .into_diagnostic()?;
+        Ok(block)
+    }
+
+    #[test]
+    fn connect_block_missing_required_m6_is_rejected_non_fatally() -> Result<()> {
+        let (_dir, dbs) = create_test_dbs()?;
+        let mut rwtxn = dbs.write_txn().into_diagnostic()?;
+        let (sc, m6id) = seed_pending(
+            &mut rwtxn,
+            &dbs,
+            1,
+            WITHDRAWAL_BUNDLE_INCLUSION_THRESHOLD + 1,
+            0,
+        );
+        let block = empty_block_with_header_stored(&mut rwtxn, &dbs)?;
+
+        let err = connect_block(&mut rwtxn, &dbs, &block).expect_err("must reject");
+        assert!(
+            matches!(
+                &err,
+                error::ConnectBlock::MissingRequiredM6 {
+                    sidechain_number,
+                    m6id: violated_m6id,
+                } if *sidechain_number == sc && *violated_m6id == m6id
+            ),
+            "expected MissingRequiredM6 for ({sc:?}, {m6id}), got `{err:?}`"
+        );
+        assert!(!err.is_fatal());
+        Ok(())
+    }
+
+    /// At-threshold (vote_count == T) does not trigger rejection. The
+    /// connect_block-level twin of the function-level boundary test.
+    #[test]
+    fn connect_block_accepts_when_pending_at_threshold() -> Result<()> {
+        let (_dir, dbs) = create_test_dbs()?;
+        let mut rwtxn = dbs.write_txn().into_diagnostic()?;
+        let _ = seed_pending(
+            &mut rwtxn,
+            &dbs,
+            1,
+            WITHDRAWAL_BUNDLE_INCLUSION_THRESHOLD,
+            0,
+        );
+        let block = empty_block_with_header_stored(&mut rwtxn, &dbs)?;
+        connect_block(&mut rwtxn, &dbs, &block).into_diagnostic()?;
+        Ok(())
+    }
+
+    /// When multiple sidechains have above-threshold bundles and none are
+    /// included, the error references one of them (we don't pin down which,
+    /// depends on iteration order).
+    #[test]
+    fn connect_block_reports_one_violator_when_multiple() -> Result<()> {
+        const T: u16 = WITHDRAWAL_BUNDLE_INCLUSION_THRESHOLD;
+        let (_dir, dbs) = create_test_dbs()?;
+        let mut rwtxn = dbs.write_txn().into_diagnostic()?;
+        let (sc_a, _) = seed_pending(&mut rwtxn, &dbs, 1, T + 1, 0);
+        let (sc_b, _) = seed_pending(&mut rwtxn, &dbs, 2, T + 1, 0);
+        let block = empty_block_with_header_stored(&mut rwtxn, &dbs)?;
+
+        let err = connect_block(&mut rwtxn, &dbs, &block).expect_err("must reject");
+        let error::ConnectBlock::MissingRequiredM6 {
+            sidechain_number, ..
+        } = err
+        else {
+            panic!("expected MissingRequiredM6, got `{err:?}`");
+        };
+        assert!(sidechain_number == sc_a || sidechain_number == sc_b);
         Ok(())
     }
 }

--- a/lib/wallet/cusf_block_producer.rs
+++ b/lib/wallet/cusf_block_producer.rs
@@ -252,6 +252,9 @@ impl CusfEnforcer for Wallet {
     }
 }
 
+// TODO: make ACKing configurable for the miner
+const ACK_ALL_PROPOSALS: bool = true;
+
 impl CusfBlockProducer for Wallet {
     type InitialBlockTemplateError = error::InitialBlockTemplate;
 
@@ -291,7 +294,6 @@ impl CusfBlockProducer for Wallet {
                 coinbase_txouts
             );
 
-            const ACK_ALL_PROPOSALS: bool = true;
             let () = self
                 .extend_coinbase_txouts(ACK_ALL_PROPOSALS, mainchain_tip, coinbase_txouts)
                 .await?;
@@ -328,6 +330,17 @@ impl CusfBlockProducer for Wallet {
 
     type SuffixTxsError = error::SuffixTxs;
 
+    /// This function is called once the RPC server has finished assembling
+    /// the bulk of a block template. The flow is something like this:
+    /// 1. RPC server (within the `cusf_enforcer_mempool` crate) calls
+    ///    `initial_block_template` (see above) for the coinbase outputs
+    /// 2. Fills in `prefix_txs` with the mempool txs it wants to include
+    /// 3. Calls this function for the trailing bits (this function!)
+    /// 4. Stitches it all together and spits out a block template to the client
+    ///
+    /// This function is our "hook" for adding M6 withdrawal txs to the end of
+    /// the block, and tacking the matching M7 BMM-accept outputs onto the
+    /// coinbase for any M8s pulled in from the mempool.
     async fn block_template_suffix<const COINBASE_TXN: bool>(
         &self,
         _parent_block_hash: &BlockHash,
@@ -423,7 +436,7 @@ impl CusfBlockProducer for Wallet {
                 )?
                 .ok_or(error::SuffixTxsInner::InitialBlockTemplate)?;
                 let suffix_txs = self
-                    .generate_suffix_txs(&ctips)
+                    .generate_suffix_txs(&ctips, ACK_ALL_PROPOSALS)
                     .await?
                     .into_iter()
                     .map(|tx| (tx, bitcoin::Amount::ZERO))

--- a/lib/wallet/mine.rs
+++ b/lib/wallet/mine.rs
@@ -195,8 +195,8 @@ impl Wallet {
             );
             coinbase_builder.bmm_accept(sidechain_number, bmm_hash)?;
         }
-        for (sidechain_id, m6ids) in self.get_bundle_proposals().await? {
-            for (m6id, _blinded_m6, m6id_info) in m6ids {
+        for (sidechain_id, bundle_proposals) in self.get_bundle_proposals().await? {
+            for (m6id, _blinded_m6, m6id_info) in bundle_proposals.proposals {
                 if m6id_info.is_none() {
                     coinbase_builder.propose_bundle(sidechain_id, m6id)?;
                 }
@@ -229,16 +229,30 @@ impl Wallet {
     }
 
     /// Generate suffix txs for a new block
+    ///
+    /// `ack_all_proposals` mirrors the value passed to [`extend_coinbase_txouts`]
+    /// for the same block: with auto-ack on, the coinbase upvotes index 0 of each
+    /// slot's pending m6ids, bumping that bundle's vote_count by 1. We simulate
+    /// that here so M6 is included in the *same* block where vote_count crosses
+    /// `WITHDRAWAL_BUNDLE_INCLUSION_THRESHOLD`. Not doing so causes the block to
+    /// be invalid.
     pub(in crate::wallet) async fn generate_suffix_txs(
         &self,
         ctips: &HashMap<SidechainNumber, crate::types::Ctip>,
+        ack_all_proposals: bool,
     ) -> Result<Vec<Transaction>, error::GenerateSuffixTxs> {
         let mut res = Vec::new();
-        for (sidechain_id, m6ids) in self.get_bundle_proposals().await? {
+        for (sidechain_id, bundle_proposals) in self.get_bundle_proposals().await? {
             let mut ctip = None;
-            for (_m6id, blinded_m6, m6id_info) in m6ids {
+            for (m6id, blinded_m6, m6id_info) in bundle_proposals.proposals {
                 let Some(m6id_info) = m6id_info else { continue };
-                if m6id_info.vote_count > WITHDRAWAL_BUNDLE_INCLUSION_THRESHOLD {
+                let projected_vote_count =
+                    if ack_all_proposals && Some(m6id) == bundle_proposals.first_pending_m6id {
+                        m6id_info.vote_count.saturating_add(1)
+                    } else {
+                        m6id_info.vote_count
+                    };
+                if projected_vote_count > WITHDRAWAL_BUNDLE_INCLUSION_THRESHOLD {
                     let Ctip { outpoint, value } = if let Some(ctip) = ctip {
                         ctip
                     } else {
@@ -263,9 +277,12 @@ impl Wallet {
     }
 
     /// select non-coinbase txs for a new block
-    async fn select_block_txs(&self) -> Result<Vec<Transaction>, error::SelectBlockTxs> {
+    async fn select_block_txs(
+        &self,
+        ack_all_proposals: bool,
+    ) -> Result<Vec<Transaction>, error::SelectBlockTxs> {
         let ctips = self.inner.validator.get_ctips()?;
-        let mut res = self.generate_suffix_txs(&ctips).await?;
+        let mut res = self.generate_suffix_txs(&ctips, ack_all_proposals).await?;
 
         // We want to include all transactions from the mempool into our newly generated block.
         // This approach is perhaps a bit naive, and could fail if there are conflicting TXs
@@ -755,7 +772,7 @@ impl Wallet {
         let () = self
             .extend_coinbase_txouts(ack_all_proposals, mainchain_tip, &mut coinbase_outputs)
             .await?;
-        let transactions = self.select_block_txs().await?;
+        let transactions = self.select_block_txs(ack_all_proposals).await?;
         let mut coinbase_builder = CoinbaseBuilder::new(&mut coinbase_outputs)?;
         for tx in &transactions {
             if let Some(bmm_request) = crate::messages::parse_m8_tx(tx)

--- a/lib/wallet/mod.rs
+++ b/lib/wallet/mod.rs
@@ -65,6 +65,14 @@ mod util;
 
 type BundleProposals = Vec<(M6id, BlindedM6<'static>, Option<PendingM6idInfo>)>;
 
+/// Per-sidechain output of [`Wallet::get_bundle_proposals`].
+pub(in crate::wallet) struct SidechainBundleProposals {
+    /// Chronologically-first pending m6id. `None` if
+    /// nothing is pending.
+    pub first_pending_m6id: Option<M6id>,
+    pub proposals: BundleProposals,
+}
+
 pub(crate) type Persistence = thread_safe_connection::ThreadSafeConnection;
 type BdkWallet = bdk_wallet::PersistedWallet<Persistence>;
 
@@ -895,7 +903,7 @@ impl Wallet {
 
     async fn get_bundle_proposals(
         &self,
-    ) -> Result<HashMap<SidechainNumber, BundleProposals>, error::GetBundleProposals> {
+    ) -> Result<HashMap<SidechainNumber, SidechainBundleProposals>, error::GetBundleProposals> {
         // Satisfy clippy with a single function call per lock
         let with_connection = |connection: &Connection| -> Result<_, error::GetBundleProposals> {
             let mut statement = connection
@@ -936,14 +944,21 @@ impl Wallet {
                     .inner
                     .validator
                     .get_pending_withdrawals(&sidechain_id)?;
-                let res: Vec<_> = m6ids
+                let first_pending_m6id = pending_m6ids.keys().next().copied();
+                let proposals: BundleProposals = m6ids
                     .into_iter()
                     .map(|(m6id, blinded_m6)| (m6id, blinded_m6, pending_m6ids.get(&m6id).copied()))
                     .collect();
-                if res.is_empty() {
+                if proposals.is_empty() {
                     Ok(None)
                 } else {
-                    Ok(Some((sidechain_id, res)))
+                    Ok(Some((
+                        sidechain_id,
+                        SidechainBundleProposals {
+                            first_pending_m6id,
+                            proposals,
+                        },
+                    )))
                 }
             })
             .collect()?;


### PR DESCRIPTION
Implement verification of presence of withdrawal bundles. If they exceed
the vote count threshold they MUST be included in the
corresponding block. This also leads to implementing corresponding fixes
in our mining logic, ensuring we don't produce invalid blocks. 

Also refactor and simplify integration tests somewhat

TODO: 
- [ ] fix block invalidation in cusf-enforcer-mempool when running in mempool mode