### PR TITLE
multi: deserialize blinded M6 TXs, filter on active chains

### DIFF
--- a/integration_tests/integration_test.rs
+++ b/integration_tests/integration_test.rs
@@ -720,5 +720,17 @@ pub fn tests(
         crate::test_consecutive_deposits::test_consecutive_deposits,
     ));
 
+    async_trials.push(new_trial_with_setup(
+        "blinded_m6_roundtrip".to_string(),
+        TestSetupComponents {
+            bin_paths: bin_paths.clone(),
+            network: Network::Regtest,
+            mode: Mode::Mempool,
+            file_registry: file_registry.clone(),
+            failure_collector: failure_collector.clone(),
+        },
+        crate::test_blinded_m6_roundtrip::test_blinded_m6_zero_input_roundtrip,
+    ));
+
     async_trials
 }

--- a/integration_tests/integration_test.rs
+++ b/integration_tests/integration_test.rs
@@ -696,5 +696,17 @@ pub fn tests(
         crate::test_invalid_block::test_invalid_block,
     ));
 
+    async_trials.push(new_trial_with_setup(
+        "blinded_m6_roundtrip".to_string(),
+        TestSetupComponents {
+            bin_paths: bin_paths.clone(),
+            network: Network::Regtest,
+            mode: Mode::Mempool,
+            file_registry: file_registry.clone(),
+            failure_collector: failure_collector.clone(),
+        },
+        crate::test_blinded_m6_roundtrip::test_blinded_m6_zero_input_roundtrip,
+    ));
+
     async_trials
 }

--- a/integration_tests/lib.rs
+++ b/integration_tests/lib.rs
@@ -1,6 +1,7 @@
 pub mod integration_test;
 pub mod mine;
 pub mod setup;
+mod test_blinded_m6_roundtrip;
 mod test_file_based_block_parser;
 mod test_invalid_block;
 mod test_peer_bmm_request;

--- a/integration_tests/lib.rs
+++ b/integration_tests/lib.rs
@@ -2,6 +2,7 @@ pub mod block_verdict;
 pub mod integration_test;
 pub mod mine;
 pub mod setup;
+mod test_blinded_m6_roundtrip;
 mod test_consecutive_deposits;
 mod test_file_based_block_parser;
 mod test_inactive_drivechain_output;

--- a/integration_tests/test_blinded_m6_roundtrip.rs
+++ b/integration_tests/test_blinded_m6_roundtrip.rs
@@ -1,0 +1,188 @@
+use std::borrow::Cow;
+
+use bip300301_enforcer_lib::{
+    bins::CommandExt as _, messages::CoinbaseMessage,
+    proto::mainchain::BroadcastWithdrawalBundleRequest, types::BlindedM6,
+};
+use bitcoin::{
+    Amount, Block, ScriptBuf, Transaction, TxOut, blockdata::locktime::absolute::LockTime,
+    consensus::Encodable, hashes::Hash as _, opcodes::all::OP_RETURN, script::Builder,
+    transaction::Version,
+};
+use either::Either;
+use futures::channel::mpsc;
+
+use crate::{
+    integration_test::{activate_sidechain, propose_sidechain},
+    mine::mine_generateblocks_check,
+    setup::{DummySidechain, PostSetup, Sidechain as _},
+};
+
+fn make_blinded_m6(fee_sats: u64, payout: Amount) -> Transaction {
+    let fee_txout = TxOut {
+        value: Amount::ZERO,
+        script_pubkey: Builder::new()
+            .push_opcode(OP_RETURN)
+            .push_slice(fee_sats.to_be_bytes())
+            .into_script(),
+    };
+    // A plausible P2WPKH payout destination. BlindedM6 does not constrain the
+    // payout script, only that there is non-zero payout value.
+    let payout_spk = {
+        let mut spk = vec![0x00, 0x14];
+        spk.extend_from_slice(&[0x11u8; 20]);
+        ScriptBuf::from_bytes(spk)
+    };
+    let payout_txout = TxOut {
+        value: payout,
+        script_pubkey: payout_spk,
+    };
+    Transaction {
+        version: Version::TWO,
+        lock_time: LockTime::ZERO,
+        input: Vec::new(), // <-- the crux: a blinded M6 has NO inputs
+        output: vec![fee_txout, payout_txout],
+    }
+}
+
+fn serialize_zero_input_legacy(tx: &Transaction) -> Vec<u8> {
+    assert!(
+        tx.input.is_empty(),
+        "legacy zero-input serializer requires no inputs"
+    );
+    assert!(
+        tx.output.len() < 0xFD,
+        "test helper only handles <253 outputs"
+    );
+    let mut buf = Vec::new();
+    tx.version.consensus_encode(&mut buf).unwrap();
+    buf.push(0x00); // CompactSize input count = 0
+    buf.push(tx.output.len() as u8); // CompactSize output count (<253 -> 1 byte)
+    for out in &tx.output {
+        out.consensus_encode(&mut buf).unwrap();
+    }
+    tx.lock_time.consensus_encode(&mut buf).unwrap();
+    buf
+}
+
+async fn mine_block_and_collect_proposed_m6ids(
+    post_setup: &mut PostSetup,
+) -> anyhow::Result<Vec<[u8; 32]>> {
+    let mut block_hashes = Vec::new();
+    mine_generateblocks_check(post_setup, 1, None, |block_hash| {
+        block_hashes.push(block_hash);
+        Ok::<(), std::convert::Infallible>(())
+    })
+    .await
+    .map_err(|err| match err {
+        Either::Left(status) => anyhow::anyhow!("generate_blocks RPC failed: {status}"),
+        Either::Right(never) => match never {},
+    })?;
+    let block_hash = block_hashes
+        .first()
+        .ok_or_else(|| anyhow::anyhow!("generate_blocks produced no block"))?;
+    let block_hex = post_setup
+        .bitcoin_cli
+        .command::<String, _, _, _, _>([], "getblock", [block_hash.to_string(), "0".to_string()])
+        .run_utf8()
+        .await?;
+    let block: Block = bitcoin::consensus::deserialize(&hex::decode(block_hex.trim())?)?;
+    let coinbase = block
+        .txdata
+        .first()
+        .ok_or_else(|| anyhow::anyhow!("mined block has no coinbase"))?;
+    let proposed = coinbase
+        .output
+        .iter()
+        .filter_map(|txout| match CoinbaseMessage::parse(&txout.script_pubkey) {
+            Ok((_, CoinbaseMessage::M3ProposeBundle(m3))) => Some(m3.bundle_txid),
+            _ => None,
+        })
+        .collect();
+    Ok(proposed)
+}
+
+pub async fn test_blinded_m6_zero_input_roundtrip(mut post_setup: PostSetup) -> anyhow::Result<()> {
+    let (sidechain_res_tx, _sidechain_res_rx) = mpsc::unbounded();
+    let mut _sidechain = DummySidechain::setup((), &post_setup, sidechain_res_tx).await?;
+    propose_sidechain::<DummySidechain>(&mut post_setup).await?;
+    activate_sidechain::<DummySidechain>(&mut post_setup).await?;
+
+    let blinded_tx = make_blinded_m6(1_000, Amount::from_sat(50_000));
+
+    // Sanity: this really is a valid blinded M6, so a fixed enforcer must accept it.
+    let _checked: BlindedM6 = Cow::<Transaction>::Owned(blinded_tx.clone())
+        .try_into()
+        .map_err(|err| anyhow::anyhow!("test constructed an invalid blinded M6: {err}"))?;
+
+    // Serialize the way Bitcoin Core / a sidechain does (legacy, NOT segwit).
+    let transaction_bytes = serialize_zero_input_legacy(&blinded_tx);
+
+    // Verify the fixture against Bitcoin Core itself: Core must parse these bytes
+    // in legacy form (`iswitness=false`) and must agree with rust-bitcoin on the txid,
+    // which per BIP300 `m6_to_id` IS the M6ID.
+    //
+    // NB: parseability is all Core can attest here — a
+    // zero-input tx always fails mempool checks (`bad-txns-vin-empty`), since a
+    // blinded M6 is an ID-computation template, not a relayable transaction.
+    let decoded = post_setup
+        .bitcoin_cli
+        .command::<String, _, _, _, _>(
+            [],
+            "decoderawtransaction",
+            [hex::encode(&transaction_bytes), "false".to_string()],
+        )
+        .run_utf8()
+        .await?;
+    let decoded: serde_json::Value = serde_json::from_str(&decoded)?;
+    anyhow::ensure!(decoded["txid"] == blinded_tx.compute_txid().to_string().as_str(),);
+
+    post_setup
+        .wallet_service_client
+        .broadcast_withdrawal_bundle(BroadcastWithdrawalBundleRequest {
+            sidechain_id: Some(0u32),
+            transaction: Some(transaction_bytes),
+        })
+        .await?;
+
+    // Verify the *storage* round-trip: mining a block through the wallet's
+    // own `generate_blocks` makes the enforcer read the bundle back out of its DB
+    // (`get_bundle_proposals` -> `types::deserialize_blinded_m6`, the second site
+    // that has to parse the legacy zero-input form) and propose it as an M3 in the
+    // coinbase. If read-back deserialization failed, block building would error.
+    // If it returned a different tx, the proposed M6ID would not match. So we
+    // mine one block and assert its coinbase proposes exactly our M6ID.
+    let m6id = blinded_tx.compute_txid();
+    let proposed = mine_block_and_collect_proposed_m6ids(&mut post_setup).await?;
+    anyhow::ensure!(
+        proposed.contains(&m6id.to_byte_array()),
+        "stored blinded M6 did not round-trip: mining read it back via \
+         get_bundle_proposals/deserialize_blinded_m6 but the coinbase did not propose our \
+         M6ID ({m6id}) as an M3"
+    );
+
+    // A bundle for a sidechain slot that is NOT active must be
+    // rejected at submission, not stored. Only slot 0 was activated above, so a
+    // submission for slot 1 must fail with FailedPrecondition.
+    //
+    const INACTIVE_SIDECHAIN_ID: u32 = 1;
+    let inactive_tx = make_blinded_m6(2_000, Amount::from_sat(60_000));
+    let inactive_result = post_setup
+        .wallet_service_client
+        .broadcast_withdrawal_bundle(BroadcastWithdrawalBundleRequest {
+            sidechain_id: Some(INACTIVE_SIDECHAIN_ID),
+            transaction: Some(serialize_zero_input_legacy(&inactive_tx)),
+        })
+        .await;
+    let status = inactive_result.err().ok_or_else(|| {
+        anyhow::anyhow!(
+            "BroadcastWithdrawalBundle accepted a bundle for inactive sidechain slot \
+             {INACTIVE_SIDECHAIN_ID}; it must be rejected at ingestion"
+        )
+    })?;
+    anyhow::ensure!(
+        status.code() == tonic::Code::FailedPrecondition,
+        "expected FailedPrecondition rejecting an inactive-slot bundle, got: {status}"
+    );
+    Ok(())
+}

--- a/integration_tests/test_blinded_m6_roundtrip.rs
+++ b/integration_tests/test_blinded_m6_roundtrip.rs
@@ -1,0 +1,194 @@
+use std::borrow::Cow;
+
+use bip300301_enforcer_lib::{
+    bins::CommandExt as _, messages::CoinbaseMessage,
+    proto::mainchain::BroadcastWithdrawalBundleRequest, types::BlindedM6,
+};
+use bitcoin::{
+    Amount, Block, ScriptBuf, Transaction, TxOut, blockdata::locktime::absolute::LockTime,
+    consensus::Encodable, hashes::Hash as _, opcodes::all::OP_RETURN, script::Builder,
+    transaction::Version,
+};
+use either::Either;
+use futures::channel::mpsc;
+
+use crate::{
+    integration_test::{activate_sidechain, propose_sidechain},
+    mine::mine_generateblocks_check,
+    setup::{DummySidechain, PostSetup, Sidechain as _},
+};
+
+fn make_blinded_m6(fee_sats: u64, payout: Amount) -> Transaction {
+    let fee_txout = TxOut {
+        value: Amount::ZERO,
+        script_pubkey: Builder::new()
+            .push_opcode(OP_RETURN)
+            .push_slice(fee_sats.to_be_bytes())
+            .into_script(),
+    };
+    // A plausible P2WPKH payout destination. BlindedM6 does not constrain the
+    // payout script, only that there is non-zero payout value.
+    let payout_spk = {
+        let mut spk = vec![0x00, 0x14];
+        spk.extend_from_slice(&[0x11u8; 20]);
+        ScriptBuf::from_bytes(spk)
+    };
+    let payout_txout = TxOut {
+        value: payout,
+        script_pubkey: payout_spk,
+    };
+    Transaction {
+        version: Version::TWO,
+        lock_time: LockTime::ZERO,
+        input: Vec::new(), // <-- the crux: a blinded M6 has NO inputs
+        output: vec![fee_txout, payout_txout],
+    }
+}
+
+fn serialize_zero_input_legacy(tx: &Transaction) -> Vec<u8> {
+    assert!(
+        tx.input.is_empty(),
+        "legacy zero-input serializer requires no inputs"
+    );
+    assert!(
+        tx.output.len() < 0xFD,
+        "test helper only handles <253 outputs"
+    );
+    let mut buf = Vec::new();
+    tx.version.consensus_encode(&mut buf).unwrap();
+    buf.push(0x00); // CompactSize input count = 0
+    buf.push(tx.output.len() as u8); // CompactSize output count (<253 -> 1 byte)
+    for out in &tx.output {
+        out.consensus_encode(&mut buf).unwrap();
+    }
+    tx.lock_time.consensus_encode(&mut buf).unwrap();
+    buf
+}
+
+async fn mine_block_and_collect_proposed_m6ids(
+    post_setup: &mut PostSetup,
+) -> anyhow::Result<Vec<[u8; 32]>> {
+    let mut block_hashes = Vec::new();
+    mine_generateblocks_check(post_setup, 1, None, |block_hash| {
+        block_hashes.push(block_hash);
+        Ok::<(), std::convert::Infallible>(())
+    })
+    .await
+    .map_err(|err| match err {
+        Either::Left(status) => anyhow::anyhow!("generate_blocks RPC failed: {status}"),
+        Either::Right(never) => match never {},
+    })?;
+    let block_hash = block_hashes
+        .first()
+        .ok_or_else(|| anyhow::anyhow!("generate_blocks produced no block"))?;
+    let block_hex = post_setup
+        .bitcoin_cli
+        .command::<String, _, _, _, _>([], "getblock", [block_hash.to_string(), "0".to_string()])
+        .run_utf8()
+        .await?;
+    let block: Block = bitcoin::consensus::deserialize(&hex::decode(block_hex.trim())?)?;
+    let coinbase = block
+        .txdata
+        .first()
+        .ok_or_else(|| anyhow::anyhow!("mined block has no coinbase"))?;
+    let proposed = coinbase
+        .output
+        .iter()
+        .filter_map(|txout| match CoinbaseMessage::parse(&txout.script_pubkey) {
+            Ok((_, CoinbaseMessage::M3ProposeBundle(m3))) => Some(m3.bundle_txid),
+            _ => None,
+        })
+        .collect();
+    Ok(proposed)
+}
+
+pub async fn test_blinded_m6_zero_input_roundtrip(mut post_setup: PostSetup) -> anyhow::Result<()> {
+    let (sidechain_res_tx, _sidechain_res_rx) = mpsc::unbounded();
+    let mut _sidechain = DummySidechain::setup((), &post_setup, sidechain_res_tx).await?;
+    propose_sidechain::<DummySidechain>(&mut post_setup).await?;
+    activate_sidechain::<DummySidechain>(&mut post_setup).await?;
+
+    let blinded_tx = make_blinded_m6(1_000, Amount::from_sat(50_000));
+
+    // Sanity: this really is a valid blinded M6, so a fixed enforcer must accept it.
+    let _checked: BlindedM6 = Cow::<Transaction>::Owned(blinded_tx.clone())
+        .try_into()
+        .map_err(|err| anyhow::anyhow!("test constructed an invalid blinded M6: {err}"))?;
+
+    // Serialize the way Bitcoin Core / a sidechain does (legacy, NOT segwit).
+    let transaction_bytes = serialize_zero_input_legacy(&blinded_tx);
+
+    // Verify the fixture against Bitcoin Core itself: Core must parse these bytes
+    // in legacy form (`iswitness=false`) and must agree with rust-bitcoin on the txid,
+    // which per BIP300 `m6_to_id` IS the M6ID.
+    //
+    // NB: parseability is all Core can attest here — a
+    // zero-input tx always fails mempool checks (`bad-txns-vin-empty`), since a
+    // blinded M6 is an ID-computation template, not a relayable transaction.
+    let decoded = post_setup
+        .bitcoin_cli
+        .command::<String, _, _, _, _>(
+            [],
+            "decoderawtransaction",
+            [hex::encode(&transaction_bytes), "false".to_string()],
+        )
+        .run_utf8()
+        .await?;
+    let decoded: serde_json::Value = serde_json::from_str(&decoded)?;
+    anyhow::ensure!(decoded["txid"] == blinded_tx.compute_txid().to_string().as_str(),);
+
+    post_setup
+        .wallet_service_client
+        .broadcast_withdrawal_bundle(BroadcastWithdrawalBundleRequest {
+            sidechain_id: bip300301_enforcer_lib::proto::wrap_u32(0),
+            transaction: buffa::MessageField::some(buffa_types::google::protobuf::BytesValue {
+                value: transaction_bytes,
+                ..Default::default()
+            }),
+        })
+        .await?;
+
+    // Verify the *storage* round-trip: mining a block through the wallet's
+    // own `generate_blocks` makes the enforcer read the bundle back out of its DB
+    // (`get_bundle_proposals` -> `BlindedM6::deserialize`, the second site
+    // that parses a stored bundle) and propose it as an M3 in the
+    // coinbase. If read-back deserialization failed, block building would error.
+    // If it returned a different tx, the proposed M6ID would not match. So we
+    // mine one block and assert its coinbase proposes exactly our M6ID.
+    let m6id = blinded_tx.compute_txid();
+    let proposed = mine_block_and_collect_proposed_m6ids(&mut post_setup).await?;
+    anyhow::ensure!(
+        proposed.contains(&m6id.to_byte_array()),
+        "stored blinded M6 did not round-trip: mining read it back via \
+         get_bundle_proposals/BlindedM6::deserialize but the coinbase did not propose our \
+         M6ID ({m6id}) as an M3"
+    );
+
+    // A bundle for a sidechain slot that is NOT active must be
+    // rejected at submission, not stored. Only slot 0 was activated above, so a
+    // submission for slot 1 must fail with FailedPrecondition.
+    //
+    const INACTIVE_SIDECHAIN_ID: u32 = 1;
+    let inactive_tx = make_blinded_m6(2_000, Amount::from_sat(60_000));
+    let inactive_result = post_setup
+        .wallet_service_client
+        .broadcast_withdrawal_bundle(BroadcastWithdrawalBundleRequest {
+            sidechain_id: bip300301_enforcer_lib::proto::wrap_u32(INACTIVE_SIDECHAIN_ID),
+            transaction: buffa::MessageField::some(buffa_types::google::protobuf::BytesValue {
+                value: serialize_zero_input_legacy(&inactive_tx),
+                ..Default::default()
+            }),
+        })
+        .await;
+    let status = inactive_result.err().ok_or_else(|| {
+        anyhow::anyhow!(
+            "BroadcastWithdrawalBundle accepted a bundle for inactive sidechain slot \
+             {INACTIVE_SIDECHAIN_ID}; it must be rejected at ingestion"
+        )
+    })?;
+    anyhow::ensure!(
+        status.code == connectrpc::ErrorCode::FailedPrecondition,
+        "expected FailedPrecondition rejecting an inactive-slot bundle, got: {status}"
+    );
+    Ok(())
+}

--- a/lib/server/wallet/grpc.rs
+++ b/lib/server/wallet/grpc.rs
@@ -326,9 +326,28 @@ impl WalletService for crate::wallet::Wallet {
                 )
             })?
         };
+        // Reject bundles for sidechains that are not active: an inactive slot has no
+        // treasury to withdraw from and, per BIP300 M3, a bundle proposed for it would
+        // be a no-op. Fail fast at ingestion rather than persisting a row that can
+        // never be acted on. NB: this gate cannot catch a slot that is deactivated by
+        // a reorg *after* a bundle is stored, so the block builder
+        // (`get_bundle_proposals`) also skips inactive-slot bundles.
+        let is_active = self
+            .validator()
+            .get_active_sidechains()
+            .map_err(|err| tonic::Status::from_error(err.into()))?
+            .iter()
+            .any(|sidechain| sidechain.proposal.sidechain_number == sidechain_id);
+        if !is_active {
+            return Err(tonic::Status::failed_precondition(format!(
+                "cannot accept a withdrawal bundle for sidechain {sidechain_id}: not active"
+            )));
+        }
         let transaction_bytes = transaction
             .ok_or_else(|| missing_field::<BroadcastWithdrawalBundleRequest>("transaction"))?;
-        let transaction: Transaction = bitcoin::consensus::deserialize(&transaction_bytes)
+        // A blinded M6 is a zero-input tx that Core/sidechains serialize in legacy
+        // form, which rust-bitcoin's standard decoder cannot parse
+        let transaction: Transaction = crate::types::deserialize_blinded_m6(&transaction_bytes)
             .map_err(|err| {
                 invalid_field_value::<BroadcastWithdrawalBundleRequest, _>(
                     "transaction",

--- a/lib/server/wallet/grpc.rs
+++ b/lib/server/wallet/grpc.rs
@@ -1,7 +1,7 @@
-use std::{borrow::Cow, collections::HashMap, str::FromStr, sync::Arc};
+use std::{collections::HashMap, str::FromStr, sync::Arc};
 
 use bdk_wallet::bip39::Mnemonic;
-use bitcoin::{Address, Amount, BlockHash, Transaction, hashes::Hash as _};
+use bitcoin::{Address, Amount, BlockHash, hashes::Hash as _};
 use buffa::MessageField;
 use buffa_types::google::protobuf::UInt32Value;
 use connectrpc::{
@@ -325,28 +325,35 @@ impl WalletService for crate::wallet::Wallet {
         } = request.to_owned_message();
         let sidechain_id =
             parse_sidechain_id::<BroadcastWithdrawalBundleRequest>(sidechain_id, "sidechain_id")?;
+        // Reject bundles for sidechains that are not active: an inactive slot has no
+        // treasury to withdraw from and, per BIP300 M3, a bundle proposed for it would
+        // be a no-op. Fail fast at ingestion rather than persisting a row that can
+        // never be acted on. NB: this gate cannot catch a slot that is deactivated by
+        // a reorg *after* a bundle is stored, so the block builder
+        // (`get_bundle_proposals`) also skips inactive-slot bundles.
+        match self.is_sidechain_active(sidechain_id) {
+            Ok(false) => {
+                return Err(ConnectError::failed_precondition(format!(
+                    "cannot accept a withdrawal bundle for sidechain {sidechain_id}: not active"
+                )));
+            }
+            Ok(true) => (),
+            Err(err) => return Err(internal_err(err)),
+        }
         let transaction_bytes: Vec<u8> = transaction
             .into_option()
             .ok_or_else(|| missing_field::<BroadcastWithdrawalBundleRequest>("transaction"))?
             .value;
-        let transaction: Transaction = bitcoin::consensus::deserialize(&transaction_bytes)
-            .map_err(|err| {
-                invalid_field_value::<BroadcastWithdrawalBundleRequest, _>(
-                    "transaction",
-                    &hex::encode(&transaction_bytes),
-                    err,
-                )
-            })?;
-        let transaction: BlindedM6 =
-            Cow::<Transaction>::Owned(transaction)
-                .try_into()
-                .map_err(|err| {
-                    invalid_field_value::<BroadcastWithdrawalBundleRequest, _>(
-                        "transaction",
-                        &hex::encode(&transaction_bytes),
-                        err,
-                    )
-                })?;
+        // A blinded M6 is a zero-input tx that Core/sidechains serialize in legacy
+        // form, which rust-bitcoin's standard decoder cannot parse;
+        // `BlindedM6::deserialize` handles that fallback and validates the bundle.
+        let transaction = BlindedM6::deserialize(&transaction_bytes).map_err(|err| {
+            invalid_field_value::<BroadcastWithdrawalBundleRequest, _>(
+                "transaction",
+                &hex::encode(&transaction_bytes),
+                err,
+            )
+        })?;
         let _m6id = self
             .put_withdrawal_bundle(sidechain_id, &transaction)
             .await

--- a/lib/types.rs
+++ b/lib/types.rs
@@ -2,8 +2,12 @@ use std::{borrow::Cow, collections::HashMap, num::TryFromIntError, sync::Arc};
 
 use bdk_wallet::chain::{ChainPosition, ConfirmationBlockTime};
 use bitcoin::{
-    Amount, BlockHash, Opcode, OutPoint, ScriptBuf, Transaction, Txid, Work,
+    Amount, BlockHash, Opcode, OutPoint, ScriptBuf, Transaction, TxOut, Txid, Work,
     amount::CheckedSum as _,
+    consensus::{
+        Decodable as _, Encodable as _,
+        encode::{self, VarInt},
+    },
     hashes::{Hash as _, sha256d},
     opcodes::{
         OP_TRUE,
@@ -865,6 +869,78 @@ impl<'a> TryFrom<Cow<'a, bitcoin::Transaction>> for BlindedM6<'a> {
     }
 }
 
+/// Serialize a blinded M6 (see BIP300 `m6_to_id`) in the same **legacy** form Bitcoin
+/// Core uses: `version || 00 (input count) || out_count || outputs || locktime`, with
+/// no BIP144 segwit marker/flag.
+///
+/// Why not just `bitcoin::consensus::serialize`? A zero-input transaction cannot
+/// be serialized unambiguously: BIP144 reuses an input count of `0x00` as the
+/// segwit marker. rust-bitcoin resolves the ambiguity on its side by *always*
+/// emitting the segwit form for zero-input txs, but Core and sidechains emit the
+/// legacy form, and `bitcoin::consensus::deserialize` cannot read it back.
+/// See <https://docs.rs/bitcoin/0.32/bitcoin/transaction/struct.Transaction.html>
+/// ("Serialization notes" on zero-input txs) and
+/// <https://github.com/rust-bitcoin/rust-bitcoin/issues/104>.
+///
+/// Transactions with inputs are not ambiguous, so they take the standard encoder.
+pub fn serialize_blinded_m6(tx: &Transaction) -> Vec<u8> {
+    if !tx.input.is_empty() {
+        return bitcoin::consensus::serialize(tx);
+    }
+
+    let mut bytes = Vec::new();
+
+    // Each `consensus_encode` writes into a `Vec`, which is infallible.
+    tx.version.consensus_encode(&mut bytes).unwrap();
+    const INPUT_COUNT: u64 = 0;
+    VarInt(INPUT_COUNT).consensus_encode(&mut bytes).unwrap();
+    VarInt(tx.output.len() as u64)
+        .consensus_encode(&mut bytes)
+        .unwrap();
+    for output in &tx.output {
+        output.consensus_encode(&mut bytes).unwrap();
+    }
+    tx.lock_time.consensus_encode(&mut bytes).unwrap();
+    bytes
+}
+
+/// Inverse of [`serialize_blinded_m6`]: decode a transaction that may be a
+/// legacy-encoded zero-input blinded M6. Try rust-bitcoin first, then fallback
+/// to our logic.
+pub fn deserialize_blinded_m6(bytes: &[u8]) -> Result<Transaction, encode::Error> {
+    let standard_err = match bitcoin::consensus::deserialize::<Transaction>(bytes) {
+        Ok(tx) => return Ok(tx),
+        Err(err) => err,
+    };
+    let mut cursor = std::io::Cursor::new(bytes);
+    let version = bitcoin::transaction::Version::consensus_decode(&mut cursor)?;
+    let input_count = VarInt::consensus_decode(&mut cursor)?;
+    if input_count.0 != 0 {
+        return Err(standard_err);
+    }
+
+    let output_count = VarInt::consensus_decode(&mut cursor)?;
+
+    // Do NOT pre-allocate from the attacker-controlled `output_count`: a crafted
+    // varint (e.g. u64::MAX) would otherwise panic in `Vec::with_capacity`
+    // or abort the process on a huge allocation. `cursor` is finite, so `push`
+    // grows only as real outputs decode
+    let mut output = Vec::new();
+    for _ in 0..output_count.0 {
+        output.push(TxOut::consensus_decode(&mut cursor)?);
+    }
+    let lock_time = bitcoin::absolute::LockTime::consensus_decode(&mut cursor)?;
+    if cursor.position() != bytes.len() as u64 {
+        return Err(standard_err);
+    }
+    Ok(Transaction {
+        version,
+        lock_time,
+        input: Vec::new(),
+        output,
+    })
+}
+
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 pub struct PendingM6idInfo {
     pub vote_count: u16,
@@ -885,7 +961,10 @@ impl PendingM6idInfo {
 mod tests {
     use miette::Diagnostic as _;
 
-    use crate::types::{SidechainDeclaration, SidechainNumber, SidechainProposal};
+    use crate::types::{
+        SidechainDeclaration, SidechainNumber, SidechainProposal, deserialize_blinded_m6,
+        serialize_blinded_m6,
+    };
 
     fn proposal(description: Vec<u8>) -> SidechainProposal {
         SidechainProposal {
@@ -991,6 +1070,78 @@ mod tests {
         assert_eq!(
             format!("{}", result.unwrap_err().code().unwrap()),
             "sidechain_proposal::unknown_version"
+        );
+    }
+
+    /// A structurally-valid zero-input blinded M6: an `OP_RETURN <fee>` marker at
+    /// index 0 followed by a payout output (so it has >= 2 outputs).
+    fn blinded_m6_tx() -> bitcoin::Transaction {
+        use bitcoin::{
+            Amount, ScriptBuf, TxOut, blockdata::locktime::absolute::LockTime,
+            opcodes::all::OP_RETURN, script::Builder, transaction::Version,
+        };
+        let fee_output = TxOut {
+            value: Amount::ZERO,
+            script_pubkey: Builder::new()
+                .push_opcode(OP_RETURN)
+                .push_slice(1_000u64.to_be_bytes())
+                .into_script(),
+        };
+        let payout_output = TxOut {
+            value: Amount::from_sat(50_000),
+            script_pubkey: ScriptBuf::from_bytes(
+                [vec![0x00, 0x14], vec![0x11; 20]].concat(), // P2WPKH
+            ),
+        };
+        bitcoin::Transaction {
+            version: Version::TWO,
+            lock_time: LockTime::ZERO,
+            input: Vec::new(),
+            output: vec![fee_output, payout_output],
+        }
+    }
+
+    #[test]
+    fn blinded_m6_legacy_roundtrips() {
+        let tx = blinded_m6_tx();
+        let bytes = serialize_blinded_m6(&tx);
+        // It's the legacy frame: version || 00 (input count) || ...
+        assert_eq!(bytes[4], 0x00, "input count byte should be a literal 0x00");
+        // rust-bitcoin's standard decoder cannot read this legacy form (it
+        // misreads the 0x00 as the BIP144 segwit marker) -- the whole reason
+        // `deserialize_blinded_m6` exists. See rust-bitcoin issue #104.
+        assert!(bitcoin::consensus::deserialize::<bitcoin::Transaction>(&bytes).is_err());
+        // ...but our fallback decoder round-trips it faithfully.
+        assert_eq!(deserialize_blinded_m6(&bytes).unwrap(), tx);
+    }
+
+    #[test]
+    fn blinded_m6_with_inputs_uses_standard_codec() {
+        // A tx with inputs is unambiguous, so both fns defer to rust-bitcoin.
+        let mut tx = blinded_m6_tx();
+        tx.input.push(bitcoin::TxIn::default());
+        let bytes = serialize_blinded_m6(&tx);
+        assert_eq!(bytes, bitcoin::consensus::serialize(&tx));
+        assert_eq!(deserialize_blinded_m6(&bytes).unwrap(), tx);
+    }
+
+    /// a zero-input header whose `output_count` varint is attacker-
+    /// chosen as `u64::MAX` must fail cleanly, NOT panic in `Vec::with_capacity`
+    /// This 14-byte payload is reachable from the `BroadcastWithdrawalBundle` RPC.
+    #[test]
+    fn deserialize_blinded_m6_rejects_oversized_output_count_without_panic() {
+        let payload = [
+            0x02, 0x00, 0x00, 0x00, // version = 2
+            0x00, // input count = 0 -> zero-input fallback engages
+            0xFF, // output count varint: 0xFF prefix -> read next 8 bytes as u64
+            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // output count = u64::MAX
+        ];
+        // Sanity: the standard decoder rejects it (segwit marker path), so the
+        // fallback really does run on this input.
+        assert!(bitcoin::consensus::deserialize::<bitcoin::Transaction>(&payload).is_err());
+        assert!(
+            deserialize_blinded_m6(&payload).is_err(),
+            "oversized output_count must be a clean Err, not a panic/abort"
         );
     }
 }

--- a/lib/types.rs
+++ b/lib/types.rs
@@ -2,8 +2,12 @@ use std::{borrow::Cow, collections::HashMap, num::TryFromIntError, sync::Arc};
 
 use bdk_wallet::chain::{ChainPosition, ConfirmationBlockTime};
 use bitcoin::{
-    Amount, BlockHash, Opcode, OutPoint, ScriptBuf, Transaction, Txid, Work,
+    Amount, BlockHash, Opcode, OutPoint, ScriptBuf, Transaction, TxOut, Txid, Work,
     amount::CheckedSum as _,
+    consensus::{
+        Decodable as _,
+        encode::{self, VarInt},
+    },
     hashes::{Hash as _, sha256d},
     opcodes::{
         OP_TRUE,
@@ -768,6 +772,70 @@ impl<'a> BlindedM6<'a> {
         M6id(self.tx.compute_txid())
     }
 
+    /// Consensus-encode this blinded M6 for storage or transport.
+    ///
+    /// Always uses rust-bitcoin's standard encoder. A finalized M6 carries a
+    /// treasury input, so it is never the ambiguous zero-input case. A
+    /// not-yet-finalized zero-input bundle still round-trips, because
+    /// [`BlindedM6::deserialize`] reads rust-bitcoin's own encoding back.
+    pub fn serialize(&self) -> Vec<u8> {
+        bitcoin::consensus::serialize(self.as_ref())
+    }
+
+    /// Decode a blinded M6 from consensus bytes, additionally accepting the
+    /// **legacy** zero-input encoding Bitcoin Core and sidechains use:
+    /// `version || 00 (input count) || out_count || outputs || locktime`, with
+    /// no BIP144 segwit marker/flag.
+    ///
+    /// rust-bitcoin's standard decoder is tried first. It cannot read the legacy
+    /// form, because a zero-input tx is ambiguous: BIP144 reuses an input count
+    /// of `0x00` as the segwit marker, so rust-bitcoin misreads the frame. See
+    /// <https://docs.rs/bitcoin/0.32/bitcoin/transaction/struct.Transaction.html>
+    /// ("Serialization notes" on zero-input txs) and
+    /// <https://github.com/rust-bitcoin/rust-bitcoin/issues/104>. When the
+    /// standard decoder fails, we fall back to parsing the legacy frame by hand.
+    pub fn deserialize(bytes: &[u8]) -> Result<BlindedM6<'static>, BlindedM6DecodeError> {
+        let tx = Self::deserialize_tx(bytes)?;
+        let blinded = BlindedM6::try_from(Cow::Owned(tx))?;
+        Ok(blinded)
+    }
+
+    /// Decode the (possibly legacy zero-input) transaction underlying a blinded
+    /// M6. See [`BlindedM6::deserialize`] for why the legacy fallback exists.
+    fn deserialize_tx(bytes: &[u8]) -> Result<Transaction, encode::Error> {
+        let standard_err = match bitcoin::consensus::deserialize::<Transaction>(bytes) {
+            Ok(tx) => return Ok(tx),
+            Err(err) => err,
+        };
+        let mut cursor = std::io::Cursor::new(bytes);
+        let version = bitcoin::transaction::Version::consensus_decode(&mut cursor)?;
+        let input_count = VarInt::consensus_decode(&mut cursor)?;
+        if input_count.0 != 0 {
+            return Err(standard_err);
+        }
+
+        let output_count = VarInt::consensus_decode(&mut cursor)?;
+
+        // Do NOT pre-allocate from the attacker-controlled `output_count`: a crafted
+        // varint (e.g. u64::MAX) would otherwise panic in `Vec::with_capacity`
+        // or abort the process on a huge allocation. `cursor` is finite, so `push`
+        // grows only as real outputs decode
+        let mut output = Vec::new();
+        for _ in 0..output_count.0 {
+            output.push(TxOut::consensus_decode(&mut cursor)?);
+        }
+        let lock_time = bitcoin::absolute::LockTime::consensus_decode(&mut cursor)?;
+        if cursor.position() != bytes.len() as u64 {
+            return Err(standard_err);
+        }
+        Ok(Transaction {
+            version,
+            lock_time,
+            input: Vec::new(),
+            output,
+        })
+    }
+
     // TODO: remove sidechain_number param
     pub fn into_m6(
         self,
@@ -865,6 +933,25 @@ impl<'a> TryFrom<Cow<'a, bitcoin::Transaction>> for BlindedM6<'a> {
     }
 }
 
+#[derive(Debug, Diagnostic, Error)]
+pub enum BlindedM6DecodeError {
+    #[error(
+        "not a valid transaction in rust-bitcoin's or Bitcoin Core's legacy zero-input encoding"
+    )]
+    Consensus(#[from] encode::Error),
+    #[error("decoded transaction is not a well-formed blinded M6")]
+    Invalid(#[from] BlindedM6Error),
+}
+
+impl ToStatus for BlindedM6DecodeError {
+    fn builder(&self) -> StatusBuilder<'_> {
+        match self {
+            Self::Consensus(err) => StatusBuilder::new(err),
+            Self::Invalid(err) => err.builder(),
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 pub struct PendingM6idInfo {
     pub vote_count: u16,
@@ -883,9 +970,11 @@ impl PendingM6idInfo {
 
 #[cfg(test)]
 mod tests {
+    use std::borrow::Cow;
+
     use miette::Diagnostic as _;
 
-    use crate::types::{SidechainDeclaration, SidechainNumber, SidechainProposal};
+    use crate::types::{BlindedM6, SidechainDeclaration, SidechainNumber, SidechainProposal};
 
     fn proposal(description: Vec<u8>) -> SidechainProposal {
         SidechainProposal {
@@ -991,6 +1080,104 @@ mod tests {
         assert_eq!(
             format!("{}", result.unwrap_err().code().unwrap()),
             "sidechain_proposal::unknown_version"
+        );
+    }
+
+    /// A structurally-valid zero-input blinded M6: an `OP_RETURN <fee>` marker at
+    /// index 0 followed by a payout output (so it has >= 2 outputs).
+    fn blinded_m6_tx() -> bitcoin::Transaction {
+        use bitcoin::{
+            Amount, ScriptBuf, TxOut, blockdata::locktime::absolute::LockTime,
+            opcodes::all::OP_RETURN, script::Builder, transaction::Version,
+        };
+        let fee_output = TxOut {
+            value: Amount::ZERO,
+            script_pubkey: Builder::new()
+                .push_opcode(OP_RETURN)
+                .push_slice(1_000u64.to_be_bytes())
+                .into_script(),
+        };
+        let payout_output = TxOut {
+            value: Amount::from_sat(50_000),
+            script_pubkey: ScriptBuf::from_bytes(
+                [vec![0x00, 0x14], vec![0x11; 20]].concat(), // P2WPKH
+            ),
+        };
+        bitcoin::Transaction {
+            version: Version::TWO,
+            lock_time: LockTime::ZERO,
+            input: Vec::new(),
+            output: vec![fee_output, payout_output],
+        }
+    }
+
+    /// Emit a zero-input tx in Bitcoin Core's legacy frame (no BIP144 marker):
+    /// `version || 00 (input count) || out_count || outputs || locktime`. This is
+    /// the encoding `BlindedM6::deserialize` must accept but rust-bitcoin rejects.
+    fn serialize_zero_input_legacy(tx: &bitcoin::Transaction) -> Vec<u8> {
+        use bitcoin::consensus::{Encodable as _, encode::VarInt};
+        assert!(tx.input.is_empty());
+        let mut bytes = Vec::new();
+        tx.version.consensus_encode(&mut bytes).unwrap();
+        VarInt(0).consensus_encode(&mut bytes).unwrap();
+        VarInt(tx.output.len() as u64)
+            .consensus_encode(&mut bytes)
+            .unwrap();
+        for output in &tx.output {
+            output.consensus_encode(&mut bytes).unwrap();
+        }
+        tx.lock_time.consensus_encode(&mut bytes).unwrap();
+        bytes
+    }
+
+    #[test]
+    fn blinded_m6_always_serializes_with_rust_bitcoin() {
+        let tx = blinded_m6_tx();
+        let blinded = BlindedM6::try_from(Cow::Owned(tx.clone())).unwrap();
+        // We always emit rust-bitcoin's standard encoding, even for the
+        // zero-input case (where it produces the BIP144 segwit form). A
+        // finalized M6 has an input anyway, so the ambiguity never bites; and
+        // this still round-trips, since `deserialize` reads our own encoding back.
+        assert_eq!(blinded.serialize(), bitcoin::consensus::serialize(&tx));
+        assert_eq!(
+            BlindedM6::deserialize(&blinded.serialize())
+                .unwrap()
+                .as_ref(),
+            &tx
+        );
+    }
+
+    #[test]
+    fn blinded_m6_deserialize_accepts_legacy_zero_input() {
+        let tx = blinded_m6_tx();
+        let bytes = serialize_zero_input_legacy(&tx);
+        // It's the legacy frame: version || 00 (input count) || ...
+        assert_eq!(bytes[4], 0x00, "input count byte should be a literal 0x00");
+        // rust-bitcoin's standard decoder cannot read this legacy form (it
+        // misreads the 0x00 as the BIP144 segwit marker) -- the whole reason
+        // the legacy fallback in `deserialize` exists. See rust-bitcoin issue #104.
+        assert!(bitcoin::consensus::deserialize::<bitcoin::Transaction>(&bytes).is_err());
+        // ...but our fallback decoder round-trips it faithfully.
+        assert_eq!(BlindedM6::deserialize(&bytes).unwrap().as_ref(), &tx);
+    }
+
+    /// a zero-input header whose `output_count` varint is attacker-
+    /// chosen as `u64::MAX` must fail cleanly, NOT panic in `Vec::with_capacity`
+    /// This 14-byte payload is reachable from the `BroadcastWithdrawalBundle` RPC.
+    #[test]
+    fn deserialize_blinded_m6_rejects_oversized_output_count_without_panic() {
+        let payload = [
+            0x02, 0x00, 0x00, 0x00, // version = 2
+            0x00, // input count = 0 -> zero-input fallback engages
+            0xFF, // output count varint: 0xFF prefix -> read next 8 bytes as u64
+            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // output count = u64::MAX
+        ];
+        // Sanity: the standard decoder rejects it (segwit marker path), so the
+        // fallback really does run on this input.
+        assert!(bitcoin::consensus::deserialize::<bitcoin::Transaction>(&payload).is_err());
+        assert!(
+            BlindedM6::deserialize(&payload).is_err(),
+            "oversized output_count must be a clean Err, not a panic/abort"
         );
     }
 }

--- a/lib/wallet/error.rs
+++ b/lib/wallet/error.rs
@@ -609,11 +609,11 @@ impl ToStatus for EncodeBlock {
 #[derive(Debug, Diagnostic, Error)]
 enum GetBundleProposalsInner {
     #[error(transparent)]
-    BlindedM6(#[from] crate::types::BlindedM6Error),
-    #[error(transparent)]
-    ConsensusEncoding(#[from] bitcoin::consensus::encode::Error),
+    DecodeBlindedM6(#[from] crate::types::BlindedM6DecodeError),
     #[error(transparent)]
     GetPendingWithdrawals(#[from] crate::validator::GetPendingWithdrawalsError),
+    #[error(transparent)]
+    GetSidechains(#[from] crate::validator::GetSidechainsError),
     #[error("rusqlite error")]
     Rusqlite(#[from] rusqlite::Error),
 }
@@ -621,9 +621,9 @@ enum GetBundleProposalsInner {
 impl ToStatus for GetBundleProposalsInner {
     fn builder(&self) -> StatusBuilder<'_> {
         match self {
-            Self::BlindedM6(err) => err.builder(),
+            Self::DecodeBlindedM6(err) => err.builder(),
             Self::GetPendingWithdrawals(err) => err.builder(),
-            Self::ConsensusEncoding(err) => StatusBuilder::new(err),
+            Self::GetSidechains(err) => err.builder(),
             Self::Rusqlite(_) => StatusBuilder::new(self),
         }
     }

--- a/lib/wallet/error.rs
+++ b/lib/wallet/error.rs
@@ -630,6 +630,8 @@ enum GetBundleProposalsInner {
     ConsensusEncoding(#[from] bitcoin::consensus::encode::Error),
     #[error(transparent)]
     GetPendingWithdrawals(#[from] crate::validator::GetPendingWithdrawalsError),
+    #[error(transparent)]
+    GetSidechains(#[from] crate::validator::GetSidechainsError),
     #[error("rusqlite error")]
     Rusqlite(#[from] rusqlite::Error),
 }
@@ -639,6 +641,7 @@ impl ToStatus for GetBundleProposalsInner {
         match self {
             Self::BlindedM6(err) => err.builder(),
             Self::GetPendingWithdrawals(err) => err.builder(),
+            Self::GetSidechains(err) => err.builder(),
             Self::ConsensusEncoding(err) => StatusBuilder::new(err),
             Self::Rusqlite(_) => StatusBuilder::new(self),
         }

--- a/lib/wallet/mod.rs
+++ b/lib/wallet/mod.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     path::Path,
     str::FromStr,
     sync::Arc,
@@ -944,9 +944,7 @@ impl Wallet {
                 .transpose_into_fallible()
                 .map_err(error::GetBundleProposals::from)
                 .for_each(|(sidechain_number, m6id, bundle_tx_bytes)| {
-                    let bundle_proposal_tx = bitcoin::consensus::deserialize(&bundle_tx_bytes)?;
-                    let bundle_proposal_tx =
-                        BlindedM6::try_from(std::borrow::Cow::Owned(bundle_proposal_tx))?;
+                    let bundle_proposal_tx = BlindedM6::deserialize(&bundle_tx_bytes)?;
                     bundle_proposals
                         .entry(sidechain_number)
                         .or_default()
@@ -955,15 +953,34 @@ impl Wallet {
                 })?;
             Ok(bundle_proposals)
         };
-        let connection = self.inner.self_db.lock().await;
-        let bundle_proposals = with_connection(&connection)?;
-        drop(connection);
+        let bundle_proposals = {
+            let connection = self.inner.self_db.lock().await;
+            with_connection(&connection)?
+        };
+        // Per BIP300 M3, a bundle proposed for a sidechain slot that is not active
+        // is interpreted as an ordinary script (a no-op), so there is nothing to
+        // gain by proposing it.
+        //
+        // Bundles for an inactive sidechain can sneak in if we're activating a sidechain
+        // and then reorging it out of existence. The wallet currently doesn't handle reorgs
+        // properly, so we would then end up with a bundle proposal for an inactive sidechain
+        // in our DB.
+        let active_sidechain_numbers: HashSet<SidechainNumber> = self
+            .inner
+            .validator
+            .get_active_sidechains()?
+            .into_iter()
+            .map(|sidechain| sidechain.proposal.sidechain_number)
+            .collect();
         // Filter out proposals that have already been created
         let res = bundle_proposals
             .into_iter()
             .map(Ok::<_, error::GetBundleProposals>)
             .transpose_into_fallible()
             .filter_map(|(sidechain_id, m6ids)| {
+                if !active_sidechain_numbers.contains(&sidechain_id) {
+                    return Ok(None);
+                }
                 let pending_m6ids = self
                     .inner
                     .validator
@@ -2217,7 +2234,10 @@ impl Wallet {
         blinded_m6: &BlindedM6<'static>,
     ) -> Result<M6id, rusqlite::Error> {
         let m6id = blinded_m6.compute_m6id();
-        let tx_bytes = bitcoin::consensus::serialize(blinded_m6.as_ref());
+        // Always encode with rust-bitcoin. A zero-input bundle round-trips
+        // because `BlindedM6::deserialize` reads this encoding back, and a
+        // finalized M6 has a treasury input anyway.
+        let tx_bytes = blinded_m6.serialize();
         self.inner.self_db
             .lock()
             .await

--- a/lib/wallet/mod.rs
+++ b/lib/wallet/mod.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     path::Path,
     str::FromStr,
     sync::Arc,
@@ -937,7 +937,8 @@ impl Wallet {
                 .transpose_into_fallible()
                 .map_err(error::GetBundleProposals::from)
                 .for_each(|(sidechain_number, m6id, bundle_tx_bytes)| {
-                    let bundle_proposal_tx = bitcoin::consensus::deserialize(&bundle_tx_bytes)?;
+                    let bundle_proposal_tx =
+                        crate::types::deserialize_blinded_m6(&bundle_tx_bytes)?;
                     let bundle_proposal_tx =
                         BlindedM6::try_from(std::borrow::Cow::Owned(bundle_proposal_tx))?;
                     bundle_proposals
@@ -948,15 +949,34 @@ impl Wallet {
                 })?;
             Ok(bundle_proposals)
         };
-        let connection = self.inner.self_db.lock().await;
-        let bundle_proposals = with_connection(&connection)?;
-        drop(connection);
+        let bundle_proposals = {
+            let connection = self.inner.self_db.lock().await;
+            with_connection(&connection)?
+        };
+        // Per BIP300 M3, a bundle proposed for a sidechain slot that is not active
+        // is interpreted as an ordinary script (a no-op), so there is nothing to
+        // gain by proposing it.
+        //
+        // Bundles for an inactive sidechain can sneak in if we're activating a sidechain
+        // and then reorging it out of existence. The wallet currently doesn't handle reorgs
+        // properly, so we would then end up with a bundle proposal for an inactive sidechain
+        // in our DB.
+        let active_sidechain_numbers: HashSet<SidechainNumber> = self
+            .inner
+            .validator
+            .get_active_sidechains()?
+            .into_iter()
+            .map(|sidechain| sidechain.proposal.sidechain_number)
+            .collect();
         // Filter out proposals that have already been created
         let res = bundle_proposals
             .into_iter()
             .map(Ok::<_, error::GetBundleProposals>)
             .transpose_into_fallible()
             .filter_map(|(sidechain_id, m6ids)| {
+                if !active_sidechain_numbers.contains(&sidechain_id) {
+                    return Ok(None);
+                }
                 let pending_m6ids = self
                     .inner
                     .validator
@@ -2169,7 +2189,9 @@ impl Wallet {
         blinded_m6: &BlindedM6<'static>,
     ) -> Result<M6id, rusqlite::Error> {
         let m6id = blinded_m6.compute_m6id();
-        let tx_bytes = bitcoin::consensus::serialize(blinded_m6.as_ref());
+        // Store in the legacy zero-input form so the bytes round-trip through
+        // `deserialize_blinded_m6` (and other Bitcoin software)
+        let tx_bytes = crate::types::serialize_blinded_m6(blinded_m6.as_ref());
         self.inner.self_db
             .lock()
             .await


### PR DESCRIPTION
Parse and store blinded M6 withdrawal bundles in Bitcoin Core's legacy zero-input encoding, which rust-bitcoin's consensus codec rejects. Reject bundles for inactive sidechains at ingestion, and skip them in the block builder as a reorg safety net.

This PR supersedes #373. I've added more tests, and also done a safer deserialization of transaction data. I've added you as a commit author @ekulkisnek. Furthermore, I've also added verification of sidechains being active when we're ingesting and serving out bundle data. 