### PR TITLE
[validation] fix sidechain proposal-age underflow in M2 ack

### DIFF
--- a/lib/validator/task/mod.rs
+++ b/lib/validator/task/mod.rs
@@ -2423,6 +2423,36 @@ mod tests {
 
     // ── handle_m2 ──
 
+    /// Regression: an M2 ack processed at a height below the stored proposal
+    /// height (e.g. a proposal from a previous sync that is not on the active
+    /// chain) must not underflow `height - proposal_height`. The sibling
+    /// `handle_failed_sidechain_proposals` already guards this case.
+    #[test]
+    fn handle_m2_ack_below_proposal_height_does_not_underflow() -> Result<()> {
+        let (_dir, dbs) = create_test_dbs()?;
+        let mut rwtxn = dbs.write_txn().into_diagnostic()?;
+        let handler = test_handler(&dbs);
+
+        let sidechain = test_sidechain(1, 100);
+        let proposal_id = sidechain.proposal.compute_id();
+        dbs.proposal_id_to_sidechain
+            .put(&mut rwtxn, &proposal_id, &sidechain)
+            .into_diagnostic()?;
+
+        // height 0 < proposal_height 100 must not panic / error.
+        let res = handler.handle_m2_ack_sidechain(
+            &rwtxn,
+            0,
+            SidechainNumber(1),
+            proposal_id.description_hash,
+        );
+        assert!(
+            res.is_ok(),
+            "M2 ack below proposal height must not underflow"
+        );
+        Ok(())
+    }
+
     #[test]
     fn handle_m2_activation_thresholds() -> Result<()> {
         let (_dir, dbs) = create_test_dbs()?;

--- a/lib/validator/task/mod.rs
+++ b/lib/validator/task/mod.rs
@@ -222,7 +222,13 @@ impl BlockHandler<'_> {
             activated: false,
         };
 
-        let sidechain_proposal_age = height - sidechain.status.proposal_height;
+        // `height - proposal_height` can underflow if the enforcer holds a
+        // proposal from a previous sync that is not on the active chain (the
+        // same case `handle_failed_sidechain_proposals` guards with
+        // `saturating_sub`). Without this, an M2 ack at a height below the
+        // stored proposal height panics under overflow checks, and wraps to a
+        // huge age in release (so the sidechain silently fails to activate).
+        let sidechain_proposal_age = height.saturating_sub(sidechain.status.proposal_height);
 
         let sidechain_slot_is_used = dbs
             .active_sidechains


### PR DESCRIPTION
Found this bug with fuzzing of `connect_block`/`disconnect_block` (reorg round-trip) with fuzzer-driven block heights and seeded proposals.

`handle_m2_ack_sidechain` computes the proposal age with an unguarded `u32` subtraction:

```rust
let sidechain_proposal_age = height - sidechain.status.proposal_height;
```

If the enforcer holds a sidechain proposal whose `proposal_height` is greater than the height at which the M2 ack is processed, this underflows. The sibling `handle_failed_sidechain_proposals` already performs the **same** computation with `saturating_sub` and an explicit comment that this case happens:

```rust
// doing `height - sidechain.status.proposal_height` can panic if the enforcer has data
// from a previous sync that is not in the active chain.
let age = height.saturating_sub(sidechain.status.proposal_height);
```

`handle_m2_ack_sidechain` simply misses the same guard.

## Impact

- With overflow checks (tests/CI): panic while validating a block carrying the M2 ack - a node crash on a block.
- In a release build (overflow checks off): the subtraction wraps to a huge age, so `age <= max_age` is false and the sidechain silently fails to activate and two nodes with different proposal-data histories can disagree on activation.

The triggering condition (a proposal with `proposal_height > height`) is the same "data from a previous sync that is not in the active chain" scenario the sibling function documents and guards against.

## Fix

Use `height.saturating_sub(sidechain.status.proposal_height)`, matching `handle_failed_sidechain_proposals`.

## Test

Adds `handle_m2_ack_below_proposal_height_does_not_underflow`: a proposal recorded at height 100, acked at height 0, must not underflow.
