### PR TITLE
Fail sidechain proposals that can no longer reach the activation threshold

### DIFF
--- a/lib/validator/task/mod.rs
+++ b/lib/validator/task/mod.rs
@@ -267,20 +267,29 @@ impl BlockHandler<'_> {
             .filter(|(_proposal_id, sidechain)| {
                 // doing `height - sidechain.status.proposal_height` can panic if the enforcer has data
                 // from a previous sync that is not in the active chain.
-                let sidechain_proposal_age =
-                    height.saturating_sub(sidechain.status.proposal_height);
+                let age = height.saturating_sub(sidechain.status.proposal_height);
                 let sidechain_slot_is_used = dbs
                     .active_sidechains
                     .sidechain()
                     .contains_key(rotxn, &sidechain.proposal.sidechain_number)?;
-                // FIXME: Do we need to check that the vote_count is below the threshold, or is it
-                // enough to check that the max age was exceeded?
-                let failed = sidechain_slot_is_used
-                    && sidechain_proposal_age
-                        > thresholds.used_sidechain_slot_proposal_max_age as u32
-                    || !sidechain_slot_is_used
-                        && sidechain_proposal_age
-                            > thresholds.unused_sidechain_slot_proposal_max_age as u32;
+                let (max_age, threshold) = if sidechain_slot_is_used {
+                    (
+                        thresholds.used_sidechain_slot_proposal_max_age as u32,
+                        thresholds.used_sidechain_slot_activation_threshold as u32,
+                    )
+                } else {
+                    (
+                        thresholds.unused_sidechain_slot_proposal_max_age as u32,
+                        thresholds.unused_sidechain_slot_activation_threshold as u32,
+                    )
+                };
+                // BIP 300: a proposal fails once its age exceeds the max age, or
+                // once it has accumulated enough non-ack blocks that it can no
+                // longer reach the activation threshold within the remaining
+                // window (max_fails = max_age - threshold).
+                let max_fails = max_age.saturating_sub(threshold);
+                let fails = age.saturating_sub(sidechain.status.vote_count as u32);
+                let failed = age > max_age || (age > max_fails && fails >= max_fails);
                 Ok(failed)
             })
             .collect()?;

--- a/lib/validator/task/mod.rs
+++ b/lib/validator/task/mod.rs
@@ -2317,6 +2317,46 @@ mod tests {
         Ok(())
     }
 
+    /// BIP 300: a proposal must fail once it has accumulated enough non-ack
+    /// blocks that it can no longer reach the activation threshold, even before
+    /// its max age. Regtest uses max_age=10, threshold=5, so max_fails=5.
+    #[test]
+    fn handle_failed_sidechain_proposals_early_fails_doomed_proposal() -> Result<()> {
+        let (_dir, dbs) = create_test_dbs()?;
+        let mut rwtxn = dbs.write_txn().into_diagnostic()?;
+        let handler = test_handler(&dbs);
+
+        // Doomed (unused slot, never acked): at height 6, age=6 > max_fails=5
+        // and fails=6 >= 5, but age <= max_age=10, so only the early-failure
+        // rule can catch it.
+        let doomed = test_sidechain(1, 0);
+        let doomed_id = doomed.proposal.compute_id();
+        dbs.proposal_id_to_sidechain
+            .put(&mut rwtxn, &doomed_id, &doomed)
+            .into_diagnostic()?;
+
+        // Healthy (acked every block, fails=0): must not fail.
+        let mut healthy = test_sidechain(2, 0);
+        healthy.status.vote_count = 6;
+        let healthy_id = healthy.proposal.compute_id();
+        dbs.proposal_id_to_sidechain
+            .put(&mut rwtxn, &healthy_id, &healthy)
+            .into_diagnostic()?;
+
+        let failed = handler
+            .handle_failed_sidechain_proposals(&rwtxn, 6)
+            .into_diagnostic()?;
+        assert!(
+            failed.0.contains_key(&doomed_id),
+            "a proposal that can no longer reach the threshold must fail early"
+        );
+        assert!(
+            !failed.0.contains_key(&healthy_id),
+            "a fully-acked proposal must not fail"
+        );
+        Ok(())
+    }
+
     // ── handle_m3 ──
 
     /// BIP 300 M3: a newly proposed bundle starts with an ACK score of 1


### PR DESCRIPTION
BIP300 lists four conditions under which a sidechain proposal fails. The code only implemented the two max-age cutoffs; it omitted the two MAX_FAILS early-failure conditions.

https://github.com/LayerTwo-Labs/bip300301_enforcer/blob/cbc1f8020cf81744b68bb52bc280a1ca385223f8/lib/validator/task/mod.rs#L276-L277

A proposal should fail as soon as it has accumulated enough non-ack blocks that it can no longer reach the activation threshold in its remaining window (max_fails = max_age - threshold; 201 for unused, 13150 for used). Otherwise a doomed proposal lingers until its max age and because `handle_m1` ignores a re-proposal of any still-existing proposal, two enforcers can **diverge** on whether a sidechain activates during that window.

## Fix

Fail a proposal when `age > max_fails && (age - vote_count) >= max_fails`, derived from the existing thresholds.