### PR TITLE
Restore withdrawal bundle at its original index on M6 undo

### DIFF
--- a/lib/validator/dbs/diff.rs
+++ b/lib/validator/dbs/diff.rs
@@ -526,6 +526,10 @@ pub struct M6 {
     pub sidechain_number: SidechainNumber,
     pub new_ctip: Ctip,
     pub removed_pending_withdrawal: M6id,
+    /// Position of the removed bundle in the chronological pending list at
+    /// apply time, so undo can restore it at the same index (M4 votes index
+    /// pending bundles by position).
+    pub removed_pending_withdrawal_index: usize,
     pub removed_pending_withdrawal_info: PendingM6idInfo,
 }
 
@@ -539,6 +543,7 @@ impl Diff for M6 {
             sidechain_number,
             new_ctip,
             removed_pending_withdrawal,
+            removed_pending_withdrawal_index: _,
             removed_pending_withdrawal_info: _,
         } = self;
         let _: u64 = dbs.put_ctip(rwtxn, *sidechain_number, new_ctip)?;
@@ -552,22 +557,20 @@ impl Diff for M6 {
             sidechain_number,
             new_ctip: _,
             removed_pending_withdrawal,
+            removed_pending_withdrawal_index,
             removed_pending_withdrawal_info,
         } = self;
         let () = dbs.delete_ctip(rwtxn, *sidechain_number)?;
-        let () = dbs.with_pending_withdrawal_entry(
-            rwtxn,
-            sidechain_number,
-            *removed_pending_withdrawal,
-            |entry| match entry {
-                ordermap::map::Entry::Occupied(mut entry) => {
-                    _ = entry.insert(*removed_pending_withdrawal_info)
-                }
-                ordermap::map::Entry::Vacant(entry) => {
-                    _ = entry.insert(*removed_pending_withdrawal_info)
-                }
-            },
-        )?;
+        // Restore the bundle at its original position. `apply` removed it with
+        // a shift-remove, so a plain re-insert would append it at the end and
+        // permanently reorder the remaining bundles.
+        let () = dbs.with_pending_withdrawals(rwtxn, sidechain_number, |pending| {
+            pending.shift_insert(
+                *removed_pending_withdrawal_index,
+                *removed_pending_withdrawal,
+                *removed_pending_withdrawal_info,
+            );
+        })?;
         Ok(())
     }
 }

--- a/lib/validator/dbs/diff.rs
+++ b/lib/validator/dbs/diff.rs
@@ -732,6 +732,61 @@ mod tests {
         Ok(())
     }
 
+    /// M4 votes index pending bundles by chronological position, so an M6
+    /// apply/undo roundtrip (a reorg across a successful withdrawal) must
+    /// restore the exact pending order.
+    #[test]
+    fn m6_undo_restores_pending_order() -> Result<()> {
+        use crate::types::{Ctip, PendingM6idInfo};
+
+        let (_dir, dbs) = create_test_dbs()?;
+        let mut rwtxn = dbs.write_txn().into_diagnostic()?;
+        let sc = SidechainNumber(1);
+        dbs.active_sidechains
+            .put_sidechain(&mut rwtxn, &sc, &test_sidechain(1, 0))
+            .into_diagnostic()?;
+
+        let a = test_m6id(0xAA);
+        let b = test_m6id(0xBB);
+        let c = test_m6id(0xCC);
+        for m in [a, b, c] {
+            dbs.active_sidechains
+                .put_pending_m6id(&mut rwtxn, &sc, m, 0)
+                .into_diagnostic()?;
+        }
+        let order = |rwtxn: &RoTxn| -> Vec<M6id> {
+            dbs.active_sidechains
+                .pending_m6ids()
+                .get(rwtxn, &sc)
+                .unwrap()
+                .keys()
+                .copied()
+                .collect()
+        };
+        assert_eq!(order(&rwtxn), vec![a, b, c]);
+
+        // A successful M6 withdraws the middle bundle b (index 1).
+        let m6 = M6 {
+            sidechain_number: sc,
+            new_ctip: Ctip {
+                outpoint: bitcoin::OutPoint::null(),
+                value: bitcoin::Amount::ZERO,
+            },
+            removed_pending_withdrawal: b,
+            removed_pending_withdrawal_index: 1,
+            removed_pending_withdrawal_info: PendingM6idInfo::new(0),
+        };
+        m6.apply(&mut rwtxn, &dbs.active_sidechains, 0)
+            .into_diagnostic()?;
+        assert_eq!(order(&rwtxn), vec![a, c]);
+
+        // Disconnect (undo) restores the original order [a, b, c].
+        m6.undo(&mut rwtxn, &dbs.active_sidechains)
+            .into_diagnostic()?;
+        assert_eq!(order(&rwtxn), vec![a, b, c]);
+        Ok(())
+    }
+
     #[test]
     fn ack_bundles_upvote_apply_undo_roundtrip() -> Result<()> {
         let (_dir, dbs) = create_test_dbs()?;

--- a/lib/validator/task/mod.rs
+++ b/lib/validator/task/mod.rs
@@ -590,7 +590,7 @@ impl BlockHandler<'_> {
         rotxn: &RoTxn,
         transaction: Transaction,
         old_treasury_value: Amount,
-    ) -> Result<(M6id, SidechainNumber, PendingM6idInfo), error::HandleM5M6> {
+    ) -> Result<(M6id, SidechainNumber, usize, PendingM6idInfo), error::HandleM5M6> {
         let (m6id, sidechain_number) = compute_m6id(transaction, old_treasury_value)?;
 
         let pending_m6ids = self
@@ -602,14 +602,17 @@ impl BlockHandler<'_> {
                 m6id,
                 sidechain_number,
             })?;
-        let info = pending_m6ids
-            .get(&m6id)
-            .ok_or(error::InvalidM6::MissingPendingWithdrawal {
-                m6id,
-                sidechain_number,
-            })?;
+        // Capture the bundle's position in the chronological list so a
+        // disconnect (undo) can restore it at the same index.
+        let (index, _, info) =
+            pending_m6ids
+                .get_full(&m6id)
+                .ok_or(error::InvalidM6::MissingPendingWithdrawal {
+                    m6id,
+                    sidechain_number,
+                })?;
         if info.vote_count > self.thresholds.withdrawal_bundle_inclusion_threshold {
-            Ok((m6id, sidechain_number, *info))
+            Ok((m6id, sidechain_number, index, *info))
         } else {
             let err = error::InvalidM6::InsufficientVoteCount {
                 m6id,
@@ -700,7 +703,7 @@ impl BlockHandler<'_> {
                         };
                         return Err(err.into());
                     }
-                    let (m6id, sidechain_number_, info) = self.handle_m6(
+                    let (m6id, sidechain_number_, removed_index, info) = self.handle_m6(
                         rotxn,
                         transaction.clone().into_owned(),
                         old_treasury_value,
@@ -723,6 +726,7 @@ impl BlockHandler<'_> {
                         sidechain_number,
                         new_ctip,
                         removed_pending_withdrawal: m6id,
+                        removed_pending_withdrawal_index: removed_index,
                         removed_pending_withdrawal_info: info,
                     };
                     match res {


### PR DESCRIPTION
M4 votes index pending withdrawal bundles by chronological position. `M6::apply` removes the withdrawn bundle with a shift-remove (preserving order), but `M6::undo` re-inserted it with a plain insert that appends at the end. So a reorg across a block containing a successful M6 permanently reordered the remaining bundles, making subsequent M4 votes apply to the wrong bundle and an enforcer that experienced the reorg would diverge from a freshly-synced one.

## Fix

Record the bundle's index in the `M6` diff at apply time and `shift_insert` it back at that index on undo (matching what the FailedM6ids path already does).

---

**Note:** Existing enforcer databases need a resync on upgrade (bincode can't default missing fields).