### PR TITLE
Fix DoS vector from non-fatal coinbase message errors

### DIFF
--- a/lib/validator/task/mod.rs
+++ b/lib/validator/task/mod.rs
@@ -1944,6 +1944,48 @@ mod tests {
         Ok(())
     }
 
+    /// A miner-controlled coinbase carrying a non-fatal malformed BIP 300
+    /// message must not be able to abort block connection. Here: an M4 (ACK
+    /// bundles) OneByte message with 1 upvote while zero sidechains are active
+    /// yields `HandleM4Votes::InvalidVotes` (non-fatal). The block is otherwise
+    /// valid and would be accepted by unmodified Bitcoin Core.
+    #[test]
+    fn connect_block_coinbase_m4_invalid_votes_should_not_halt() -> Result<()> {
+        let (_dir, dbs) = create_test_dbs()?;
+        let mut rwtxn = dbs.write_txn().into_diagnostic()?;
+        let prev_hash = BlockHash::all_zeros();
+
+        let m4_script: ScriptBuf = M4AckBundles::OneByte {
+            upvotes: vec![0x00],
+        }
+        .try_into()
+        .expect("build m4 script");
+        let m4_output = TxOut {
+            script_pubkey: m4_script,
+            value: Amount::ZERO,
+        };
+
+        let block = build_test_block(
+            prev_hash,
+            TestBlockParts {
+                extra_coinbase_outputs: vec![m4_output],
+                ..Default::default()
+            },
+        );
+
+        dbs.block_hashes
+            .put_headers(&mut rwtxn, &[(block.header, 0)])
+            .into_diagnostic()?;
+
+        let res = test_handler(&dbs).connect_block(&mut rwtxn, &block);
+        assert!(
+            res.is_ok(),
+            "connect_block must not abort on a non-fatal coinbase M4 error, got: {:?}",
+            res.err()
+        );
+        Ok(())
+    }
+
     #[test]
     fn connect_then_disconnect_restores_db_state() -> Result<()> {
         let (_dir, dbs) = create_test_dbs()?;

--- a/lib/validator/task/mod.rs
+++ b/lib/validator/task/mod.rs
@@ -948,7 +948,7 @@ impl BlockHandler<'_> {
         let mut coinbase_msg_diffs = diff::DiffBuilder::new(rwtxn, dbs, height);
         let m4_exists = coinbase_messages.m4_exists();
         for (message, _vout) in coinbase_messages {
-            let (event, diff) = coinbase_msg_diffs.rotxn(|rotxn, _dbs| {
+            let (event, diff) = match coinbase_msg_diffs.rotxn(|rotxn, _dbs| {
                 self.handle_coinbase_message(
                     rotxn,
                     height,
@@ -956,7 +956,20 @@ impl BlockHandler<'_> {
                     &mut accepted_bmm_requests,
                     message,
                 )
-            })?;
+            }) {
+                Ok(ok) => ok,
+                // Mirror the non-coinbase tx loop below: a non-fatal error from
+                // a (miner-controlled) coinbase message must not abort block
+                // connection or any miner could wedge every enforcer with a
+                // malformed M3/M4/etc.
+                Err(err) => {
+                    if err.is_fatal() {
+                        return Err(err);
+                    }
+                    tracing::warn!("Non-fatal error handling coinbase message: {err:#}");
+                    continue;
+                }
+            };
             match event {
                 Some(CoinbaseMessageEvent::NewSidechainProposal { sidechain }) => {
                     let proposal = sidechain.proposal;


### PR DESCRIPTION
A non-fatal error from a coinbase message (e.g. an M4 with the wrong vote count or an M3 for an inactive sidechain) aborts `connect_block`. The non-coinbase tx loop already skips non-fatal errors but the coinbase loop did not.

## Fix

Skip non-fatal coinbase message errors, matching the tx loop.

## Test

Adds `connect_block_coinbase_m4_invalid_votes_should_not_halt` which fails before the fix (`InvalidVotes { expected: 0, len: 1 }`) and passes on PR branch.