### PR TITLE
[DoS] Fix 2 remotely-triggerable panics parsing M1 sidechain descriptions

### DIFF
--- a/lib/types.rs
+++ b/lib/types.rs
@@ -328,8 +328,14 @@ impl SidechainDeclaration {
         }
         const VERSION_0: u8 = 0;
         let (input, _) = tag([VERSION_0].as_slice())(input).map_err(
-            |_: nom::Err<nom::error::Error<&[u8]>>| {
-                nom::Err::Error(ParseSidechainDeclarationError::UnknownVersion(input[0]))
+            |err: nom::Err<nom::error::Error<&[u8]>>| match input.first() {
+                // The version byte is present but unrecognized.
+                Some(&version) => {
+                    nom::Err::Error(ParseSidechainDeclarationError::UnknownVersion(version))
+                }
+                // Empty input: there is no version byte to report. Surface the
+                // underlying `tag` failure instead of indexing out of bounds.
+                None => failed_to_deserialize(err),
             },
         )?;
 
@@ -1179,5 +1185,15 @@ mod tests {
             BlindedM6::deserialize(&payload).is_err(),
             "oversized output_count must be a clean Err, not a panic/abort"
         );
+    }
+
+    /// Regression: an empty description (a valid M1 carries an arbitrary,
+    /// possibly empty, `rest`-encoded description) must return an error, not
+    /// panic indexing `input[0]` while building the version error.
+    #[test]
+    fn test_try_deserialize_empty_description() {
+        let sidechain_proposal = proposal(vec![]);
+        let result: Result<SidechainDeclaration, _> = (&sidechain_proposal.description).try_into();
+        assert!(result.is_err());
     }
 }

--- a/lib/types.rs
+++ b/lib/types.rs
@@ -348,7 +348,18 @@ impl SidechainDeclaration {
         const HASH_ID_1_LENGTH: usize = 32;
         const HASH_ID_2_LENGTH: usize = 20;
 
-        let description_length = input.len() - HASH_ID_1_LENGTH - HASH_ID_2_LENGTH;
+        // The description field's length is the remaining input minus the two
+        // trailing fixed-length hash fields. If fewer bytes remain than those
+        // fields require, the input is malformed: fail rather than underflow.
+        let description_length = input
+            .len()
+            .checked_sub(HASH_ID_1_LENGTH + HASH_ID_2_LENGTH)
+            .ok_or_else(|| {
+                failed_to_deserialize(nom::Err::Error(nom::error::Error::new(
+                    input,
+                    nom::error::ErrorKind::Eof,
+                )))
+            })?;
         let (input, description_bytes) =
             take(description_length)(input).map_err(failed_to_deserialize)?;
         let description = std::str::from_utf8(description_bytes).map_err(|err| {
@@ -1195,5 +1206,24 @@ mod tests {
         let sidechain_proposal = proposal(vec![]);
         let result: Result<SidechainDeclaration, _> = (&sidechain_proposal.description).try_into();
         assert!(result.is_err());
+    }
+
+    /// Regression: a version-0 declaration whose remaining bytes are too short
+    /// to hold the trailing 32+20-byte hash fields must return an error, not
+    /// panic on `input.len() - 52` underflow.
+    #[test]
+    fn test_try_deserialize_too_short_for_hashes() {
+        // version 0, title length 0, then fewer than 52 trailing bytes.
+        for tail_len in [0usize, 1, 51] {
+            let mut bytes = vec![0u8 /* version */, 0u8 /* title length */];
+            bytes.extend(std::iter::repeat_n(0u8, tail_len));
+            let sidechain_proposal = proposal(bytes);
+            let result: Result<SidechainDeclaration, _> =
+                (&sidechain_proposal.description).try_into();
+            assert!(
+                result.is_err(),
+                "expected error for tail_len {tail_len}, got Ok"
+            );
+        }
     }
 }


### PR DESCRIPTION
I found these bugs using differential fuzzing. Like rust-bitcoin, the enforcer's custom parsers must never panic when processing adversarial input. A libFuzzer [harness](https://github.com/LayerTwo-Labs/bip300301_enforcer/commit/c1ff347a2c3389896438c40da47856df3de83d58) for the M1 description path reproduces both panics (e.g. the empty input). 

---

`SidechainDeclaration::try_parse` (`lib/types.rs`) panics on two classes of malformed input. Both are reachable from a miner-controlled M1 sidechain proposal, so a single crafted coinbase can crash any enforcer that later reads
the stored proposal.

An M1 proposal's `description` is parsed from the coinbase with `rest` (`M1ProposeSidechain::parse`), so it is arbitrary, attacker-controlled, and may be empty or shorter than the fixed trailing fields. `handle_m1_propose_sidechain` stores it **without** parsing it as a declaration, so the malformed bytes are
accepted into state and persist.

The declaration is only parsed later, in two places, both of which panic rather than erroring:

- `Validator::sync_state_summary` runs automatically in `exit-after-sync` / state-digest mode (`app/main.rs`),
  so the node crashes while computing its consensus state summary. No client interaction required.
  
- The validator gRPC sidechain query crashes the node on demand for any caller. Note both call sites use `.ok()`, which discards an `Err` but does **not** stop a panic from unwinding.


## Bugs and fixes

1. **Out-of-bounds index on empty description.** When the description is empty, the version `tag` fails and the error closure built `UnknownVersion(input[0])`, indexing an empty slice. Fixed by reporting the version only when a byte is present, and surfacing the underlying parse error otherwise.

2. **Integer underflow on short description.** The description length is `remaining input - 52` (the trailing 32-byte and 20-byte hash fields). With fewer than 52 bytes left after the title, the `usize` subtraction underflows (panics under overflow checks; produces a wild `take` length otherwise). Fixed with `checked_sub`, failing on malformed input.

## Tests

Adds two regression tests (`test_try_deserialize_empty_description`,`test_try_deserialize_too_short_for_hashes`).