### PR TITLE
wallet: apply unconfirmed deposit transaction post create

### DIFF
--- a/integration_tests/integration_test.rs
+++ b/integration_tests/integration_test.rs
@@ -706,6 +706,17 @@ pub fn tests(
         },
         crate::test_inactive_drivechain_output::test_inactive_slot_drivechain_output,
     ));
+    async_trials.push(new_trial_with_setup(
+        "consecutive_deposits".to_string(),
+        TestSetupComponents {
+            bin_paths: bin_paths.clone(),
+            network: Network::Regtest,
+            mode: Mode::NoMempool,
+            file_registry: file_registry.clone(),
+            failure_collector: failure_collector.clone(),
+        },
+        crate::test_consecutive_deposits::test_consecutive_deposits,
+    ));
 
     async_trials
 }

--- a/integration_tests/lib.rs
+++ b/integration_tests/lib.rs
@@ -2,6 +2,7 @@ pub mod block_verdict;
 pub mod integration_test;
 pub mod mine;
 pub mod setup;
+mod test_consecutive_deposits;
 mod test_file_based_block_parser;
 mod test_inactive_drivechain_output;
 mod test_invalid_block;

--- a/integration_tests/test_consecutive_deposits.rs
+++ b/integration_tests/test_consecutive_deposits.rs
@@ -1,0 +1,172 @@
+use bip300301_enforcer_lib::{
+    bins::CommandExt as _,
+    proto::{
+        self,
+        mainchain::{
+            CreateDepositTransactionRequest, CreateDepositTransactionResponse,
+            CreateNewAddressRequest, ListUnspentOutputsRequest, SendTransactionRequest,
+        },
+    },
+};
+use futures::channel::mpsc;
+use tokio::time::sleep;
+
+use crate::{
+    integration_test::{
+        activate_sidechain, fund_enforcer, propose_sidechain, wait_for_wallet_sync,
+    },
+    setup::{DummySidechain, PostSetup, Sidechain as _},
+};
+
+const DEPOSIT_AMOUNT: bitcoin::Amount = bitcoin::Amount::from_sat(21_000_000);
+const DEPOSIT_FEE: bitcoin::Amount = bitcoin::Amount::from_sat(1_000_000);
+
+/// Create a deposit via the wallet gRPC, without mining a block.
+async fn create_deposit(
+    post_setup: &mut PostSetup,
+    sidechain_address: &str,
+) -> anyhow::Result<bitcoin::Txid> {
+    let deposit_txid = post_setup
+        .wallet_service_client
+        .create_deposit_transaction(CreateDepositTransactionRequest {
+            sidechain_id: Some(DummySidechain::SIDECHAIN_NUMBER.0.into()),
+            address: Some(sidechain_address.to_owned()),
+            value_sats: Some(DEPOSIT_AMOUNT.to_sat()),
+            fee_sats: Some(DEPOSIT_FEE.to_sat()),
+        })
+        .await?
+        .into_inner()
+        .txid
+        .ok_or_else(|| proto::Error::missing_field::<CreateDepositTransactionResponse>("txid"))?
+        .decode::<CreateDepositTransactionResponse, _>("txid")?;
+    Ok(deposit_txid)
+}
+
+async fn raw_mempool(post_setup: &mut PostSetup) -> anyhow::Result<Vec<String>> {
+    let mempool_json = post_setup
+        .bitcoin_cli
+        .command::<String, _, String, _, _>([], "getrawmempool", [])
+        .run_utf8()
+        .await?;
+    Ok(serde_json::from_str(&mempool_json)?)
+}
+
+async fn unspent_output_count(post_setup: &mut PostSetup) -> anyhow::Result<usize> {
+    let utxos = post_setup
+        .wallet_service_client
+        .list_unspent_outputs(ListUnspentOutputsRequest {})
+        .await?
+        .into_inner();
+    Ok(utxos.outputs.len())
+}
+
+/// Mine `blocks` to Bitcoin Core's own address (not the enforcer wallet), so
+/// the coinbases do not add new UTXOs to the enforcer wallet.
+async fn mine_to_core(post_setup: &mut PostSetup, blocks: u32) -> anyhow::Result<()> {
+    let core_address = post_setup.receive_address.to_string();
+    post_setup
+        .bitcoin_cli
+        .command::<String, _, _, _, _>([], "generatetoaddress", [blocks.to_string(), core_address])
+        .run_utf8()
+        .await?;
+    Ok(())
+}
+
+/// Collapse the entire wallet into a single confirmed UTXO.
+async fn consolidate_to_single_utxo(post_setup: &mut PostSetup) -> anyhow::Result<()> {
+    // The funding coinbases are mostly immature (coinbase maturity is 100
+    // blocks), so a drain can only sweep the few mature ones. Advance the
+    // chain so every funding coinbase matures and a single drain can sweep the
+    // whole wallet.
+    let () = mine_to_core(post_setup, 100).await?;
+    let () = wait_for_wallet_sync().await?;
+
+    for _ in 0..6 {
+        if unspent_output_count(post_setup).await? <= 1 {
+            return Ok(());
+        }
+        let drain_address = post_setup
+            .wallet_service_client
+            .create_new_address(CreateNewAddressRequest {})
+            .await?
+            .into_inner()
+            .address;
+        let _drain = post_setup
+            .wallet_service_client
+            .send_transaction(SendTransactionRequest {
+                drain_wallet_to: Some(drain_address),
+                ..Default::default()
+            })
+            .await?;
+        sleep(std::time::Duration::from_secs(1)).await;
+        let () = mine_to_core(post_setup, 1).await?;
+        // Poll for the enforcer wallet to ingest the confirmed drain.
+        for _ in 0..10 {
+            sleep(std::time::Duration::from_secs(2)).await;
+            if unspent_output_count(post_setup).await? == 1 {
+                return Ok(());
+            }
+        }
+    }
+    anyhow::bail!(
+        "failed to consolidate wallet to a single UTXO, still have {}",
+        unspent_output_count(post_setup).await?
+    )
+}
+
+pub async fn test_consecutive_deposits(mut post_setup: PostSetup) -> anyhow::Result<()> {
+    let (res_tx, _res_rx) = mpsc::unbounded();
+    let sidechain = DummySidechain::setup((), &post_setup, res_tx).await?;
+    let () = propose_sidechain::<DummySidechain>(&mut post_setup).await?;
+    tracing::info!("Proposed sidechain successfully");
+    let () = activate_sidechain::<DummySidechain>(&mut post_setup).await?;
+    tracing::info!("Activated sidechain successfully");
+    let () = fund_enforcer::<DummySidechain>(&mut post_setup).await?;
+    tracing::info!("Funded enforcer successfully");
+    drop(sidechain);
+
+    // Collapse the wallet into a single UTXO so the two deposits below have no
+    // choice but to compete for the same funding input.
+    let () = consolidate_to_single_utxo(&mut post_setup).await?;
+    tracing::info!("Consolidated wallet into a single UTXO");
+
+    // First deposit: always succeeds, spending the sole UTXO.
+    let deposit_txid_1 = create_deposit(&mut post_setup, "sidechain address 1").await?;
+    tracing::info!(%deposit_txid_1, "Created first deposit");
+    // Wait for the deposit tx to enter the mempool.
+    sleep(std::time::Duration::from_secs(1)).await;
+
+    // Second deposit, without a block in between. This must succeed: it should
+    // be funded from the first deposit's change output, not by reselecting the
+    // first deposit's (now spent) input.
+    let deposit_txid_2 = create_deposit(&mut post_setup, "sidechain address 2")
+        .await
+        .map_err(|err| {
+            anyhow::anyhow!(
+                "second consecutive deposit failed to broadcast \
+                 (the wallet reused the first deposit's funding input, so Core \
+                 rejected it as an RBF replacement): {err:#}"
+            )
+        })?;
+    tracing::info!(%deposit_txid_2, "Created second deposit");
+    sleep(std::time::Duration::from_secs(1)).await;
+
+    anyhow::ensure!(
+        deposit_txid_1 != deposit_txid_2,
+        "expected two distinct deposit txids"
+    );
+
+    // Both deposits must coexist in the mempool. If the second had replaced the
+    // first (RBF), only one would be present.
+    let mempool = raw_mempool(&mut post_setup).await?;
+    anyhow::ensure!(
+        mempool.contains(&deposit_txid_1.to_string()),
+        "first deposit {deposit_txid_1} missing from mempool (was it replaced?): {mempool:?}"
+    );
+    anyhow::ensure!(
+        mempool.contains(&deposit_txid_2.to_string()),
+        "second deposit {deposit_txid_2} missing from mempool: {mempool:?}"
+    );
+    tracing::info!("Both consecutive deposits are in the mempool");
+    Ok(())
+}

--- a/lib/wallet/cusf_block_producer.rs
+++ b/lib/wallet/cusf_block_producer.rs
@@ -275,18 +275,32 @@ impl CusfEnforcer for Wallet {
                     let inner = self.inner.clone();
                     let tx = tx.clone();
                     || async move {
-                        let mut wallet_write = match inner.write_wallet().await {
-                            Ok(wallet_write) => wallet_write,
-                            Err(err) => {
-                                tracing::error!("{:#}", ErrorChain::new(&err));
-                                return;
-                            }
+                        // Apply the unconfirmed tx and persist, so the spent
+                        // inputs survive a restart before the tx confirms. The
+                        // locks are scoped so they are released before logging.
+                        let persist_res = {
+                            let mut bdk_db_lock = inner.bdk_db.lock().await;
+                            let mut wallet_write = match inner.write_wallet().await {
+                                Ok(wallet_write) => wallet_write,
+                                Err(err) => {
+                                    tracing::error!("{:#}", ErrorChain::new(&err));
+                                    return;
+                                }
+                            };
+                            let now = SystemTime::now()
+                                .duration_since(UNIX_EPOCH)
+                                .unwrap()
+                                .as_secs();
+                            wallet_write
+                                .with_mut(|wallet| {
+                                    wallet.apply_unconfirmed_txs([(tx, now)]);
+                                    wallet.persist_async(&mut bdk_db_lock)
+                                })
+                                .await
                         };
-                        let now = SystemTime::now()
-                            .duration_since(UNIX_EPOCH)
-                            .unwrap()
-                            .as_secs();
-                        wallet_write.with_mut(|wallet| wallet.apply_unconfirmed_txs([(tx, now)]));
+                        if let Err(err) = persist_res {
+                            tracing::error!("{:#}", ErrorChain::new(&err));
+                        }
                     }
                 }());
             }

--- a/lib/wallet/error.rs
+++ b/lib/wallet/error.rs
@@ -729,6 +729,10 @@ pub enum CreateDeposit {
     #[error("failed to convert sidechain address to PushBytesBuf")]
     ConvertSidechainAddress(#[source] bitcoin::script::PushBytesError),
     #[error(transparent)]
+    NotUnlocked(#[from] NotUnlocked),
+    #[error(transparent)]
+    Persistence(#[from] Persistence),
+    #[error(transparent)]
     Psbt(#[from] CreateDepositPsbt),
     #[error(transparent)]
     SignTransaction(#[from] WalletSignTransaction),
@@ -745,6 +749,8 @@ impl ToStatus for CreateDeposit {
             | Self::BroadcastNonstandardTx { .. }
             | Self::BroadcastUnsuccessful { .. }
             | Self::ConvertSidechainAddress(_) => StatusBuilder::new(self),
+            Self::NotUnlocked(err) => err.builder(),
+            Self::Persistence(err) => StatusBuilder::new(err),
             Self::Psbt(err) => err.builder(),
             Self::SignTransaction(err) => err.builder(),
             Self::TryGetCtip(err) => err.builder(),

--- a/lib/wallet/mod.rs
+++ b/lib/wallet/mod.rs
@@ -1443,6 +1443,36 @@ impl Wallet {
         }
         if broadcast_successfully {
             tracing::info!(%txid, "Broadcast deposit transaction successfully");
+
+            // Apply the unconfirmed deposit to the wallet so its funding input
+            // is marked spent. Otherwise a deposit created before this tx
+            // confirms can reselect the same UTXO, which Bitcoin Core rejects
+            // as an RBF replacement. Mirrors `send_wallet_transaction`.
+            let mut bdk_db_lock = self.inner.bdk_db.lock().await;
+            let last_seen = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap();
+            let applied_changes = self
+                .inner
+                .write_wallet()
+                .await?
+                .with_mut(|wallet| {
+                    wallet.apply_unconfirmed_txs(vec![(tx, last_seen.as_secs())]);
+                    wallet.persist_async(&mut bdk_db_lock)
+                })
+                .await?;
+            if applied_changes {
+                tracing::debug!(%txid, "Applied unconfirmed deposit transaction to wallet");
+            } else {
+                // A deposit can be funded entirely by the sidechain's CTIP
+                // foreign UTXO, with no wallet-owned input or change, in which
+                // case there is nothing for the wallet to track.
+                tracing::warn!(
+                    %txid,
+                    "No wallet changes after applying unconfirmed deposit transaction",
+                );
+            }
+
             Ok(convert::bdk_txid_to_bitcoin_txid(txid))
         } else {
             Err(error::CreateDeposit::BroadcastUnsuccessful { txid })


### PR DESCRIPTION
Prior to this commit we would fail with RBF-looking errors due to the BDK wallet not having the correct view of our UTXOs.