### PR TITLE
Handle zero-input blinded M6 transactions

### DIFF
--- a/lib/server/wallet/grpc.rs
+++ b/lib/server/wallet/grpc.rs
@@ -1,10 +1,14 @@
-use std::{borrow::Cow, collections::HashMap, str::FromStr, sync::Arc};
+use std::{borrow::Cow, collections::HashMap, io::Cursor, str::FromStr, sync::Arc};
 
 use bdk_wallet::bip39::Mnemonic;
-use bitcoin::{Address, Amount, BlockHash, Transaction, hashes::Hash as _};
+use bitcoin::{
+    consensus::encode::{Decodable, VarInt},
+    hashes::Hash as _,
+    Address, Amount, BlockHash, Transaction, TxOut,
+};
 use futures::{
-    StreamExt as _,
     stream::{BoxStream, FusedStream},
+    StreamExt as _,
 };
 use thiserror::Error;
 
@@ -12,29 +16,28 @@ use crate::{
     convert,
     errors::ErrorChain,
     proto::{
-        StatusBuilder, ToStatus,
         common::ReverseHex,
         mainchain::{
-            BroadcastWithdrawalBundleRequest, BroadcastWithdrawalBundleResponse,
-            CreateBmmCriticalDataTransactionRequest, CreateBmmCriticalDataTransactionResponse,
-            CreateDepositTransactionRequest, CreateDepositTransactionResponse,
-            CreateNewAddressRequest, CreateNewAddressResponse, CreateSidechainProposalRequest,
-            CreateSidechainProposalResponse, CreateWalletRequest, CreateWalletResponse,
-            GenerateBlocksRequest, GenerateBlocksResponse, GetBalanceRequest, GetBalanceResponse,
-            GetInfoRequest, GetInfoResponse, ListSidechainDepositTransactionsRequest,
-            ListSidechainDepositTransactionsResponse, ListTransactionsRequest,
-            ListTransactionsResponse, ListUnspentOutputsRequest, ListUnspentOutputsResponse,
-            SendTransactionRequest, SendTransactionResponse, UnlockWalletRequest,
-            UnlockWalletResponse, WalletTransaction, create_sidechain_proposal_response,
-            get_info_response,
+            create_sidechain_proposal_response, get_info_response,
             list_sidechain_deposit_transactions_response::SidechainDepositTransaction,
             list_unspent_outputs_response, send_transaction_request::RequiredUtxo,
-            wallet_service_server::WalletService,
+            wallet_service_server::WalletService, BroadcastWithdrawalBundleRequest,
+            BroadcastWithdrawalBundleResponse, CreateBmmCriticalDataTransactionRequest,
+            CreateBmmCriticalDataTransactionResponse, CreateDepositTransactionRequest,
+            CreateDepositTransactionResponse, CreateNewAddressRequest, CreateNewAddressResponse,
+            CreateSidechainProposalRequest, CreateSidechainProposalResponse, CreateWalletRequest,
+            CreateWalletResponse, GenerateBlocksRequest, GenerateBlocksResponse, GetBalanceRequest,
+            GetBalanceResponse, GetInfoRequest, GetInfoResponse,
+            ListSidechainDepositTransactionsRequest, ListSidechainDepositTransactionsResponse,
+            ListTransactionsRequest, ListTransactionsResponse, ListUnspentOutputsRequest,
+            ListUnspentOutputsResponse, SendTransactionRequest, SendTransactionResponse,
+            UnlockWalletRequest, UnlockWalletResponse, WalletTransaction,
         },
+        StatusBuilder, ToStatus,
     },
     server::{invalid_field_value, missing_field},
     types::{BlindedM6, Event, SidechainNumber},
-    wallet::{CreateTransactionParams, error::WalletInitialization},
+    wallet::{error::WalletInitialization, CreateTransactionParams},
 };
 
 /// Stream (non-)confirmations for a sidechain proposal
@@ -112,6 +115,37 @@ fn stream_proposal_confirmations(
         };
         futures::future::ready(resp)
     })
+}
+
+fn deserialize_blinded_m6_transaction(
+    bytes: &[u8],
+) -> Result<Transaction, bitcoin::consensus::encode::Error> {
+    match bitcoin::consensus::deserialize(bytes) {
+        Ok(tx) => Ok(tx),
+        Err(deserialize_err) => {
+            let mut cursor = Cursor::new(bytes);
+            let version = bitcoin::transaction::Version::consensus_decode(&mut cursor)?;
+            let input_count = VarInt::consensus_decode(&mut cursor)?;
+            if input_count.0 != 0 {
+                return Err(deserialize_err);
+            }
+            let output_count = VarInt::consensus_decode(&mut cursor)?;
+            let mut output = Vec::with_capacity(output_count.0 as usize);
+            for _ in 0..output_count.0 {
+                output.push(TxOut::consensus_decode(&mut cursor)?);
+            }
+            let lock_time = bitcoin::absolute::LockTime::consensus_decode(&mut cursor)?;
+            if cursor.position() != bytes.len() as u64 {
+                return Err(deserialize_err);
+            }
+            Ok(Transaction {
+                version,
+                lock_time,
+                input: Vec::new(),
+                output,
+            })
+        }
+    }
 }
 
 #[tonic::async_trait]
@@ -296,7 +330,7 @@ impl WalletService for crate::wallet::Wallet {
         };
         let transaction_bytes = transaction
             .ok_or_else(|| missing_field::<BroadcastWithdrawalBundleRequest>("transaction"))?;
-        let transaction: Transaction = bitcoin::consensus::deserialize(&transaction_bytes)
+        let transaction: Transaction = deserialize_blinded_m6_transaction(&transaction_bytes)
             .map_err(|err| {
                 invalid_field_value::<BroadcastWithdrawalBundleRequest, _>(
                     "transaction",

--- a/lib/wallet/mod.rs
+++ b/lib/wallet/mod.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::HashMap,
+    io::Cursor,
     path::Path,
     str::FromStr,
     sync::Arc,
@@ -20,7 +21,11 @@ use bdk_wallet::{
     },
 };
 use bitcoin::{
-    Amount, BlockHash, Network, Transaction, Txid,
+    Amount, BlockHash, Network, Transaction, TxOut, Txid,
+    consensus::{
+        Decodable, Encodable,
+        encode::{self, VarInt},
+    },
     hashes::{Hash as _, HashEngine, sha256, sha256d},
     script::PushBytesBuf,
 };
@@ -70,6 +75,61 @@ type BdkWallet = bdk_wallet::PersistedWallet<Persistence>;
 
 type ElectrumClient = BdkElectrumClient<bdk_electrum::electrum_client::Client>;
 type EsploraClient = bdk_esplora::esplora_client::AsyncClient;
+
+fn serialize_blinded_m6_for_storage(tx: &Transaction) -> Vec<u8> {
+    if !tx.input.is_empty() {
+        return bitcoin::consensus::serialize(tx);
+    }
+
+    let mut bytes = Vec::new();
+    tx.version
+        .consensus_encode(&mut bytes)
+        .expect("Vec writes cannot fail");
+    VarInt(0)
+        .consensus_encode(&mut bytes)
+        .expect("Vec writes cannot fail");
+    VarInt(tx.output.len() as u64)
+        .consensus_encode(&mut bytes)
+        .expect("Vec writes cannot fail");
+    for output in &tx.output {
+        output
+            .consensus_encode(&mut bytes)
+            .expect("Vec writes cannot fail");
+    }
+    tx.lock_time
+        .consensus_encode(&mut bytes)
+        .expect("Vec writes cannot fail");
+    bytes
+}
+
+fn deserialize_blinded_m6_from_storage(bytes: &[u8]) -> Result<Transaction, encode::Error> {
+    match bitcoin::consensus::deserialize(bytes) {
+        Ok(tx) => Ok(tx),
+        Err(deserialize_err) => {
+            let mut cursor = Cursor::new(bytes);
+            let version = bitcoin::transaction::Version::consensus_decode(&mut cursor)?;
+            let input_count = VarInt::consensus_decode(&mut cursor)?;
+            if input_count.0 != 0 {
+                return Err(deserialize_err);
+            }
+            let output_count = VarInt::consensus_decode(&mut cursor)?;
+            let mut output = Vec::with_capacity(output_count.0 as usize);
+            for _ in 0..output_count.0 {
+                output.push(TxOut::consensus_decode(&mut cursor)?);
+            }
+            let lock_time = bitcoin::absolute::LockTime::consensus_decode(&mut cursor)?;
+            if cursor.position() != bytes.len() as u64 {
+                return Err(deserialize_err);
+            }
+            Ok(Transaction {
+                version,
+                lock_time,
+                input: Vec::new(),
+                output,
+            })
+        }
+    }
+}
 
 #[non_exhaustive]
 enum ChainSourceClient {
@@ -912,7 +972,8 @@ impl Wallet {
                 .transpose_into_fallible()
                 .map_err(error::GetBundleProposals::from)
                 .for_each(|(sidechain_number, m6id, bundle_tx_bytes)| {
-                    let bundle_proposal_tx = bitcoin::consensus::deserialize(&bundle_tx_bytes)?;
+                    let bundle_proposal_tx =
+                        deserialize_blinded_m6_from_storage(&bundle_tx_bytes)?;
                     let bundle_proposal_tx =
                         BlindedM6::try_from(std::borrow::Cow::Owned(bundle_proposal_tx))?;
                     bundle_proposals
@@ -2144,7 +2205,7 @@ impl Wallet {
         blinded_m6: &BlindedM6<'static>,
     ) -> Result<M6id, rusqlite::Error> {
         let m6id = blinded_m6.compute_m6id();
-        let tx_bytes = bitcoin::consensus::serialize(blinded_m6.as_ref());
+        let tx_bytes = serialize_blinded_m6_for_storage(blinded_m6.as_ref());
         self.inner.self_db
             .lock()
             .await


### PR DESCRIPTION
## Summary
- accept zero-input blinded M6 transactions in BroadcastWithdrawalBundle without mis-parsing them as segwit marker/flag bytes
- store zero-input blinded M6 bundle proposals with an explicit input-count VarInt instead of witness marker encoding
- reload stored bundle proposals with the same zero-input fallback parser so M3 proposal mining works after restart

## Verification
- cargo check -p bip300301_enforcer_lib --lib
- local Liquid sidechain peg-out smoke: BroadcastWithdrawalBundle accepted M6id 12f164c44356a63417364a9fa532335aad14ace2745c90501dfeddd045350bb2; native enforcer template included M3; mined mainchain block 15281 reported sidechain 5 withdrawal bundle event submitted; next block 15282 included M4 ACK output.