### PR TITLE
Reject re-proposing an already-pending withdrawal bundle (M3)

### DIFF
--- a/lib/validator/task/error.rs
+++ b/lib/validator/task/error.rs
@@ -62,9 +62,21 @@ impl From<db::Error> for HandleFailedSidechainProposals {
 }
 
 #[derive(Debug, Error, Fatality, Split, Transitive)]
+#[expect(clippy::duplicated_attributes)]
 #[split(attrs(derive(Debug, Error)))]
-#[transitive(from(db::error::TryGet, db::Error))]
+#[transitive(from(db::error::Get, db::Error), from(db::error::TryGet, db::Error))]
 pub(in crate::validator) enum HandleM3ProposeBundle {
+    /// BIP 300: an M6ID already proposed in a previous block and not yet paid
+    /// out must not be re-proposed; re-proposing it would reset its ack count.
+    #[error(
+        "withdrawal bundle {m6id} for sidechain slot {} is already pending",
+        .sidechain_number.0
+    )]
+    #[fatal(false)]
+    BundleAlreadyPending {
+        sidechain_number: SidechainNumber,
+        m6id: M6id,
+    },
     #[error(transparent)]
     #[fatal(true)]
     Db(Box<db::Error>),

--- a/lib/validator/task/mod.rs
+++ b/lib/validator/task/mod.rs
@@ -2348,6 +2348,46 @@ mod tests {
         Ok(())
     }
 
+    /// BIP 300 M3: re-proposing a withdrawal bundle that is already pending
+    /// must be rejected, otherwise a miner could reset its ack count and age.
+    #[test]
+    fn handle_m3_rejects_already_pending_bundle() -> Result<()> {
+        let (_dir, dbs) = create_test_dbs()?;
+        let mut rwtxn = dbs.write_txn().into_diagnostic()?;
+        let sc = SidechainNumber(1);
+        dbs.active_sidechains
+            .put_sidechain(&mut rwtxn, &sc, &test_sidechain(1, 0))
+            .into_diagnostic()?;
+
+        // Propose a bundle and apply it, so the m6id is pending.
+        let m6id = test_m6id(0xAA);
+        let diff = test_handler(&dbs)
+            .handle_m3_propose_bundle(&rwtxn, sc, m6id)
+            .into_diagnostic()?;
+        diff.apply(&mut rwtxn, &dbs.active_sidechains, 0)
+            .into_diagnostic()?;
+
+        // Re-proposing the same m6id is rejected.
+        let err = test_handler(&dbs)
+            .handle_m3_propose_bundle(&rwtxn, sc, m6id)
+            .expect_err("re-proposing a pending bundle must be rejected");
+        assert!(matches!(
+            err,
+            error::HandleM3ProposeBundle::BundleAlreadyPending { sidechain_number, m6id: e }
+                if sidechain_number == sc && e == m6id
+        ));
+        assert!(!err.is_fatal());
+
+        // A different, not-yet-pending m6id is still accepted.
+        assert!(
+            test_handler(&dbs)
+                .handle_m3_propose_bundle(&rwtxn, sc, test_m6id(0xBB))
+                .is_ok(),
+            "a not-yet-pending bundle should be accepted"
+        );
+        Ok(())
+    }
+
     // ── handle_m4_votes ──
 
     #[test]

--- a/lib/validator/task/mod.rs
+++ b/lib/validator/task/mod.rs
@@ -298,19 +298,30 @@ impl BlockHandler<'_> {
         m6id: M6id,
     ) -> Result<diff::ProposeBundle, error::HandleM3ProposeBundle> {
         let dbs = self.dbs;
-        if dbs
+        if !dbs
             .active_sidechains
             .sidechain()
             .contains_key(rotxn, &sidechain_number)?
         {
-            let diff = diff::ProposeBundle {
-                m6id,
-                sidechain_number,
-            };
-            Ok(diff)
-        } else {
-            Err(error::HandleM3ProposeBundle::InactiveSidechain { sidechain_number })
+            return Err(error::HandleM3ProposeBundle::InactiveSidechain { sidechain_number });
         }
+        // BIP 300: re-proposing an M6ID that is already pending (proposed in a
+        // previous block and not yet paid out) would reset its ack count and
+        // age. Reject such a block instead.
+        let pending = dbs
+            .active_sidechains
+            .pending_m6ids()
+            .get(rotxn, &sidechain_number)?;
+        if pending.contains_key(&m6id) {
+            return Err(error::HandleM3ProposeBundle::BundleAlreadyPending {
+                sidechain_number,
+                m6id,
+            });
+        }
+        Ok(diff::ProposeBundle {
+            m6id,
+            sidechain_number,
+        })
     }
 
     /// Core M4 upvote resolver: for each active sidechain, interprets the vote


### PR DESCRIPTION
Per BIP300 re-proposing an M6ID that was already proposed in a previous block and not yet paid out must invalidate the block.

`handle_m3_propose_bundle` only checked that the slot is active, and `put_pending_m6id` overwrites an existing entry with a fresh `PendingM6idInfo` (vote_count reset to 1, proposal_height reset). So a miner could reset any pending withdrawal bundle's ack count and age by re-proposing its M6ID via M3, indefinitely blocking a withdrawal or reviving an expired bundle. The M1 path already has this anti-reset protection; M3 did not.

## Fix

Reject an M3 that re-proposes an already-pending M6ID. Re-proposing an expired or paid-out bundle (no longer pending) is still allowed.