### PR TITLE
Integration tests: revert "integration tests: refactor, simplify"

### DIFF
--- a/integration_tests/integration_test.rs
+++ b/integration_tests/integration_test.rs
@@ -20,7 +20,9 @@ use tracing::Instrument as _;
 
 use crate::{
     mine::{mine, mine_check_block_events, mine_signet_check},
-    setup::{Directories, DummySidechain, MiningMode, Mode, Network, PostSetup, PreSetup},
+    setup::{
+        Directories, DummySidechain, MiningMode, Mode, Network, PostSetup, PreSetup, Sidechain,
+    },
     test_peer_bmm_request, test_unconfirmed_transactions,
     util::{AsyncTrial, BinPaths, FileDumpConfig, TestFailureCollector, TestFileRegistry},
 };
@@ -131,7 +133,10 @@ where
     )
 }
 
-pub async fn propose_sidechain(post_setup: &mut PostSetup) -> anyhow::Result<()> {
+pub async fn propose_sidechain<S>(post_setup: &mut PostSetup) -> anyhow::Result<()>
+where
+    S: Sidechain,
+{
     tracing::info!("Proposing sidechain");
     let create_sidechain_proposal_request = {
         let sidechain_declaration =
@@ -147,7 +152,7 @@ pub async fn propose_sidechain(post_setup: &mut PostSetup) -> anyhow::Result<()>
             sidechain_declaration: Some(sidechain_declaration),
         };
         CreateSidechainProposalRequest {
-            sidechain_id: Some(DummySidechain::SIDECHAIN_NUMBER.0.into()),
+            sidechain_id: Some(S::SIDECHAIN_NUMBER.0.into()),
             declaration: Some(declaration),
         }
     };
@@ -159,7 +164,7 @@ pub async fn propose_sidechain(post_setup: &mut PostSetup) -> anyhow::Result<()>
     // Wait before mining
     sleep(std::time::Duration::from_secs(1)).await;
     tracing::debug!("Mining 1 block");
-    let () = mine(post_setup, 1, Some(true)).await?;
+    let () = mine::<S>(post_setup, 1, Some(true)).await?;
     let Some(_) = create_sidechain_proposal_resp.try_next().await? else {
         anyhow::bail!("Expected response when proposing sidechain");
     };
@@ -176,7 +181,10 @@ pub async fn propose_sidechain(post_setup: &mut PostSetup) -> anyhow::Result<()>
     Ok(())
 }
 
-pub async fn activate_sidechain(post_setup: &mut PostSetup) -> anyhow::Result<()> {
+pub async fn activate_sidechain<S>(post_setup: &mut PostSetup) -> anyhow::Result<()>
+where
+    S: Sidechain,
+{
     tracing::info!("Activating sidechain");
     tracing::debug!("Checking that 0 sidechains are active");
     let sidechains_resp = post_setup
@@ -189,7 +197,8 @@ pub async fn activate_sidechain(post_setup: &mut PostSetup) -> anyhow::Result<()
     };
     let blocks_to_mine = 6;
     tracing::debug!("Mining {blocks_to_mine} blocks");
-    let _ = mine_check_block_events(post_setup, blocks_to_mine, Some(true), |_, _| Ok(())).await?;
+    let _ = mine_check_block_events::<_, S>(post_setup, blocks_to_mine, Some(true), |_, _| Ok(()))
+        .await?;
     tracing::debug!("Checking that exactly 1 sidechain is active");
     let sidechains_resp = post_setup
         .validator_service_client
@@ -223,7 +232,10 @@ pub async fn wait_for_wallet_sync() -> anyhow::Result<()> {
     Ok(())
 }
 
-pub async fn fund_enforcer(post_setup: &mut PostSetup) -> anyhow::Result<()> {
+pub async fn fund_enforcer<S>(post_setup: &mut PostSetup) -> anyhow::Result<()>
+where
+    S: Sidechain,
+{
     use std::convert::Infallible;
     const BLOCKS: u32 = 100;
     let progress_bar = indicatif::ProgressBar::new(BLOCKS as u64).with_style(
@@ -250,7 +262,7 @@ pub async fn fund_enforcer(post_setup: &mut PostSetup) -> anyhow::Result<()> {
                 .await?;
         }
         Network::Signet => {
-            mine_signet_check::<_, Infallible>(post_setup, BLOCKS, |_| {
+            mine_signet_check::<_, Infallible, S>(post_setup, BLOCKS, |_| {
                 progress_bar.inc(1);
                 Ok(())
             })
@@ -262,26 +274,19 @@ pub async fn fund_enforcer(post_setup: &mut PostSetup) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Propose a sidechain via M1, ack it over `USED_SIDECHAIN_SLOT_ACTIVATION_THRESHOLD`
-/// blocks until activation, then top up the enforcer wallet with UTXOs to mine
-/// with. The standard prelude for tests that need an active sidechain.
-pub async fn setup_active_sidechain(post_setup: &mut PostSetup) -> anyhow::Result<()> {
-    propose_sidechain(post_setup).await?;
-    activate_sidechain(post_setup).await?;
-    fund_enforcer(post_setup).await?;
-    Ok(())
-}
-
 const DEPOSIT_AMOUNT: bitcoin::Amount = bitcoin::Amount::from_sat(21_000_000);
 const DEPOSIT_FEE: bitcoin::Amount = bitcoin::Amount::from_sat(1_000_000);
 
-pub async fn deposit(
+pub async fn deposit<S>(
     post_setup: &mut PostSetup,
-    sidechain: &mut DummySidechain,
+    sidechain: &mut S,
     sidechain_address: &str,
     deposit_amount: bitcoin::Amount,
     deposit_fee: bitcoin::Amount,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<()>
+where
+    S: Sidechain,
+{
     tracing::info!(
         deposit_amount = %deposit_amount.display_dynamic(),
         deposit_fee = %deposit_fee.display_dynamic(),
@@ -290,7 +295,7 @@ pub async fn deposit(
     let deposit_txid: bitcoin::Txid = post_setup
         .wallet_service_client
         .create_deposit_transaction(CreateDepositTransactionRequest {
-            sidechain_id: Some(DummySidechain::SIDECHAIN_NUMBER.0.into()),
+            sidechain_id: Some(S::SIDECHAIN_NUMBER.0.into()),
             address: Some(sidechain_address.to_owned()),
             value_sats: Some(deposit_amount.to_sat()),
             fee_sats: Some(deposit_fee.to_sat()),
@@ -304,18 +309,21 @@ pub async fn deposit(
     // Wait for deposit tx to enter mempool
     sleep(std::time::Duration::from_secs(1)).await;
     tracing::debug!("Mining 1 sidechain block");
-    let () = mine_check_block_events(post_setup, 1, None, |_, block_info| {
-        match block_info.events.as_slice() {
-            [
-                block_info::Event {
-                    event: Some(block_info::event::Event::Deposit(_)),
-                },
-            ] => Ok(()),
-            events => anyhow::bail!("Expected deposit event, found `{events:?}`"),
-        }
+    let () = mine_check_block_events::<_, S>(post_setup, 1, None, |_, block_info| match block_info
+        .events
+        .as_slice()
+    {
+        [
+            block_info::Event {
+                event: Some(block_info::event::Event::Deposit(_)),
+            },
+        ] => Ok(()),
+        events => anyhow::bail!("Expected deposit event, found `{events:?}`"),
     })
     .await?;
-    sidechain.confirm_deposit(post_setup, sidechain_address, deposit_amount, deposit_txid);
+    let () = sidechain
+        .confirm_deposit(post_setup, sidechain_address, deposit_amount, deposit_txid)
+        .await?;
     Ok(())
 }
 
@@ -346,12 +354,15 @@ const WITHDRAW_AMOUNT_1: Amount = Amount::from_sat(18_000_000);
 const WITHDRAW_FEE_1: Amount = Amount::from_sat(1_000_000);
 
 // Create a withdrawal, and let it expire
-async fn withdraw_expire(
+async fn withdraw_expire<S>(
     post_setup: &mut PostSetup,
-    sidechain: &mut DummySidechain,
+    sidechain: &mut S,
     withdraw_amount: Amount,
     withdraw_fee: Amount,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<()>
+where
+    S: Sidechain,
+{
     tracing::info!(
         value = %withdraw_amount.display_dynamic(),
         fee = %withdraw_fee.display_dynamic(),
@@ -367,27 +378,28 @@ async fn withdraw_expire(
         )
         .await?;
     tracing::debug!("Mining 1 block to include M3 for withdrawal bundle");
-    let () = mine_check_block_events(post_setup, 1, None, |_, block_info| {
-        match block_info.events.as_slice() {
-            [event] => {
-                let (event_m6id, event) = expect_withdrawal_bundle_event(event)?;
-                let withdrawal_bundle_event::event::Event::Submitted(
-                    withdrawal_bundle_event::event::Submitted {},
-                ) = event
-                else {
-                    anyhow::bail!("Expected withdrawal bundle submitted event, found `{event:?}`")
-                };
-                anyhow::ensure!(*event_m6id == ConsensusHex::encode(&m6id.0));
-                Ok(())
-            }
-            events => {
-                anyhow::bail!("Expected withdrawal bundle submitted event, found `{events:?}`")
-            }
+    let () = mine_check_block_events::<_, S>(post_setup, 1, None, |_, block_info| match block_info
+        .events
+        .as_slice()
+    {
+        [event] => {
+            let (event_m6id, event) = expect_withdrawal_bundle_event(event)?;
+            let withdrawal_bundle_event::event::Event::Submitted(
+                withdrawal_bundle_event::event::Submitted {},
+            ) = event
+            else {
+                anyhow::bail!("Expected withdrawal bundle submitted event, found `{event:?}`")
+            };
+            anyhow::ensure!(*event_m6id == ConsensusHex::encode(&m6id.0));
+            Ok(())
+        }
+        events => {
+            anyhow::bail!("Expected withdrawal bundle submitted event, found `{events:?}`")
         }
     })
     .await?;
     tracing::debug!("Mining blocks until withdrawal bundle failure due to expiry");
-    let () = mine_check_block_events(post_setup, 11, None, |seq, block_info| {
+    let () = mine_check_block_events::<_, S>(post_setup, 11, None, |seq, block_info| {
         match (seq, block_info.events.as_slice()) {
             (10, [event]) => {
                 let (event_m6id, event) = expect_withdrawal_bundle_event(event)?;
@@ -412,13 +424,16 @@ async fn withdraw_expire(
 }
 
 // Upvote the next withdrawal bundle so that it succeeds
-pub async fn withdraw_succeed(
+pub async fn withdraw_succeed<S>(
     post_setup: &mut PostSetup,
-    sidechain: &mut DummySidechain,
+    sidechain: &mut S,
     withdraw_amount: Amount,
     withdraw_fee: Amount,
     pending_withdrawal_value: Amount,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<()>
+where
+    S: Sidechain,
+{
     tracing::info!(
         value = %withdraw_amount.display_dynamic(),
         fee = %withdraw_fee.display_dynamic(),
@@ -429,22 +444,23 @@ pub async fn withdraw_succeed(
         .create_withdrawal(post_setup, &receive_address, withdraw_amount, withdraw_fee)
         .await?;
     tracing::debug!("Mining 1 block to include M3 for withdrawal bundle");
-    let () = mine_check_block_events(post_setup, 1, None, |_, block_info| {
-        match block_info.events.as_slice() {
-            [event] => {
-                let (event_m6id, event) = expect_withdrawal_bundle_event(event)?;
-                let withdrawal_bundle_event::event::Event::Submitted(
-                    withdrawal_bundle_event::event::Submitted {},
-                ) = event
-                else {
-                    anyhow::bail!("Expected withdrawal bundle submitted event, found `{event:?}`")
-                };
-                anyhow::ensure!(*event_m6id == ConsensusHex::encode(&m6id.0));
-                Ok(())
-            }
-            events => {
-                anyhow::bail!("Expected withdrawal bundle submitted event, found `{events:?}`")
-            }
+    let () = mine_check_block_events::<_, S>(post_setup, 1, None, |_, block_info| match block_info
+        .events
+        .as_slice()
+    {
+        [event] => {
+            let (event_m6id, event) = expect_withdrawal_bundle_event(event)?;
+            let withdrawal_bundle_event::event::Event::Submitted(
+                withdrawal_bundle_event::event::Submitted {},
+            ) = event
+            else {
+                anyhow::bail!("Expected withdrawal bundle submitted event, found `{event:?}`")
+            };
+            anyhow::ensure!(*event_m6id == ConsensusHex::encode(&m6id.0));
+            Ok(())
+        }
+        events => {
+            anyhow::bail!("Expected withdrawal bundle submitted event, found `{events:?}`")
         }
     })
     .await?;
@@ -462,7 +478,7 @@ pub async fn withdraw_succeed(
         bitcoin::Amount::from_str_in(&receive_addr_balance_str, bitcoin::Denomination::Bitcoin)?;
     anyhow::ensure!(receive_addr_balance == bitcoin::Amount::ZERO);
     tracing::debug!("Mining blocks until withdrawal success");
-    let () = mine_check_block_events(post_setup, 6, Some(true), |seq, block_info| {
+    let () = mine_check_block_events::<_, S>(post_setup, 6, Some(true), |seq, block_info| {
         match (seq, block_info.events.as_slice()) {
             (5, [event]) => {
                 let (event_m6id, event) = expect_withdrawal_bundle_event(event)?;
@@ -506,14 +522,23 @@ pub async fn withdraw_succeed(
     Ok(())
 }
 
-pub async fn deposit_withdraw_roundtrip_task(
+pub async fn deposit_withdraw_roundtrip_task<S>(
     post_setup: &mut PostSetup,
-) -> anyhow::Result<DummySidechain> {
-    let mut sidechain = DummySidechain::setup(post_setup).await?;
+    res_tx: mpsc::UnboundedSender<anyhow::Result<()>>,
+    sidechain_init: S::Init,
+) -> anyhow::Result<S>
+where
+    S: Sidechain,
+{
+    let mut sidechain = S::setup(sidechain_init, post_setup, res_tx).await?;
     tracing::info!("Setup successfully");
-    let () = setup_active_sidechain(post_setup).await?;
-    tracing::info!("Active sidechain set up successfully");
-    let deposit_address = sidechain.get_deposit_address();
+    let () = propose_sidechain::<S>(post_setup).await?;
+    tracing::info!("Proposed sidechain successfully");
+    let () = activate_sidechain::<S>(post_setup).await?;
+    tracing::info!("Activated sidechain successfully");
+    let () = fund_enforcer::<S>(post_setup).await?;
+    tracing::info!("Funded enforcer successfully");
+    let deposit_address = sidechain.get_deposit_address().await?;
     let () = deposit(
         post_setup,
         &mut sidechain,
@@ -567,8 +592,17 @@ pub async fn deposit_withdraw_roundtrip_task(
 /// * Creates two deposits
 /// * If mode is not GBT, creates a withdrawal that will be allowed to expire
 /// * Creates and handles a withdrawal
-pub async fn deposit_withdraw_roundtrip(mut post_setup: PostSetup) -> anyhow::Result<()> {
-    let _sidechain = deposit_withdraw_roundtrip_task(&mut post_setup).await?;
+pub async fn deposit_withdraw_roundtrip<S>(
+    mut post_setup: PostSetup,
+    sidechain_init: S::Init,
+) -> anyhow::Result<()>
+where
+    S: Sidechain + Send,
+    S::Init: Send + 'static,
+{
+    let (res_tx, _) = mpsc::unbounded();
+    let _sidechain: S =
+        deposit_withdraw_roundtrip_task::<S>(&mut post_setup, res_tx, sidechain_init).await?;
     Ok(())
 }
 
@@ -594,7 +628,7 @@ pub fn tests(
                 file_registry: file_registry.clone(),
                 failure_collector: failure_collector.clone(),
             },
-            deposit_withdraw_roundtrip,
+            |post_setup| deposit_withdraw_roundtrip::<DummySidechain>(post_setup, ()),
         )
     });
 

--- a/integration_tests/mine.rs
+++ b/integration_tests/mine.rs
@@ -19,7 +19,7 @@ use futures::TryStreamExt as _;
 use thiserror::Error;
 
 use crate::{
-    setup::{DummySidechain, MiningMode, Network, PostSetup},
+    setup::{MiningMode, Network, PostSetup, Sidechain},
     util::VarError,
 };
 
@@ -149,13 +149,14 @@ pub enum MineSignetError {
 }
 
 // Mine blocks, running a check after each block
-pub async fn mine_signet_check<F, Err>(
+pub async fn mine_signet_check<F, Err, S>(
     post_setup: &mut PostSetup,
     blocks: u32,
     mut check: F,
 ) -> Result<(), Either<MineSignetError, Err>>
 where
     F: FnMut(bitcoin::BlockHash) -> Result<(), Err>,
+    S: Sidechain,
 {
     use proto::mainchain::subscribe_events_response::event::Event;
     let signet_miner = post_setup
@@ -165,7 +166,7 @@ where
     let mut stream = post_setup
         .validator_service_client
         .subscribe_events(SubscribeEventsRequest {
-            sidechain_id: Some(DummySidechain::SIDECHAIN_NUMBER.0.into()),
+            sidechain_id: Some(S::SIDECHAIN_NUMBER.0.into()),
         })
         .await
         .map_err(|err| Either::Left(err.into()))?
@@ -211,19 +212,20 @@ where
 }
 
 // Mine blocks, running a check after each block
-pub async fn mine_gbt_check<F, Err>(
+pub async fn mine_gbt_check<F, Err, S>(
     post_setup: &mut PostSetup,
     blocks: u32,
     mut check: F,
 ) -> Result<(), Either<MineGbtError, Err>>
 where
     F: FnMut(bitcoin::BlockHash) -> Result<(), Err>,
+    S: Sidechain,
 {
     use proto::mainchain::subscribe_events_response::event::Event;
     let mut stream = post_setup
         .validator_service_client
         .subscribe_events(SubscribeEventsRequest {
-            sidechain_id: Some(DummySidechain::SIDECHAIN_NUMBER.0.into()),
+            sidechain_id: Some(S::SIDECHAIN_NUMBER.0.into()),
         })
         .await
         .map_err(|err| Either::Left(err.into()))?
@@ -310,11 +312,14 @@ pub enum MineError {
     SignetGenerateBlocks,
 }
 
-pub async fn mine(
+pub async fn mine<S>(
     post_setup: &mut PostSetup,
     blocks: u32,
     ack_all_proposals: Option<bool>,
-) -> Result<(), MineError> {
+) -> Result<(), MineError>
+where
+    S: Sidechain,
+{
     use std::convert::Infallible;
     match (post_setup.network, post_setup.mode.mining_mode()) {
         (Network::Regtest, MiningMode::GenerateBlocks) => {
@@ -327,14 +332,14 @@ pub async fn mine(
             })
         }
         (Network::Regtest, MiningMode::GetBlockTemplate) => {
-            mine_gbt_check::<_, Infallible>(post_setup, blocks, |_| Ok(()))
+            mine_gbt_check::<_, Infallible, S>(post_setup, blocks, |_| Ok(()))
                 .await
                 .map_err(|err| match err {
                     Either::Left(err) => MineError::Gbt(err),
                 })
         }
         (Network::Signet, MiningMode::GetBlockTemplate) => {
-            mine_signet_check::<_, Infallible>(post_setup, blocks, |_| Ok(()))
+            mine_signet_check::<_, Infallible, S>(post_setup, blocks, |_| Ok(()))
                 .await
                 .map_err(|err| match err {
                     Either::Left(err) => MineError::Signet(err),
@@ -345,7 +350,7 @@ pub async fn mine(
 }
 
 /// Mine blocks, and check the events for each block
-pub async fn mine_check_block_events<F>(
+pub async fn mine_check_block_events<F, S>(
     post_setup: &mut PostSetup,
     blocks: u32,
     ack_all_proposals: Option<bool>,
@@ -353,17 +358,18 @@ pub async fn mine_check_block_events<F>(
 ) -> anyhow::Result<()>
 where
     F: FnMut(u32, proto::mainchain::BlockInfo) -> anyhow::Result<()>,
+    S: Sidechain,
 {
     tracing::debug!("Mining {blocks} block(s)");
     let mut events = post_setup
         .validator_service_client
         .subscribe_events(SubscribeEventsRequest {
-            sidechain_id: Some(DummySidechain::SIDECHAIN_NUMBER.0.into()),
+            sidechain_id: Some(S::SIDECHAIN_NUMBER.0.into()),
         })
         .await?
         .into_inner();
     for blocks_mined in 0..blocks {
-        let () = mine(post_setup, 1, ack_all_proposals).await?;
+        let () = mine::<S>(post_setup, 1, ack_all_proposals).await?;
         let Some(event) = events
             .try_next()
             .await?

--- a/integration_tests/setup.rs
+++ b/integration_tests/setup.rs
@@ -4,6 +4,7 @@ use std::{
     borrow::Borrow,
     collections::HashMap,
     ffi::OsStr,
+    future::Future,
     net::SocketAddr,
     path::PathBuf,
     sync::{Arc, LazyLock},
@@ -23,7 +24,7 @@ use bip300301_enforcer_lib::{
     types::{BlindedM6, BlindedM6Error, M6id, SidechainNumber},
 };
 use bitcoin::{Address, Txid};
-use futures::{FutureExt as _, StreamExt, channel::mpsc};
+use futures::{FutureExt as _, StreamExt, channel::mpsc, future};
 use reserve_port::ReservedPort;
 use temp_dir::TempDir;
 use thiserror::Error;
@@ -734,6 +735,48 @@ impl<B> PreSetup<B> {
     }
 }
 
+pub trait Sidechain: Sized {
+    const SIDECHAIN_NUMBER: SidechainNumber;
+
+    type Init;
+
+    type SetupError: std::error::Error + Send + Sync + 'static;
+
+    fn setup(
+        init: Self::Init,
+        post_setup: &PostSetup,
+        res_tx: mpsc::UnboundedSender<anyhow::Result<()>>,
+    ) -> impl Future<Output = Result<Self, Self::SetupError>> + Send;
+
+    type GetDepositAddressError: std::error::Error + Send + Sync + 'static;
+
+    /// Get a sidechain address to deposit to
+    fn get_deposit_address(
+        &self,
+    ) -> impl Future<Output = Result<String, Self::GetDepositAddressError>> + Send;
+
+    type ConfirmDepositError: std::error::Error + Send + Sync + 'static;
+
+    fn confirm_deposit(
+        &mut self,
+        post_setup: &mut PostSetup,
+        address: &str,
+        value: bitcoin::Amount,
+        txid: bitcoin::Txid,
+    ) -> impl Future<Output = Result<(), Self::ConfirmDepositError>> + Send;
+
+    /// Create a withdrawal and broadcast the bundle
+    type CreateWithdrawalError: std::error::Error + Send + Sync + 'static;
+
+    fn create_withdrawal(
+        &mut self,
+        post_setup: &mut PostSetup,
+        receive_address: &bitcoin::Address,
+        value: bitcoin::Amount,
+        fee: bitcoin::Amount,
+    ) -> impl Future<Output = Result<M6id, Self::CreateWithdrawalError>> + Send;
+}
+
 #[derive(Debug, Error)]
 pub enum DummySidechainError {
     #[error(transparent)]
@@ -909,10 +952,18 @@ impl DummySidechain {
     }
 }
 
-impl DummySidechain {
-    pub const SIDECHAIN_NUMBER: SidechainNumber = SidechainNumber(0);
+impl Sidechain for DummySidechain {
+    const SIDECHAIN_NUMBER: SidechainNumber = SidechainNumber(0);
 
-    pub async fn setup(post_setup: &PostSetup) -> Result<Self, tonic::Status> {
+    type Init = ();
+
+    type SetupError = tonic::Status;
+
+    async fn setup(
+        _: Self::Init,
+        post_setup: &PostSetup,
+        _: mpsc::UnboundedSender<anyhow::Result<()>>,
+    ) -> Result<Self, Self::SetupError> {
         use bip300301_enforcer_lib::proto::mainchain::SubscribeEventsRequest;
         let subscribe_events_request = SubscribeEventsRequest {
             sidechain_id: Some(Self::SIDECHAIN_NUMBER.0.into()),
@@ -931,26 +982,35 @@ impl DummySidechain {
         })
     }
 
-    pub fn get_deposit_address(&self) -> String {
-        "sidechain address".to_owned()
+    type GetDepositAddressError = std::convert::Infallible;
+
+    fn get_deposit_address(
+        &self,
+    ) -> impl Future<Output = Result<String, Self::GetDepositAddressError>> + Send {
+        future::ok("sidechain address".to_owned())
     }
 
-    pub fn confirm_deposit(
+    type ConfirmDepositError = std::convert::Infallible;
+
+    async fn confirm_deposit(
         &mut self,
-        _post_setup: &mut PostSetup,
-        _address: &str,
-        _value: bitcoin::Amount,
-        _txid: bitcoin::Txid,
-    ) {
+        _: &mut PostSetup,
+        _: &str,
+        _: bitcoin::Amount,
+        _: bitcoin::Txid,
+    ) -> Result<(), Self::ConfirmDepositError> {
+        Ok(())
     }
 
-    pub async fn create_withdrawal(
+    type CreateWithdrawalError = DummySidechainError;
+
+    async fn create_withdrawal(
         &mut self,
         post_setup: &mut PostSetup,
         receive_address: &bitcoin::Address,
         mut value: bitcoin::Amount,
         mut fee: bitcoin::Amount,
-    ) -> Result<M6id, DummySidechainError> {
+    ) -> Result<M6id, Self::CreateWithdrawalError> {
         let () = self.update_from_events()?;
         value += self.pending_withdrawal_value;
         self.pending_withdrawal_value = bitcoin::Amount::ZERO;

--- a/integration_tests/test_invalid_block.rs
+++ b/integration_tests/test_invalid_block.rs
@@ -14,12 +14,13 @@ use bitcoin::{
     script::{Builder as ScriptBuilder, PushBytesBuf},
     transaction::Version,
 };
+use futures::channel::mpsc;
 use serde::Deserialize;
 use tokio::time::sleep;
 
 use crate::{
-    integration_test::setup_active_sidechain,
-    setup::{DummySidechain, PostSetup},
+    integration_test::{activate_sidechain, fund_enforcer, propose_sidechain},
+    setup::{DummySidechain, PostSetup, Sidechain},
 };
 
 struct BadBlockCase {
@@ -106,9 +107,12 @@ fn duplicate_m7_outputs() -> anyhow::Result<Vec<TxOut>> {
 }
 
 pub async fn test_invalid_block(mut post_setup: PostSetup) -> anyhow::Result<()> {
-    let _sidechain = DummySidechain::setup(&post_setup).await?;
+    let (sidechain_res_tx, _sidechain_res_rx) = mpsc::unbounded();
+    let mut _sidechain = DummySidechain::setup((), &post_setup, sidechain_res_tx).await?;
 
-    setup_active_sidechain(&mut post_setup).await?;
+    propose_sidechain::<DummySidechain>(&mut post_setup).await?;
+    activate_sidechain::<DummySidechain>(&mut post_setup).await?;
+    fund_enforcer::<DummySidechain>(&mut post_setup).await?;
     wait_past_mtp(&post_setup).await?;
 
     let stdout_path = post_setup.directories.enforcer_dir.join("stdout.txt");

--- a/integration_tests/test_peer_bmm_request.rs
+++ b/integration_tests/test_peer_bmm_request.rs
@@ -15,9 +15,9 @@ use tokio::time::sleep;
 use tracing::Instrument as _;
 
 use crate::{
-    integration_test::setup_active_sidechain,
+    integration_test::{activate_sidechain, fund_enforcer, propose_sidechain},
     mine,
-    setup::{BitcoindKind, DummySidechain, Mode, Network, SetupOpts},
+    setup::{BitcoindKind, DummySidechain, Mode, Network, SetupOpts, Sidechain},
     util::{self, BinPaths, FileDumpConfig, TestFileRegistry},
 };
 
@@ -146,8 +146,12 @@ impl PreSetup {
 
 async fn test_peer_bmm_request_task(mut post_setup: PostSetup) -> anyhow::Result<()> {
     tracing::info!("Setup successfully");
-    let () = setup_active_sidechain(&mut post_setup.miner).await?;
-    tracing::info!("Active sidechain set up successfully (miner)");
+    let () = propose_sidechain::<DummySidechain>(&mut post_setup.miner).await?;
+    tracing::info!("Proposed sidechain successfully");
+    let () = activate_sidechain::<DummySidechain>(&mut post_setup.miner).await?;
+    tracing::info!("Activated sidechain successfully");
+    let () = fund_enforcer::<DummySidechain>(&mut post_setup.miner).await?;
+    tracing::info!("Funded enforcer successfully (miner)");
 
     let sender_addr = post_setup
         .sender
@@ -170,7 +174,7 @@ async fn test_peer_bmm_request_task(mut post_setup: PostSetup) -> anyhow::Result
     {
         anyhow::bail!("Failed to create a tx to fund sender wallet")
     };
-    let () = crate::mine::mine(&mut post_setup.miner, 1, None).await?;
+    let () = crate::mine::mine::<DummySidechain>(&mut post_setup.miner, 1, None).await?;
     // Wait for sender to receive block
     sleep(std::time::Duration::from_secs(1)).await;
     let sender_balance = post_setup
@@ -233,14 +237,19 @@ async fn test_peer_bmm_request_task(mut post_setup: PostSetup) -> anyhow::Result
         .await?;
     tracing::debug!(%mempool_entry);
     // Mine a block and check that the BMM request worked
-    let () = mine::mine_check_block_events(&mut post_setup.miner, 1, None, |_, block_info| {
-        let bmm_commitment = block_info
-            .bmm_commitment
-            .ok_or_else(|| anyhow::anyhow!("Expected a BMM commitment"))?;
-        let expected_bmm_commitment = ConsensusHex::encode(&sidechain_block_hash);
-        anyhow::ensure!(bmm_commitment == expected_bmm_commitment);
-        Ok(())
-    })
+    let () = mine::mine_check_block_events::<_, DummySidechain>(
+        &mut post_setup.miner,
+        1,
+        None,
+        |_, block_info| {
+            let bmm_commitment = block_info
+                .bmm_commitment
+                .ok_or_else(|| anyhow::anyhow!("Expected a BMM commitment"))?;
+            let expected_bmm_commitment = ConsensusHex::encode(&sidechain_block_hash);
+            anyhow::ensure!(bmm_commitment == expected_bmm_commitment);
+            Ok(())
+        },
+    )
     .await?;
     tracing::info!("Included BMM request tx successfully");
     tracing::info!(

--- a/integration_tests/test_unconfirmed_transactions.rs
+++ b/integration_tests/test_unconfirmed_transactions.rs
@@ -4,12 +4,15 @@ use bip300301_enforcer_lib::proto::mainchain::{
     ListTransactionsRequest, ListUnspentOutputsRequest, SendTransactionRequest,
 };
 
-use crate::{integration_test, setup::PostSetup};
+use crate::{
+    integration_test,
+    setup::{DummySidechain, PostSetup},
+};
 
 // Verify that unconfirmed transactions are immediately available when listing wallet
 // transactions.
 pub async fn test_unconfirmed_transactions(mut post_setup: PostSetup) -> anyhow::Result<()> {
-    integration_test::fund_enforcer(&mut post_setup).await?;
+    integration_test::fund_enforcer::<DummySidechain>(&mut post_setup).await?;
 
     let txs_pre = post_setup
         .wallet_service_client


### PR DESCRIPTION
This reverts commit e28dfaac5afa564523eda0db3491eaeb5b7fca64.
Some integration tests are used downstream for various other sidechains, and are intentionally parametrized by a user-provided sidechain implementation.