### PR TITLE
multi: expand exit-after-sync, add verify-consensus-state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 /.integration-deps
 bip300301_enforcer.mdb
 datadir
+datadir-sync-benchmark*
 sync_analysis
 integrationtests.env

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,6 +452,7 @@ dependencies = [
  "either",
  "futures",
  "http",
+ "jiff",
  "jsonrpsee",
  "miette",
  "reqwest 0.13.4",

--- a/Justfile
+++ b/Justfile
@@ -6,6 +6,38 @@ default:
 generate:
     buf generate --clean
 
+# Benchmark a from-scratch signet sync. Each run creates a brand-new, isolated
+# data dir with a random suffix (./datadir-sync-benchmark.XXXXXX). Logs stats
+# and a consensus-state digest on exit, and writes the full consensus state
+# to <data-dir>/consensus-state.json so runs are easy to diff.
+#
+# The single argument (default 0) is either:
+#   - a block height to sync to (0 = the chain tip), or
+#   - a path to a consensus-state.json file from a previous run: we sync to that
+#     file's tip height and then verify our consensus state matches it, exiting
+#     non-zero on any mismatch.
+#
+@sync-benchmark-signet target='0':
+    #!/usr/bin/env bash
+    set -euo pipefail
+    target='{{target}}'
+    if [[ -f "$target" ]]; then
+        echo "Verifying consensus state against reference: $target"
+        mode=(--verify-consensus-state "$target")
+    else
+        echo "Syncing to height: $target"
+        mode=(--exit-after-sync="$target")
+    fi
+    datadir="$(mktemp -d "./datadir-sync-benchmark.XXXXXX")"
+    echo "Using fresh data dir: $datadir"
+    env RUST_BACKTRACE=1 cargo run --release -- \
+        --data-dir "$datadir" \
+        --node-rpc-addr=localhost:38332 \
+        --node-rpc-user=user \
+        --node-rpc-pass=password \
+        "${mode[@]}"
+    echo "Consensus state written to $datadir/consensus-state.json"
+
 clippy:
     cargo clippy --all-targets --all-features --fix --allow-dirty --allow-staged -- --deny warnings
     cargo +nightly clippy -- -A clippy::all -D unqualified_local_imports -Zcrate-attr="feature(unqualified_local_imports)"

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -16,6 +16,7 @@ educe = { workspace = true }
 either = { workspace = true }
 futures = { workspace = true }
 http = { workspace = true }
+jiff = { workspace = true }
 jsonrpsee = { workspace = true, features = ["server"] }
 miette = { workspace = true, features = ["fancy"] }
 reqwest = { workspace = true }

--- a/app/main.rs
+++ b/app/main.rs
@@ -1,4 +1,8 @@
-use std::{net::SocketAddr, time::Duration};
+use std::{
+    net::SocketAddr,
+    path::{Path, PathBuf},
+    time::Duration,
+};
 
 use bdk_wallet::bip39::{Language, Mnemonic};
 use bip300301_enforcer_lib::{
@@ -14,9 +18,8 @@ use bip300301_enforcer_lib::{
         },
     },
     rpc_client, server,
-    types::Event,
     validator::{
-        Validator,
+        SyncStateSummary, Validator,
         main_rest_client::{MainRestClient, MainRestClientError},
     },
     version,
@@ -26,7 +29,7 @@ use bitcoin::ScriptBuf;
 use bitcoin_jsonrpsee::{MainClient, jsonrpsee::http_client::transport};
 use clap::Parser;
 use either::Either;
-use futures::{StreamExt, TryFutureExt as _, channel::oneshot};
+use futures::{TryFutureExt as _, channel::oneshot};
 use http::{Request, header::HeaderName};
 use jsonrpsee::{core::client::Error, server::middleware::rpc::RpcServiceBuilder};
 use miette::{Diagnostic, IntoDiagnostic, Result, WrapErr as _, miette};
@@ -626,33 +629,153 @@ async fn run_wallet_mempool_task(
     result
 }
 
-async fn run_exit_after_sync(validator: Validator, goal_height: u32) -> Result<(), miette::Report> {
-    tracing::info!("Waiting for sync to height {} before exiting", goal_height);
+fn report_sync_state(validator: &Validator, state_file: &Path) -> Result<SyncStateSummary> {
+    match validator.sync_state_summary() {
+        Ok(summary) => {
+            tracing::info!(
+                state_digest = %summary.digest(),
+                tip_hash = %summary.tip_hash,
+                tip_height = summary.tip_height,
+                sidechain_proposals = summary.sidechains.len(),
+                active_sidechains = summary.active_sidechain_count(),
+                pending_withdrawal_bundles = summary.pending_withdrawal_count(),
+                "writing consensus state summary to {}", state_file.display(),
+            );
+            let json = summary.to_json_pretty();
+            std::fs::write(state_file, format!("{json}\n")).map_err(|err| {
+                miette::Report::from_err(err).wrap_err("write sync state summary")
+            })?;
+            Ok(summary)
+        }
+        err => err,
+    }
+}
 
-    let mut events = std::pin::pin!(validator.subscribe_events());
-    tracing::debug!("Subscribed to validator events");
+fn load_consensus_reference(path: &Path) -> Result<SyncStateSummary, miette::Report> {
+    let contents = std::fs::read_to_string(path)
+        .map_err(|err| miette::Report::from_err(err).wrap_err("load consensus reference"))?;
 
-    loop {
-        match events.next().await {
-            Some(Ok(Event::ConnectBlock { header_info, .. }))
-                if header_info.height >= goal_height =>
-            {
-                tracing::info!("Synced to block height {}, exiting", header_info.height);
-                return Ok(());
-            }
+    SyncStateSummary::from_json(&contents)
+        .map_err(|err| miette!("consensus-state file {} is invalid: {err}", path.display()))
+}
 
-            Some(Ok(_)) => {}
+fn verify_against_reference(
+    produced: SyncStateSummary,
+    reference: &Option<SyncStateSummary>,
+) -> Result<(), miette::Report> {
+    use std::fmt::Write as _;
 
-            Some(Err(err)) => {
-                return Err(miette::Report::from_err(err)
-                    .wrap_err("exit-after-sync: error receiving event"));
-            }
+    let Some(reference) = reference else {
+        return Ok(());
+    };
 
-            None => {
-                return Err(miette!("exit-after-sync: no event received"));
-            }
+    if produced == *reference {
+        tracing::info!(
+            digest = %produced.digest(),
+            tip_height = produced.tip_height,
+            "consensus-state verification PASSED: state matches reference exactly",
+        );
+        return Ok(());
+    }
+
+    // Short hash/digest prefixes keep every report line on one line
+    let short = |v: &dyn std::fmt::Display| -> String { v.to_string().chars().take(12).collect() };
+
+    let mut report = String::new();
+    let _ = writeln!(report, "consensus-state verification FAILED");
+    let _ = writeln!(
+        report,
+        "  current   tip:    height {} ({}..)",
+        produced.tip_height,
+        short(&produced.tip_hash)
+    );
+    let _ = writeln!(
+        report,
+        "  reference tip:    height {} ({}..)",
+        reference.tip_height,
+        short(&reference.tip_hash)
+    );
+    let _ = writeln!(
+        report,
+        "  current   digest: {}..",
+        short(&produced.digest())
+    );
+    let _ = write!(
+        report,
+        "  reference digest: {}..",
+        short(&reference.digest())
+    );
+
+    let sidechain_diffs = produced.sidechain_diffs(reference);
+    if !sidechain_diffs.is_empty() {
+        let _ = write!(report, "\nsidechain differences:");
+        for diff in sidechain_diffs {
+            let _ = write!(report, "\n  - {diff}");
         }
     }
+
+    Err(miette!("{report}"))
+}
+
+async fn run_exit_after_sync(
+    mut validator: Validator,
+    goal_height: u32,
+    state_file: PathBuf,
+    reference: Option<SyncStateSummary>,
+    mainchain_client: bitcoin_jsonrpsee::jsonrpsee::http_client::HttpClient,
+    cancel: CancellationToken,
+) -> Result<(), miette::Report> {
+    use cusf_enforcer_mempool::cusf_enforcer::CusfEnforcer as _;
+
+    let start_height = validator.try_get_block_height().ok().flatten();
+
+    if let Some(current) = start_height {
+        if current > goal_height {
+            return Err(miette!(
+                "data dir is already synced to height {current}, past the requested height \
+                 {goal_height}"
+            ));
+        }
+    }
+
+    let target_hash = mainchain_client
+        .getblockhash(goal_height as usize)
+        .await
+        .map_err(|err| {
+            miette::Report::from_err(err).wrap_err(format!(
+                "exit-after-sync: failed to resolve block #{goal_height}"
+            ))
+        })?;
+
+    tracing::info!(
+        goal_height,
+        target_hash = %target_hash,
+        ?start_height,
+        "Syncing to height #{goal_height}: {target_hash}, then exiting",
+    );
+
+    let started_at = tokio::time::Instant::now();
+    validator
+        .sync_to_tip(cancel.cancelled(), target_hash)
+        .await?;
+    let elapsed = started_at.elapsed();
+
+    let final_height = validator.try_get_block_height().ok().flatten();
+    let blocks_synced = match (start_height, final_height) {
+        (Some(start), Some(end)) => u64::from(end.saturating_sub(start)),
+        (None, Some(end)) => u64::from(end) + 1,
+        _ => 0,
+    };
+    let elapsed_secs = elapsed.as_secs_f64();
+    let blocks_per_sec = blocks_synced as f64 / elapsed_secs;
+    let elapsed = jiff::SignedDuration::try_from(elapsed).unwrap_or_default();
+    tracing::info!(
+        "exit-after-sync complete: synced {blocks_synced} blocks to height {} in {elapsed} ({blocks_per_sec:.1} blocks/sec)",
+        final_height.map_or_else(|| "?".to_owned(), |h| h.to_string()),
+    );
+
+    let produced = report_sync_state(&validator, &state_file)?;
+    verify_against_reference(produced, &reference)
 }
 
 #[tokio::main]
@@ -692,6 +815,23 @@ async fn main() -> Result<()> {
         build = if cfg!(debug_assertions) { "debug" } else { "release" },
         "Starting up bip300301_enforcer",
     );
+
+    // Validate the verification reference early, before creating node connections etc.
+    let verify_reference = cli
+        .verify_consensus_state
+        .clone()
+        .map(|path| {
+            let reference = load_consensus_reference(path.as_ref())?;
+            tracing::info!(
+                reference = %path.display(),
+                tip_height = reference.tip_height,
+                reference_digest = %reference.digest(),
+                "Loaded consensus-state reference, will sync to #{} and verify",
+                reference.tip_height,
+            );
+            Ok::<_, miette::Report>(reference)
+        })
+        .transpose()?;
 
     let raw_url = format!("http://{}", cli.node_rpc_opts.addr);
     let mainchain_rest_client = MainRestClient::new(
@@ -962,7 +1102,14 @@ async fn main() -> Result<()> {
     let mut tasks: tokio::task::JoinSet<(&'static str, Result<(), miette::Report>)> =
         tokio::task::JoinSet::new();
 
-    {
+    // `--exit-after-sync` / `--verify-consensus-state` drive a single bounded
+    // sync to a specific height (spawned below) instead of the normal task that
+    // chases the live chain tip. Skip the tip-chasing sync (and the periodic
+    // wallet sync) in that mode so the two don't race on the validator.
+    let exit_after_sync_mode =
+        cli.exit_after_sync.is_some() || cli.verify_consensus_state.is_some();
+
+    if !exit_after_sync_mode {
         let cancel = cancel.clone();
         let mainchain_client = mainchain_client.clone();
         let zmq = node_zmq_addr_sequence.clone();
@@ -1032,7 +1179,7 @@ async fn main() -> Result<()> {
         // periodic sync. Therefore we expose a knob to disable it.
         let sync_source_disabled = cli.wallet_opts.sync_source == WalletSyncSource::Disabled;
 
-        if !cli.wallet_opts.skip_periodic_sync && !sync_source_disabled {
+        if !cli.wallet_opts.skip_periodic_sync && !sync_source_disabled && !exit_after_sync_mode {
             let cancel = cancel.clone();
             tasks.spawn(async move {
                 let res = wallet.sync_task(cancel).await;
@@ -1041,32 +1188,39 @@ async fn main() -> Result<()> {
         }
     }
 
-    if let Some(exit_after_sync) = cli.exit_after_sync {
+    if exit_after_sync_mode {
         let validator = match &enforcer {
             Either::Left(validator) => validator.clone(),
             Either::Right(wallet) => wallet.validator().clone(),
         };
 
-        let goal_height = if exit_after_sync != 0 {
-            // Sanity check that the user didn't give an exit height that's
-            // below what we're currently at.
-
-            let mainchain_tip = validator.try_get_block_height()?;
-            if exit_after_sync < mainchain_tip.unwrap_or_default() {
-                return Err(miette!(
-                    "exit-after-sync height {} is below current height {}",
-                    exit_after_sync,
-                    mainchain_tip.unwrap_or_default()
-                ));
+        // The reference (if any) was loaded + validated at startup.
+        let (goal_height, reference) = match verify_reference {
+            Some(reference) => (reference.tip_height, Some(reference)),
+            None => {
+                let exit_after_sync = cli.exit_after_sync.unwrap_or(0);
+                let goal_height = if exit_after_sync != 0 {
+                    exit_after_sync
+                } else {
+                    info.blocks
+                };
+                (goal_height, None)
             }
-
-            exit_after_sync
-        } else {
-            info.blocks
         };
 
+        let state_file = cli.data_dir.join("consensus-state.json");
+        let mainchain_client = mainchain_client.clone();
+        let cancel = cancel.clone();
         tasks.spawn(async move {
-            let res = run_exit_after_sync(validator, goal_height).await;
+            let res = run_exit_after_sync(
+                validator,
+                goal_height,
+                state_file,
+                reference,
+                mainchain_client,
+                cancel,
+            )
+            .await;
             ("exit-after-sync task", res)
         });
     }

--- a/lib/cli.rs
+++ b/lib/cli.rs
@@ -432,9 +432,17 @@ pub struct Config {
     pub wallet_opts: WalletConfig,
 
     /// Exit after syncing to the specified block height. If set to 0, we exit
-    /// after syncing to the tip. Can be used for benchmarking sync speeds.
+    /// after syncing to the tip. On exit, a summary of the sync (blocks
+    /// synced, elapsed time, blocks/sec) is logged.
     #[arg(long)]
     pub exit_after_sync: Option<u32>,
+
+    /// Path to a reference `consensus-state.json` (from a prior
+    /// `--exit-after-sync` run). Syncs to that file's tip height and verifies
+    /// the resulting consensus state matches it, exiting non-zero on any
+    /// mismatch. Cannot be combined with `--exit-after-sync`.
+    #[arg(long, conflicts_with = "exit_after_sync")]
+    pub verify_consensus_state: Option<PathBuf>,
 
     /// Assert that the connected Bitcoin Core node is running this major
     /// version (e.g. `30`). If not set, the enforcer accepts any major in

--- a/lib/validator/mod.rs
+++ b/lib/validator/mod.rs
@@ -28,11 +28,15 @@ pub mod cusf_enforcer;
 mod dbs;
 pub mod main_rest_client;
 pub mod parse_block_files;
+mod sync_state_summary;
 mod task;
 #[cfg(test)]
 mod test_utils;
 
 use self::dbs::{Dbs, PendingM6ids};
+pub use self::sync_state_summary::{
+    CtipSummary, PendingWithdrawalSummary, SidechainStateSummary, SyncStateSummary,
+};
 
 #[derive(Debug, Error)]
 pub enum InitError {
@@ -800,45 +804,4 @@ impl Validator {
             .get_seen_bmm_requests_for_parent_block(&rotxn, parent_block_hash)?;
         Ok(res)
     }
-
-    /*
-    pub fn get_deposits(&self, sidechain_number: u8) -> Result<Vec<Deposit>> {
-        let txn = self.env.read_txn().into_diagnostic()?;
-        let treasury_utxos_range = self
-            .sidechain_number_sequence_number_to_treasury_utxo
-            .range(&txn, &((sidechain_number, 0)..(sidechain_number, u64::MAX)))
-            .into_diagnostic()?;
-        let mut deposits = vec![];
-        for item in treasury_utxos_range {
-            let ((_, sequence_number), treasury_utxo) = item.into_diagnostic()?;
-            if treasury_utxo.total_value > treasury_utxo.previous_total_value
-                && treasury_utxo.address.is_some()
-            {
-                let deposit = Deposit {
-                    sequence_number,
-                    address: treasury_utxo.address.unwrap(),
-                    value: treasury_utxo.total_value - treasury_utxo.previous_total_value,
-                };
-                deposits.push(deposit);
-            }
-        }
-        Ok(deposits)
-    }
-    */
-
-    /*
-    pub fn get_accepted_bmm_hashes(&self) -> Result<Vec<(u32, Vec<[u8; 32]>)>> {
-        let mut block_height_accepted_bmm_hashes = vec![];
-        let txn = self.env.read_txn().into_diagnostic()?;
-        for item in self
-            .block_height_to_accepted_bmm_block_hashes
-            .iter(&txn)
-            .into_diagnostic()?
-        {
-            let (block_height, accepted_bmm_hashes) = item.into_diagnostic()?;
-            block_height_accepted_bmm_hashes.push((block_height, accepted_bmm_hashes.to_vec()));
-        }
-        Ok(block_height_accepted_bmm_hashes)
-    }
-    */
 }

--- a/lib/validator/sync_state_summary.rs
+++ b/lib/validator/sync_state_summary.rs
@@ -1,0 +1,352 @@
+//! A deterministic snapshot of BIP300/301 consensus state at a mainchain tip,
+//! intended for cross-run consistency checks. See [`SyncStateSummary`] and
+//! [`Validator::sync_state_summary`].
+
+use std::collections::HashSet;
+
+use bitcoin::{BlockHash, OutPoint};
+
+use crate::{
+    types::{M6id, SidechainDeclaration},
+    validator::Validator,
+};
+
+impl Validator {
+    /// Collect a deterministic snapshot of BIP300/301 consensus state at the
+    /// current tip. The result is ordered, so two validators synced to the same
+    /// tip and in agreement produce byte-identical summaries (and digests).
+    /// Intended for cross-run consistency checks.
+    pub fn sync_state_summary(&self) -> Result<SyncStateSummary, miette::Report> {
+        let tip_hash = self.get_mainchain_tip()?;
+        let tip_height = self
+            .try_get_block_height()?
+            .ok_or_else(|| miette::miette!("cannot summarize state: validator is not synced"))?;
+
+        let ctips = self.get_ctips()?;
+
+        // Activated sidechains and un-activated proposals live in separate DBs:
+        // Gather both so the summary reflects the
+        // full set. Active entries come first so they win the dedup below.
+        let sidechains_iter = self
+            .get_active_sidechains()?
+            .into_iter()
+            .chain(self.get_sidechains()?.into_iter().map(|(_id, sc)| sc));
+
+        let mut seen = HashSet::new();
+        let mut sidechains = Vec::new();
+        for sidechain in sidechains_iter {
+            let sidechain_number = sidechain.proposal.sidechain_number;
+            let description_hash = sidechain.proposal.description.sha256d_hash();
+            if !seen.insert((sidechain_number, description_hash)) {
+                continue;
+            }
+            let activation_height = sidechain.status.activation_height;
+
+            let (ctip, ctip_sequence_number, mut pending_withdrawals) =
+                // Ctip, sequence number and pending withdrawal bundles only exist
+                // for activated sidechains.
+                if activation_height.is_some() {
+                    let ctip = ctips.get(&sidechain_number).map(|ctip| CtipSummary {
+                        outpoint: ctip.outpoint,
+                        value_sats: ctip.value.to_sat(),
+                    });
+                    let ctip_sequence_number = self.get_ctip_sequence_number(sidechain_number)?;
+                    let pending: Vec<_> = self
+                        .get_pending_withdrawals(&sidechain_number)?
+                        .into_iter()
+                        .map(|(m6id, info)| PendingWithdrawalSummary {
+                            m6id,
+                            vote_count: info.vote_count,
+                            proposal_height: info.proposal_height,
+                        })
+                        .collect();
+                    (ctip, ctip_sequence_number, pending)
+                } else {
+                    (None, None, Vec::new())
+                };
+
+            // Canonical ordering of bundles by M6id.
+            pending_withdrawals.sort_by(|a, b| a.m6id.0.cmp(&b.m6id.0));
+
+            // Human-readable title/description, best-effort
+            let declaration = SidechainDeclaration::try_from(&sidechain.proposal.description).ok();
+
+            sidechains.push(SidechainStateSummary {
+                sidechain_number: sidechain_number.0,
+                description_hash,
+                title: declaration.as_ref().map(|d| d.title.clone()),
+                description: declaration.map(|d| d.description),
+                vote_count: sidechain.status.vote_count,
+                proposal_height: sidechain.status.proposal_height,
+                activation_height,
+                ctip,
+                ctip_sequence_number,
+                pending_withdrawals,
+            });
+        }
+
+        // Canonical ordering: by sidechain number, then proposal description
+        // hash (a single sidechain number can have multiple competing proposals).
+        sidechains.sort_by(|a, b| {
+            a.sidechain_number
+                .cmp(&b.sidechain_number)
+                .then_with(|| a.description_hash.cmp(&b.description_hash))
+        });
+
+        Ok(SyncStateSummary {
+            tip_hash,
+            tip_height,
+            sidechains,
+        })
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+pub struct SyncStateSummary {
+    pub tip_hash: BlockHash,
+    pub tip_height: u32,
+    pub sidechains: Vec<SidechainStateSummary>,
+}
+
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+pub struct SidechainStateSummary {
+    pub sidechain_number: u8,
+    pub description_hash: bitcoin::hashes::sha256d::Hash,
+    /// Human-readable title from the M1 declaration, if it parses.
+    pub title: Option<String>,
+    /// Human-readable description from the M1 declaration, if it parses.
+    pub description: Option<String>,
+    /// BIP300 M1 ACK vote count for this proposal.
+    pub vote_count: u16,
+    pub proposal_height: u32,
+    /// `Some` once the sidechain has activated.
+    pub activation_height: Option<u32>,
+    pub ctip: Option<CtipSummary>,
+    pub ctip_sequence_number: Option<u64>,
+    pub pending_withdrawals: Vec<PendingWithdrawalSummary>,
+}
+
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+pub struct CtipSummary {
+    pub outpoint: OutPoint,
+    pub value_sats: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+pub struct PendingWithdrawalSummary {
+    pub m6id: M6id,
+    /// BIP300 M3/M4 ACK vote count for this withdrawal bundle.
+    pub vote_count: u16,
+    pub proposal_height: u32,
+}
+
+impl SyncStateSummary {
+    pub fn digest(&self) -> bitcoin::hashes::sha256::Hash {
+        use bitcoin::hashes::Hash as _;
+        let json = serde_json::to_vec(self)
+            .expect("SyncStateSummary contain infallibly-serializable fields");
+        bitcoin::hashes::sha256::Hash::hash(&json)
+    }
+
+    pub fn to_json_pretty(&self) -> String {
+        serde_json::to_string_pretty(self)
+            .expect("SyncStateSummary is composed of infallibly-serializable fields")
+    }
+
+    pub fn from_json(json: &str) -> Result<Self, serde_json::Error> {
+        serde_json::from_str(json)
+    }
+
+    /// Compare this summary against a `reference`, returning a list of
+    /// human-readable differences in the consensus values (tip first, then
+    /// sidechains). An empty list means the two are byte-for-byte identical
+    pub fn diff(&self, reference: &Self) -> Vec<String> {
+        let mut diffs = Vec::new();
+        if self.tip_hash != reference.tip_hash {
+            diffs.push(format!(
+                "tip_hash: {} (current) != {} (reference)",
+                self.tip_hash, reference.tip_hash
+            ));
+        }
+        if self.tip_height != reference.tip_height {
+            diffs.push(format!(
+                "tip_height: {} (current) != {} (reference)",
+                self.tip_height, reference.tip_height
+            ));
+        }
+        diffs.extend(self.sidechain_diffs(reference));
+        diffs
+    }
+
+    /// Human-readable differences in the per-sidechain consensus state
+    pub fn sidechain_diffs(&self, reference: &Self) -> Vec<String> {
+        use std::collections::BTreeMap;
+
+        let mut diffs = Vec::new();
+
+        let key = |sc: &SidechainStateSummary| (sc.sidechain_number, sc.description_hash);
+        let current: BTreeMap<_, _> = self.sidechains.iter().map(|sc| (key(sc), sc)).collect();
+        let reference_map: BTreeMap<_, _> = reference
+            .sidechains
+            .iter()
+            .map(|sc| (key(sc), sc))
+            .collect();
+
+        for (k, sc) in &current {
+            match reference_map.get(k) {
+                None => diffs.push(format!(
+                    "sidechain {} ({}): present now but absent in reference",
+                    k.0,
+                    short_hash(&k.1)
+                )),
+                Some(ref_sc) => {
+                    diffs.extend(sc.field_diffs(ref_sc));
+                }
+            }
+        }
+        for k in reference_map.keys() {
+            if !current.contains_key(k) {
+                diffs.push(format!(
+                    "sidechain {} ({}): in reference but absent now",
+                    k.0,
+                    short_hash(&k.1)
+                ));
+            }
+        }
+        diffs
+    }
+
+    pub fn active_sidechain_count(&self) -> usize {
+        self.sidechains
+            .iter()
+            .filter(|sc| sc.activation_height.is_some())
+            .count()
+    }
+
+    pub fn pending_withdrawal_count(&self) -> usize {
+        self.sidechains
+            .iter()
+            .map(|sc| sc.pending_withdrawals.len())
+            .sum()
+    }
+}
+
+fn short_hash(hash: &bitcoin::hashes::sha256d::Hash) -> String {
+    hash.to_string()[..8].to_owned()
+}
+
+impl SidechainStateSummary {
+    fn field_diffs(&self, reference: &Self) -> Vec<String> {
+        let label = format!(
+            "sidechain {} ({})",
+            self.sidechain_number,
+            short_hash(&self.description_hash)
+        );
+        let mut diffs = Vec::new();
+        macro_rules! cmp {
+            ($field:ident) => {
+                if self.$field != reference.$field {
+                    diffs.push(format!(
+                        "{label}: {} differs ({:?} now vs {:?} reference)",
+                        stringify!($field),
+                        self.$field,
+                        reference.$field,
+                    ));
+                }
+            };
+        }
+        cmp!(vote_count);
+        cmp!(proposal_height);
+        cmp!(activation_height);
+        cmp!(ctip_sequence_number);
+        cmp!(title);
+        cmp!(description);
+        if self.ctip != reference.ctip {
+            diffs.push(format!(
+                "{label}: ctip differs ({:?} now vs {:?} reference)",
+                self.ctip, reference.ctip
+            ));
+        }
+        if self.pending_withdrawals != reference.pending_withdrawals {
+            diffs.push(format!(
+                "{label}: pending withdrawal bundles differ ({} now vs {} reference)",
+                self.pending_withdrawals.len(),
+                reference.pending_withdrawals.len(),
+            ));
+        }
+        diffs
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bitcoin::{Txid, hashes::Hash as _};
+
+    use super::*;
+
+    fn sample() -> SyncStateSummary {
+        SyncStateSummary {
+            tip_hash: BlockHash::all_zeros(),
+            tip_height: 15139,
+            sidechains: vec![SidechainStateSummary {
+                sidechain_number: 9,
+                description_hash: bitcoin::hashes::sha256d::Hash::all_zeros(),
+                title: Some("Thunder".to_owned()),
+                description: Some("A sidechain with a large blocksize".to_owned()),
+                vote_count: 6,
+                proposal_height: 248,
+                activation_height: Some(254),
+                ctip: Some(CtipSummary {
+                    outpoint: OutPoint::null(),
+                    value_sats: 12_345,
+                }),
+                ctip_sequence_number: Some(3),
+                pending_withdrawals: vec![PendingWithdrawalSummary {
+                    m6id: M6id(Txid::all_zeros()),
+                    vote_count: 1,
+                    proposal_height: 250,
+                }],
+            }],
+        }
+    }
+
+    #[test]
+    fn json_round_trip_preserves_state_and_digest() {
+        let original = sample();
+        let parsed = SyncStateSummary::from_json(&original.to_json_pretty())
+            .expect("consensus-state JSON should round-trip");
+        assert_eq!(original, parsed);
+        assert_eq!(original.digest(), parsed.digest());
+        assert!(original.diff(&parsed).is_empty());
+    }
+
+    #[test]
+    fn diff_reports_changed_fields_and_membership() {
+        let reference = sample();
+
+        // A changed ACK vote count is reported.
+        let mut changed = sample();
+        changed.sidechains[0].vote_count = 7;
+        let diffs = changed.diff(&reference);
+        assert!(diffs.iter().any(|d| d.contains("vote_count")), "{diffs:?}");
+
+        // A sidechain present now but not in the reference is reported.
+        let mut extra = sample();
+        extra.sidechains[0].sidechain_number = 13;
+        let diffs = extra.diff(&reference);
+        assert!(
+            diffs.iter().any(|d| d.contains("absent in reference"))
+                && diffs.iter().any(|d| d.contains("absent now")),
+            "{diffs:?}"
+        );
+
+        // Differing tip is reported.
+        let mut tip = sample();
+        tip.tip_height = 15140;
+        assert!(
+            tip.diff(&reference)
+                .iter()
+                .any(|d| d.contains("tip_height"))
+        );
+    }
+}

--- a/lib/wallet/sync.rs
+++ b/lib/wallet/sync.rs
@@ -85,7 +85,7 @@ impl WalletInner {
             .delete_pending_sidechain_proposals(sidechain_proposal_ids)
             .await?;
         let mut database = self.bdk_db.lock().await;
-        tracing::debug!("applying block to BDK wallet");
+        tracing::trace!("applying block to BDK wallet");
 
         match wallet_write.with_mut(|wallet| wallet.apply_block(block, block_height)) {
             Ok(()) => (),
@@ -96,7 +96,7 @@ impl WalletInner {
             .await
             .map_err(error::HandleConnectBlock::from)?;
 
-        tracing::debug!(
+        tracing::trace!(
             "applied block {} in persisted changes to BDK wallet",
             if persisted_changed {
                 "resulted"


### PR DESCRIPTION
Expands the exit-after-sync mode to write a consensus state file. Introduce a new cli opt that reads this file, performs the same sync, and then verifies everything matches exactly. Can be used for running different builds of the enforcer and ensuring that nothing changes in its output.