### PR TITLE
Reject transactions that spend a treasury UTXO without creating a new one

### DIFF
--- a/lib/validator/task/error.rs
+++ b/lib/validator/task/error.rs
@@ -243,6 +243,15 @@ pub(in crate::validator) enum HandleM5M6 {
     #[error("Old Ctip for sidechain {} is unspent", .sidechain_number.0)]
     #[fatal(false)]
     OldCtipUnspent { sidechain_number: SidechainNumber },
+    /// BIP 300: a transaction that spends a treasury UTXO as one of its inputs
+    /// and does not create a new treasury UTXO as one of its outputs is
+    /// invalid.
+    #[error(
+        "treasury UTXO for sidechain {} is spent without creating a new treasury UTXO",
+        .sidechain_number.0
+    )]
+    #[fatal(false)]
+    TreasurySpentWithoutNewCtip { sidechain_number: SidechainNumber },
     #[error("cannot deposit or withdraw zero sats from sidechain")]
     #[fatal(false)]
     ZeroDiff,

--- a/lib/validator/task/mod.rs
+++ b/lib/validator/task/mod.rs
@@ -2180,6 +2180,55 @@ mod tests {
         Ok(())
     }
 
+    /// BIP 300: a tx that spends a treasury UTXO without creating a new
+    /// treasury UTXO is invalid. OP_DRIVECHAIN is anyone-can-spend, so without
+    /// this rule anyone could drain the treasury.
+    #[test]
+    fn handle_m5_m6_treasury_spent_without_new_ctip_is_invalid() -> Result<()> {
+        let (_dir, dbs) = create_test_dbs()?;
+        let mut rwtxn = dbs.write_txn().into_diagnostic()?;
+        let sc = SidechainNumber(1);
+        let treasury_outpoint = OutPoint {
+            txid: Txid::from_byte_array([0x11; 32]),
+            vout: 0,
+        };
+        dbs.active_sidechains
+            .put_ctip(
+                &mut rwtxn,
+                sc,
+                &Ctip {
+                    outpoint: treasury_outpoint,
+                    value: Amount::from_sat(5_000),
+                },
+            )
+            .into_diagnostic()?;
+
+        // Spend the treasury UTXO and pay it all to a non-treasury output.
+        let theft_tx = Transaction {
+            version: bitcoin::transaction::Version::TWO,
+            lock_time: bitcoin::locktime::absolute::LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: treasury_outpoint,
+                ..TxIn::default()
+            }],
+            output: vec![TxOut {
+                script_pubkey: ScriptBuf::new(),
+                value: Amount::from_sat(5_000),
+            }],
+        };
+
+        let err = test_handler(&dbs)
+            .handle_m5_m6(&rwtxn, Cow::Borrowed(&theft_tx))
+            .expect_err("spending a treasury without creating a new one must be invalid");
+        assert!(matches!(
+            err,
+            error::HandleM5M6::TreasurySpentWithoutNewCtip { sidechain_number }
+                if sidechain_number == sc
+        ));
+        assert!(!err.is_fatal());
+        Ok(())
+    }
+
     // ── handle_m1 ──
 
     #[test]

--- a/lib/validator/task/mod.rs
+++ b/lib/validator/task/mod.rs
@@ -669,6 +669,17 @@ impl BlockHandler<'_> {
             new_ctips
         };
         let n_new_ctips = new_ctips.len();
+        // BIP 300: a tx that spends a treasury UTXO must also create a new
+        // treasury UTXO for that sidechain. Without this check, a spend of the
+        // anyone-can-spend OP_DRIVECHAIN treasury that creates no replacement
+        // output is silently ignored and drains the slot.
+        for sidechain_number in ctip_spends.keys() {
+            if !new_ctips.contains_key(sidechain_number) {
+                return Err(error::HandleM5M6::TreasurySpentWithoutNewCtip {
+                    sidechain_number: *sidechain_number,
+                });
+            }
+        }
         // Check that old ctips are spent
         let mut res = Option::<DepositsOrSuccessfulWithdrawal>::None;
         for (sidechain_number, new_ctip) in new_ctips {


### PR DESCRIPTION
Per BIP300 a transaction that spends a treasury UTXO as an input and creates no new treasury UTXO as an output is invalid.

https://github.com/LayerTwo-Labs/bip300_bip301_specifications/blob/master/bip300.md#validation-rules-specification

`handle_m5_m6` builds `ctip_spends` (treasury inputs) but only consults it inside the loop over `new_ctips` (treasury outputs). A tx that spends a treasury UTXO and creates no new treasury output never enters that loop, so it returns `Ok(None)` and is ignored. OP_DRIVECHAIN is anyone-can-spend, so anyone could drain a sidechain's treasury this way.

This adds the missing check. Every spent treasury must have a corresponding new treasury output, otherwise the tx is invalid. Block-level rejection of the invalid tx is handled by #365 (which propagates non-fatal tx errors instead of
skipping them).