### PR TITLE
validator/dbs: delete treasury_utxo_count key on last ctip disconnect

### DIFF
--- a/lib/validator/dbs/mod.rs
+++ b/lib/validator/dbs/mod.rs
@@ -155,9 +155,16 @@ impl ActiveSidechainDbs {
             .ctip_outpoint_to_value_seq
             .delete(rwtxn, &ctip.outpoint)?;
         let treasury_utxo_count = self.treasury_utxo_count.get(rwtxn, &sidechain_number)?;
-        let sequence_number = treasury_utxo_count - 1;
-        self.treasury_utxo_count
-            .put(rwtxn, &sidechain_number, &sequence_number)?;
+        // Defense-in-depth: a stale zero count must not underflow here.
+        let sequence_number = treasury_utxo_count
+            .checked_sub(1)
+            .expect("treasury_utxo_count must be > 0 when deleting a ctip");
+        if sequence_number == 0 {
+            let _ = self.treasury_utxo_count.delete(rwtxn, &sidechain_number)?;
+        } else {
+            self.treasury_utxo_count
+                .put(rwtxn, &sidechain_number, &sequence_number)?;
+        }
         let _ = self
             .slot_sequence_to_treasury_utxo
             .delete(rwtxn, &(sidechain_number, sequence_number))?;

--- a/lib/validator/mod.rs
+++ b/lib/validator/mod.rs
@@ -519,8 +519,8 @@ impl Validator {
         // Sequence numbers begin at 0, so the total number of treasury utxos in the database
         // gives us the *next* sequence number.
         // In order to get the current sequence number we decrement it by one.
-        let sequence_number =
-            treasury_utxo_count.map(|treasury_utxo_count| treasury_utxo_count - 1);
+        // Defense-in-depth: a stale or zero count must not panic or wrap here.
+        let sequence_number = treasury_utxo_count.and_then(|count| count.checked_sub(1));
         Ok(sequence_number)
     }
 

--- a/lib/validator/task/mod.rs
+++ b/lib/validator/task/mod.rs
@@ -3303,4 +3303,56 @@ mod tests {
         ));
         Ok(())
     }
+
+    // Regression test: deleting the only ctip must restore the pre-deposit
+    // state, i.e. the `treasury_utxo_count` key must be removed entirely.
+    // Before the fix it was left as `Some(0)`, causing the sequence-number
+    // reader to underflow (`0u64 - 1`) and corrupt `sync_state_summary`.
+    #[test]
+    fn delete_ctip_restores_treasury_utxo_count() -> Result<()> {
+        let (_dir, dbs) = create_test_dbs()?;
+        let mut rwtxn = dbs.write_txn().into_diagnostic()?;
+        let sc = SidechainNumber(1);
+        dbs.active_sidechains
+            .put_sidechain(&mut rwtxn, &sc, &test_sidechain(1, 0))
+            .into_diagnostic()?;
+
+        let read_count = |rwtxn: &_| {
+            dbs.active_sidechains
+                .treasury_utxo_count
+                .try_get(rwtxn, &sc)
+                .into_diagnostic()
+        };
+
+        // A fresh node that never saw a deposit has no count key.
+        let pre = read_count(&rwtxn)?;
+        assert_eq!(pre, None, "sanity: fresh slot has no count key");
+
+        // A single deposit creates the first (and only) ctip.
+        let ctip = Ctip {
+            outpoint: OutPoint {
+                txid: Txid::from_byte_array([0xA0; 32]),
+                vout: 0,
+            },
+            value: Amount::from_sat(100),
+        };
+        let seq = dbs
+            .active_sidechains
+            .put_ctip(&mut rwtxn, sc, &ctip)
+            .into_diagnostic()?;
+        let after_apply = read_count(&rwtxn)?;
+        assert_eq!(after_apply, Some(1), "first deposit -> count == 1, seq == 0");
+        assert_eq!(seq, 0);
+
+        // Disconnecting the block must restore the pre-deposit state.
+        dbs.active_sidechains
+            .delete_ctip(&mut rwtxn, sc)
+            .into_diagnostic()?;
+        let after_undo = read_count(&rwtxn)?;
+        assert_eq!(
+            after_undo, pre,
+            "delete_ctip must restore pre-deposit state"
+        );
+        Ok(())
+    }
 }


### PR DESCRIPTION
### Summary

This fixes a reorg handling bug that can leave one enforcer with different CTIP
bookkeeping than another enforcer at the same chain tip.

The issue occurs when a sidechain receives its first CTIP deposit and that block
is later reorged out. The reorged node applies the deposit, then disconnects it.
A fresh-sync node never sees the deposit. Those two paths should produce the
same validator state, but today they do not: the reorged node keeps a leftover
zero-count record, while the fresh-sync node has no record at all.

That leftover record is later read as if it were a real CTIP count. The reader
subtracts one from it, which can either panic in checked builds or become
`u64::MAX` in release builds. Since the value is included in
`sync_state_summary`, the reorged node can report a different deterministic
state digest than a fresh-sync node at the same tip, or fail to produce the
summary.

The root cause is in `ActiveSidechainDbs::delete_ctip`.

When the only CTIP for a sidechain is disconnected, `delete_ctip` decrements
`treasury_utxo_count` from `1` to `0` and writes that zero back to the DB:

```rust
let sequence_number = treasury_utxo_count - 1;
self.treasury_utxo_count
    .put(rwtxn, &sidechain_number, &sequence_number)?;
```

That leaves `treasury_utxo_count[sidechain] = Some(0)`. A fresh-sync node that
never saw the reorged-out deposit has no key at all (`None`) for the same
sidechain.

`get_ctip_sequence_number` then derives the current sequence number as
`treasury_utxo_count - 1`, so the residual `Some(0)` becomes `0u64 - 1`.

### Change

- Delete the `treasury_utxo_count` key when disconnecting the last CTIP, instead
  of writing `Some(0)`.
- Guard the subtraction in `delete_ctip` with `checked_sub`.
- Harden the CTIP sequence-number reader so a stale zero count cannot wrap.
- Add a regression test covering the `1 -> 0` disconnect case.

### Testing

```bash
cargo test -p bip300301_enforcer_lib --lib delete_ctip_restores_treasury_utxo_count
cargo clippy -p bip300301_enforcer_lib --tests
cargo test -p bip300301_enforcer_lib --lib
```

The regression test fails before the fix (`Some(0) != None`) and passes after.