### PR TITLE
[validation] fix reorg deleting a previously-active sidechain on activation undo

### DIFF
--- a/lib/validator/dbs/diff.rs
+++ b/lib/validator/dbs/diff.rs
@@ -95,6 +95,13 @@ pub struct AckSidechain {
     /// true IFF the sidechain should be activated due to this ack causing the
     /// proposal to reach the vote threshold
     pub activated: bool,
+    /// When `activated` and the slot was *already* occupied by an active
+    /// sidechain, that prior sidechain (which `apply` overwrites). `undo` must
+    /// restore it instead of deleting the slot, otherwise a reorg of the
+    /// activating block permanently deletes the previously-active sidechain.
+    /// `serde(default)` keeps diffs stored before this field was added readable.
+    #[serde(default)]
+    pub replaced_active: Option<Sidechain>,
 }
 
 impl Diff for AckSidechain {
@@ -131,9 +138,25 @@ impl Diff for AckSidechain {
                 .active_sidechains
                 .sidechain()
                 .get(rwtxn, &self.id.sidechain_number)?;
-            let () = dbs
-                .active_sidechains
-                .delete_sidechain(rwtxn, &self.id.sidechain_number)?;
+            match &self.replaced_active {
+                // `apply` overwrote an already-active sidechain in this slot;
+                // restore it (leaving its pending_m6ids, which `apply` did not
+                // touch) instead of deleting the slot.
+                Some(prev) => {
+                    let () = dbs.active_sidechains.put_sidechain(
+                        rwtxn,
+                        &self.id.sidechain_number,
+                        prev,
+                    )?;
+                }
+                // The slot was empty before activation; `apply` created it, so
+                // undo removes it entirely.
+                None => {
+                    let () = dbs
+                        .active_sidechains
+                        .delete_sidechain(rwtxn, &self.id.sidechain_number)?;
+                }
+            }
             sidechain.status.activation_height = None;
             sidechain
         } else {
@@ -705,6 +728,7 @@ mod tests {
         let diff = AckSidechain {
             id: proposal_id,
             activated: false,
+            replaced_active: None,
         };
 
         diff.apply(&mut rwtxn, &dbs, 101).into_diagnostic()?;

--- a/lib/validator/dbs/diff.rs
+++ b/lib/validator/dbs/diff.rs
@@ -88,90 +88,129 @@ impl Diff for NewSidechainProposal {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize)]
-#[must_use]
-pub struct AckSidechain {
-    pub id: SidechainProposalId,
-    /// true IFF the sidechain should be activated due to this ack causing the
-    /// proposal to reach the vote threshold
-    pub activated: bool,
-    /// When `activated` and the slot was *already* occupied by an active
-    /// sidechain, that prior sidechain (which `apply` overwrites). `undo` must
-    /// restore it instead of deleting the slot, otherwise a reorg of the
-    /// activating block permanently deletes the previously-active sidechain.
-    /// `serde(default)` keeps diffs stored before this field was added readable.
-    #[serde(default)]
-    pub replaced_active: Option<Sidechain>,
-}
+pub mod ack_sidechain_proposal {
+    use serde::{Deserialize, Serialize};
+    use sneed::{DbError, RwTxn};
 
-impl Diff for AckSidechain {
-    type Dbs = dbs::Dbs;
-    type ApplyError = db::Error;
-    type UndoError = UndoError;
+    use crate::validator::{
+        SidechainProposalId,
+        dbs::{self, diff},
+    };
 
-    fn apply(&self, rwtxn: &mut RwTxn, dbs: &Self::Dbs, height: u32) -> Result<(), db::Error> {
-        let mut sidechain = dbs.proposal_id_to_sidechain.get(rwtxn, &self.id)?;
-        sidechain.status.vote_count += 1;
-        if self.activated {
-            sidechain.status.activation_height = Some(height);
-            tracing::info!(
-                "sidechain {} in slot {} was activated",
-                String::from_utf8_lossy(&sidechain.proposal.description.0),
-                self.id.sidechain_number.0
-            );
-            let () = dbs.active_sidechains.put_sidechain(
-                rwtxn,
-                &self.id.sidechain_number,
-                &sidechain,
-            )?;
-            let _ = dbs.proposal_id_to_sidechain.delete(rwtxn, &self.id)?;
-        } else {
-            dbs.proposal_id_to_sidechain
-                .put(rwtxn, &self.id, &sidechain)?;
-        }
-        Ok(())
+    /// Effect of a sidechain proposal ack
+    #[derive(Debug, Deserialize, Serialize)]
+    #[must_use]
+    pub enum Effect {
+        /// No sidechain activation
+        NoActivation,
+        /// Replace active sidechain
+        ReplaceActive(crate::types::Sidechain),
+        /// Activation in an unoccupied slot
+        SlotActivation,
     }
 
-    fn undo(&self, rwtxn: &mut RwTxn, dbs: &Self::Dbs) -> Result<(), UndoError> {
-        let mut sidechain = if self.activated {
-            let mut sidechain = dbs
-                .active_sidechains
-                .sidechain()
-                .get(rwtxn, &self.id.sidechain_number)?;
-            match &self.replaced_active {
-                // `apply` overwrote an already-active sidechain in this slot;
-                // restore it (leaving its pending_m6ids, which `apply` did not
-                // touch) instead of deleting the slot.
-                Some(prev) => {
+    impl Effect {
+        /// Returns `true` if a new sidechain was activated
+        #[cfg(test)]
+        pub fn activated(&self) -> bool {
+            match self {
+                Self::NoActivation => false,
+                Self::ReplaceActive(_) | Self::SlotActivation => true,
+            }
+        }
+    }
+
+    #[derive(Debug, Deserialize, Serialize)]
+    pub struct Diff {
+        pub id: SidechainProposalId,
+        pub effect: Effect,
+    }
+
+    impl Diff {
+        /// Returns `true` if a new sidechain was activated
+        #[cfg(test)]
+        #[inline(always)]
+        pub fn activated(&self) -> bool {
+            self.effect.activated()
+        }
+    }
+
+    impl diff::Diff for Diff {
+        type Dbs = dbs::Dbs;
+        type ApplyError = DbError;
+        type UndoError = diff::UndoError;
+
+        fn apply(
+            &self,
+            rwtxn: &mut RwTxn,
+            dbs: &Self::Dbs,
+            height: u32,
+        ) -> Result<(), Self::ApplyError> {
+            let mut sidechain = dbs.proposal_id_to_sidechain.get(rwtxn, &self.id)?;
+            sidechain.status.vote_count += 1;
+            match self.effect {
+                Effect::NoActivation => {
+                    dbs.proposal_id_to_sidechain
+                        .put(rwtxn, &self.id, &sidechain)?;
+                }
+                Effect::SlotActivation | Effect::ReplaceActive(_) => {
+                    sidechain.status.activation_height = Some(height);
+                    tracing::info!(
+                        "sidechain {} in slot {} was activated",
+                        String::from_utf8_lossy(&sidechain.proposal.description.0),
+                        self.id.sidechain_number.0
+                    );
+                    let () = dbs.active_sidechains.put_sidechain(
+                        rwtxn,
+                        &self.id.sidechain_number,
+                        &sidechain,
+                    )?;
+                    let _ = dbs.proposal_id_to_sidechain.delete(rwtxn, &self.id)?;
+                }
+            }
+            Ok(())
+        }
+
+        fn undo(&self, rwtxn: &mut RwTxn, dbs: &Self::Dbs) -> Result<(), Self::UndoError> {
+            let mut sidechain = match &self.effect {
+                Effect::NoActivation => dbs.proposal_id_to_sidechain.get(rwtxn, &self.id)?,
+                Effect::ReplaceActive(prev) => {
+                    let mut sidechain = dbs
+                        .active_sidechains
+                        .sidechain()
+                        .get(rwtxn, &self.id.sidechain_number)?;
                     let () = dbs.active_sidechains.put_sidechain(
                         rwtxn,
                         &self.id.sidechain_number,
                         prev,
                     )?;
+                    sidechain.status.activation_height = None;
+                    sidechain
                 }
-                // The slot was empty before activation; `apply` created it, so
-                // undo removes it entirely.
-                None => {
+                Effect::SlotActivation => {
+                    let mut sidechain = dbs
+                        .active_sidechains
+                        .sidechain()
+                        .get(rwtxn, &self.id.sidechain_number)?;
                     let () = dbs
                         .active_sidechains
                         .delete_sidechain(rwtxn, &self.id.sidechain_number)?;
+                    sidechain.status.activation_height = None;
+                    sidechain
                 }
-            }
-            sidechain.status.activation_height = None;
-            sidechain
-        } else {
-            dbs.proposal_id_to_sidechain.get(rwtxn, &self.id)?
-        };
-        sidechain.status.vote_count = sidechain.status.vote_count.checked_sub(1).ok_or(
-            UndoError::SidechainVoteCountUnderflow {
-                sidechain_number: self.id.sidechain_number,
-            },
-        )?;
-        dbs.proposal_id_to_sidechain
-            .put(rwtxn, &self.id, &sidechain)?;
-        Ok(())
+            };
+            sidechain.status.vote_count = sidechain.status.vote_count.checked_sub(1).ok_or(
+                Self::UndoError::SidechainVoteCountUnderflow {
+                    sidechain_number: self.id.sidechain_number,
+                },
+            )?;
+            dbs.proposal_id_to_sidechain
+                .put(rwtxn, &self.id, &sidechain)?;
+            Ok(())
+        }
     }
 }
+pub use self::ack_sidechain_proposal::Diff as AckSidechainProposal;
 
 #[derive(Debug, Deserialize, Serialize)]
 #[must_use]
@@ -311,7 +350,7 @@ impl Diff for AckBundles {
 #[must_use]
 pub enum CoinbaseMsg {
     AckBundles(AckBundles),
-    AckSidechain(AckSidechain),
+    AckSidechainProposal(AckSidechainProposal),
     NewSidechainProposal(NewSidechainProposal),
     ProposeBundle(ProposeBundle),
 }
@@ -326,7 +365,7 @@ impl Diff for CoinbaseMsg {
             Self::AckBundles(diff) => {
                 let () = diff.apply(rwtxn, &dbs.active_sidechains, height)?;
             }
-            Self::AckSidechain(diff) => {
+            Self::AckSidechainProposal(diff) => {
                 let () = diff.apply(rwtxn, dbs, height)?;
             }
             Self::NewSidechainProposal(diff) => {
@@ -344,7 +383,7 @@ impl Diff for CoinbaseMsg {
             Self::AckBundles(diff) => {
                 let () = diff.undo(rwtxn, &dbs.active_sidechains)?;
             }
-            Self::AckSidechain(diff) => {
+            Self::AckSidechainProposal(diff) => {
                 let () = diff.undo(rwtxn, dbs)?;
             }
             Self::NewSidechainProposal(diff) => {
@@ -707,15 +746,18 @@ mod tests {
     use std::collections::{HashMap, HashSet};
 
     use miette::{IntoDiagnostic, Result};
+    use sneed::RoTxn;
 
-    use super::*;
     use crate::{
-        types::SidechainNumber,
-        validator::test_utils::{create_test_dbs, test_m6id, test_sidechain},
+        types::{M6id, SidechainNumber},
+        validator::{
+            dbs::diff::{self, Diff as _, UndoError},
+            test_utils::{create_test_dbs, test_m6id, test_sidechain},
+        },
     };
 
     #[test]
-    fn ack_sidechain_apply_undo_roundtrip_and_underflow_error() -> Result<()> {
+    fn ack_sidechain_proposal_apply_undo_roundtrip_and_underflow_error() -> Result<()> {
         let (_dir, dbs) = create_test_dbs()?;
         let mut rwtxn = dbs.write_txn().into_diagnostic()?;
 
@@ -725,10 +767,9 @@ mod tests {
             .put(&mut rwtxn, &proposal_id, &sidechain)
             .into_diagnostic()?;
 
-        let diff = AckSidechain {
+        let diff = diff::AckSidechainProposal {
             id: proposal_id,
-            activated: false,
-            replaced_active: None,
+            effect: diff::ack_sidechain_proposal::Effect::NoActivation,
         };
 
         diff.apply(&mut rwtxn, &dbs, 101).into_diagnostic()?;
@@ -778,10 +819,10 @@ mod tests {
                 .put_pending_m6id(&mut rwtxn, &sc, m, 0)
                 .into_diagnostic()?;
         }
-        let order = |rwtxn: &RoTxn| -> Vec<M6id> {
+        let order = |rotxn: &RoTxn| -> Vec<M6id> {
             dbs.active_sidechains
                 .pending_m6ids()
-                .get(rwtxn, &sc)
+                .get(rotxn, &sc)
                 .unwrap()
                 .keys()
                 .copied()
@@ -790,7 +831,7 @@ mod tests {
         assert_eq!(order(&rwtxn), vec![a, b, c]);
 
         // A successful M6 withdraws the middle bundle b (index 1).
-        let m6 = M6 {
+        let m6 = diff::M6 {
             sidechain_number: sc,
             new_ctip: Ctip {
                 outpoint: bitcoin::OutPoint::null(),
@@ -826,11 +867,11 @@ mod tests {
             .put_pending_m6id(&mut rwtxn, &sc, m6id, 0)
             .into_diagnostic()?;
 
-        let diff = AckBundles({
+        let diff = diff::AckBundles({
             let mut map = HashMap::new();
             map.insert(
                 sc,
-                AckBundleAction::Upvote {
+                diff::AckBundleAction::Upvote {
                     m6id,
                     downvoted_others: Vec::new(),
                 },
@@ -887,11 +928,11 @@ mod tests {
                 .into_diagnostic()?;
         }
 
-        let diff = AckBundles({
+        let diff = diff::AckBundles({
             let mut map = HashMap::new();
             map.insert(
                 sc,
-                AckBundleAction::Alarm {
+                diff::AckBundleAction::Alarm {
                     positive_votes_proposals: HashSet::from([m6id_a, m6id_b]),
                 },
             );
@@ -948,11 +989,11 @@ mod tests {
             })
             .into_diagnostic()?;
 
-        let upvote_diff = AckBundles({
+        let upvote_diff = diff::AckBundles({
             let mut map = HashMap::new();
             map.insert(
                 sc,
-                AckBundleAction::Upvote {
+                diff::AckBundleAction::Upvote {
                     m6id,
                     downvoted_others: Vec::new(),
                 },

--- a/lib/validator/task/mod.rs
+++ b/lib/validator/task/mod.rs
@@ -2701,6 +2701,85 @@ mod tests {
 
     // ── handle_m2 ──
 
+    /// Regression: activating a proposal into an already-used slot overwrites
+    /// the active sidechain. A disconnect (reorg) must restore the overwritten
+    /// sidechain, not delete the slot — otherwise the reorg permanently deletes
+    /// a previously-active sidechain (and orphans any treasury it held).
+    #[test]
+    fn ack_sidechain_undo_restores_overwritten_active_sidechain() -> Result<()> {
+        use crate::{
+            types::{Sidechain, SidechainProposalStatus},
+            validator::dbs::diff::Diff as _,
+        };
+
+        let (_dir, dbs) = create_test_dbs()?;
+        let mut rwtxn = dbs.write_txn().into_diagnostic()?;
+        let handler = test_handler(&dbs);
+        let slot = SidechainNumber(1);
+
+        // Active sidechain A occupies slot 1.
+        let sidechain_a = test_sidechain(1, 0);
+        let desc_a = sidechain_a.proposal.description.clone();
+        dbs.active_sidechains
+            .put_sidechain(&mut rwtxn, &slot, &sidechain_a)
+            .into_diagnostic()?;
+
+        // Competing proposal B for slot 1, one vote short of the used-slot
+        // activation threshold so the next ack activates it.
+        let threshold = handler.thresholds.used_sidechain_slot_activation_threshold;
+        let proposal_b = SidechainProposal {
+            sidechain_number: slot,
+            description: SidechainDescription(vec![0x00, 0x01, 0xBB]),
+        };
+        let id_b = proposal_b.compute_id();
+        dbs.proposal_id_to_sidechain
+            .put(
+                &mut rwtxn,
+                &id_b,
+                &Sidechain {
+                    proposal: proposal_b,
+                    status: SidechainProposalStatus {
+                        vote_count: threshold,
+                        proposal_height: 0,
+                        activation_height: None,
+                    },
+                },
+            )
+            .into_diagnostic()?;
+
+        // Ack B -> activates over the used slot, overwriting A.
+        let diff = handler
+            .handle_m2_ack_sidechain(&rwtxn, 1, slot, id_b.description_hash)
+            .into_diagnostic()?
+            .expect("ack should produce a diff");
+        assert!(diff.activated, "B should activate over the used slot");
+        diff.apply(&mut rwtxn, &dbs, 1).into_diagnostic()?;
+        assert_eq!(
+            dbs.active_sidechains
+                .sidechain()
+                .get(&rwtxn, &slot)
+                .into_diagnostic()?
+                .proposal
+                .description,
+            SidechainDescription(vec![0x00, 0x01, 0xBB]),
+            "slot should now hold B"
+        );
+
+        // Disconnect: A must be restored, not deleted.
+        diff.undo(&mut rwtxn, &dbs).into_diagnostic()?;
+        let restored = dbs
+            .active_sidechains
+            .sidechain()
+            .try_get(&rwtxn, &slot)
+            .into_diagnostic()?
+            .expect("slot must still be active after undo (A restored)");
+        assert_eq!(
+            restored.proposal.description, desc_a,
+            "previously-active sidechain A must be restored on disconnect"
+        );
+        Ok(())
+    }
+
     /// Regression: an M2 ack processed at a height below the stored proposal
     /// height (e.g. a proposal from a previous sync that is not on the active
     /// chain) must not underflow `height - proposal_height`. The sibling

--- a/lib/validator/task/mod.rs
+++ b/lib/validator/task/mod.rs
@@ -199,7 +199,7 @@ impl BlockHandler<'_> {
         height: u32,
         sidechain_number: SidechainNumber,
         description_hash: sha256d::Hash,
-    ) -> Result<Option<diff::AckSidechain>, error::HandleM2AckSidechain> {
+    ) -> Result<Option<diff::AckSidechainProposal>, error::HandleM2AckSidechain> {
         let dbs = self.dbs;
         let thresholds = self.thresholds;
         let proposal_id = SidechainProposalId {
@@ -231,15 +231,11 @@ impl BlockHandler<'_> {
         }
         sidechain.status.vote_count += 1;
         tracing::debug!(
-        %sidechain_number,
-        %description_hash,
-        vote_count = %sidechain.status.vote_count,
-        "ACK'd sidechain proposal");
-        let mut diff = diff::AckSidechain {
-            id: proposal_id,
-            activated: false,
-            replaced_active: None,
-        };
+            %sidechain_number,
+            %description_hash,
+            vote_count = %sidechain.status.vote_count,
+            "ACK'd sidechain proposal",
+        );
 
         // `height - proposal_height` can underflow if the enforcer holds a
         // proposal from a previous sync that is not on the active chain (the
@@ -270,12 +266,19 @@ impl BlockHandler<'_> {
                     <= thresholds.unused_sidechain_slot_proposal_max_age as u32
         };
 
-        if new_sidechain_activated {
-            diff.activated = true;
-            // Record the sidechain this activation will overwrite (if the slot
-            // was already in use) so a disconnect restores it.
-            diff.replaced_active = existing_active_sidechain;
-        }
+        let effect = if new_sidechain_activated {
+            if let Some(replaced) = existing_active_sidechain {
+                diff::ack_sidechain_proposal::Effect::ReplaceActive(replaced)
+            } else {
+                diff::ack_sidechain_proposal::Effect::SlotActivation
+            }
+        } else {
+            diff::ack_sidechain_proposal::Effect::NoActivation
+        };
+        let diff = diff::AckSidechainProposal {
+            id: proposal_id,
+            effect,
+        };
         Ok(Some(diff))
     }
 
@@ -920,7 +923,7 @@ impl BlockHandler<'_> {
                 );
                 let diff = self
                     .handle_m2_ack_sidechain(rotxn, height, sidechain_number, description_hash)?
-                    .map(diff::CoinbaseMsg::AckSidechain);
+                    .map(diff::CoinbaseMsg::AckSidechainProposal);
                 Ok((None, diff))
             }
             CoinbaseMessage::M3ProposeBundle(M3ProposeBundle {
@@ -2752,7 +2755,7 @@ mod tests {
             .handle_m2_ack_sidechain(&rwtxn, 1, slot, id_b.description_hash)
             .into_diagnostic()?
             .expect("ack should produce a diff");
-        assert!(diff.activated, "B should activate over the used slot");
+        assert!(diff.activated(), "B should activate over the used slot");
         diff.apply(&mut rwtxn, &dbs, 1).into_diagnostic()?;
         assert_eq!(
             dbs.active_sidechains
@@ -2905,7 +2908,7 @@ mod tests {
             )
             .into_diagnostic()?
             .expect("M2 for known proposal must produce a diff");
-        assert!(!diff.activated, "1 vote should not activate");
+        assert!(!diff.activated(), "1 vote should not activate");
 
         sidechain.status.vote_count = activation_threshold;
         dbs.proposal_id_to_sidechain
@@ -2921,7 +2924,7 @@ mod tests {
             .into_diagnostic()?
             .expect("M2 for known proposal must produce a diff");
         assert!(
-            diff.activated,
+            diff.activated(),
             "vote_count > threshold within max age should activate"
         );
 
@@ -2938,7 +2941,7 @@ mod tests {
             .into_diagnostic()?
             .expect("M2 for known proposal must produce a diff");
         assert!(
-            !diff.activated,
+            !diff.activated(),
             "proposal exceeding max age should not activate"
         );
         Ok(())

--- a/lib/validator/task/mod.rs
+++ b/lib/validator/task/mod.rs
@@ -238,6 +238,7 @@ impl BlockHandler<'_> {
         let mut diff = diff::AckSidechain {
             id: proposal_id,
             activated: false,
+            replaced_active: None,
         };
 
         // `height - proposal_height` can underflow if the enforcer holds a
@@ -248,11 +249,14 @@ impl BlockHandler<'_> {
         // huge age in release (so the sidechain silently fails to activate).
         let sidechain_proposal_age = height.saturating_sub(sidechain.status.proposal_height);
 
-        let sidechain_slot_is_used = dbs
+        // The active sidechain currently occupying this slot, if any. If this
+        // ack activates the proposal, `apply` overwrites it, so the diff must
+        // remember it for `undo` to restore on a reorg.
+        let existing_active_sidechain = dbs
             .active_sidechains
             .sidechain()
-            .try_get(rotxn, &sidechain_number)?
-            .is_some();
+            .try_get(rotxn, &sidechain_number)?;
+        let sidechain_slot_is_used = existing_active_sidechain.is_some();
 
         let new_sidechain_activated = {
             sidechain_slot_is_used
@@ -268,6 +272,9 @@ impl BlockHandler<'_> {
 
         if new_sidechain_activated {
             diff.activated = true;
+            // Record the sidechain this activation will overwrite (if the slot
+            // was already in use) so a disconnect restores it.
+            diff.replaced_active = existing_active_sidechain;
         }
         Ok(Some(diff))
     }


### PR DESCRIPTION
Found this bug with fuzzing of `connect_block` then `disconnect_block` (reorg round-trip), asserting the consensus state is exactly restored.

When an M2 ack activates a sidechain proposal into a slot that is **already occupied** by an active sidechain, the activation overwrites the incumbent — but a block disconnect (reorg) then *deletes* the slot instead of restoring it, permanently losing the previously-active sidechain.

`handle_m2_ack_sidechain` activates a proposal even when the slot is in use:

```rust
let new_sidechain_activated =
    (sidechain_slot_is_used && vote_count > used_sidechain_slot_activation_threshold && ...)
    || (!sidechain_slot_is_used && ...);
```

`AckSidechain::apply` then does `put_sidechain(slot, new)` (overwriting the incumbent) and deletes the proposal. `AckSidechain::undo` does `delete_sidechain(slot)`. Since the `AckSidechain` diff only stored `{id, activated}`, undo had no way to restore the overwritten sidechain, so disconnecting the activating block removes the slot entirely.

## Impact

- A chain reorg through such an activation block permanently deletes a sidechain that was active before the block; nodes with different reorg histories end up with divergent state (`connect_block` / `disconnect_block` are not inverse).
- If the deleted slot held a treasury, `ctip[slot]` persists while the slot becomes inactive. `handle_m5_m6` skips inactive slots, so the OP_DRIVECHAIN treasury output is no longer defended and can be spent — i.e. the reorg can orphan a treasury into an undefended state.

## Fix

Record the overwritten active sidechain in the `AckSidechain` diff (`replaced_active: Option<Sidechain>`, `serde(default)` for compatibility with previously-serialized diffs) and have `undo` restore it with `put_sidechain` instead of `delete_sidechain` when the slot was already in use.

## Test

`ack_sidechain_undo_restores_overwritten_active_sidechain`: active sidechain A in a slot, a competing proposal B activates over it, and after apply+undo the slot must again hold A (not be deleted).

