### PR TITLE
[DoS] Invalidate consensus-invalid blocks during sync instead of halting the enforcer

### DIFF
--- a/lib/validator/cusf_enforcer.rs
+++ b/lib/validator/cusf_enforcer.rs
@@ -8,12 +8,13 @@ use std::{
 
 use async_broadcast::TrySendError;
 use bitcoin::{Block, BlockHash, Transaction, Txid, hashes::Hash as _};
+use bitcoin_jsonrpsee::client::MainClient as _;
 use cusf_enforcer_mempool::cusf_enforcer::{
     ConnectBlockAction, CusfEnforcer, DisconnectBlockAction, TxAcceptAction,
 };
 use error_fatality::{Nested as _, Split};
 use fallible_iterator::FallibleIterator;
-use futures::TryFutureExt as _;
+use futures::{FutureExt as _, TryFutureExt as _};
 use miette::Diagnostic;
 use ouroboros::self_referencing;
 use sneed::{RoTxn, RwTxn, db, env, rwtxn};
@@ -351,14 +352,13 @@ where
     }
 }
 
-impl CusfEnforcer for Validator {
-    type SyncError = SyncError;
-
-    async fn sync_to_tip<Signal>(
-        &mut self,
+impl Validator {
+    /// Sync to the specified tip, without handling consensus-invalid blocks.
+    async fn sync_to_tip_once<Signal>(
+        &self,
         shutdown_signal: Signal,
         tip: BlockHash,
-    ) -> Result<(), Self::SyncError>
+    ) -> Result<(), SyncError>
     where
         Signal: Future<Output = ()> + Send,
     {
@@ -402,6 +402,68 @@ impl CusfEnforcer for Validator {
                 cancel.cancel();
                 *self.header_sync_progress_rx.write() = None;
                 Err(SyncError(crate::validator::task::error::Sync::Shutdown))
+            }
+        }
+    }
+}
+
+impl CusfEnforcer for Validator {
+    type SyncError = SyncError;
+
+    async fn sync_to_tip<Signal>(
+        &mut self,
+        shutdown_signal: Signal,
+        mut tip: BlockHash,
+    ) -> Result<(), Self::SyncError>
+    where
+        Signal: Future<Output = ()> + Send,
+    {
+        let shutdown_signal = shutdown_signal.shared();
+        let mut invalidated = HashSet::new();
+        loop {
+            match self.sync_to_tip_once(shutdown_signal.clone(), tip).await {
+                Ok(()) => return Ok(()),
+                Err(SyncError(task::error::Sync::BlockRejected { block_hash, source })) => {
+                    // The mainchain node accepted a block that violates BIP300/301.
+                    // Invalidate it so that the node reorgs away from it, and sync to
+                    // the resulting tip. This mirrors the live
+                    // `ConnectBlockAction::Reject` path, which the
+                    // cusf-enforcer-mempool crate does not apply during sync.
+                    // Halting here would leave a bootstrapping or catching-up
+                    // enforcer stuck forever on such a block.
+                    if !invalidated.insert(block_hash) {
+                        return Err(SyncError(task::error::Sync::BlockRejected {
+                            block_hash,
+                            source,
+                        }));
+                    }
+                    tracing::warn!(
+                        %block_hash,
+                        "invalidating consensus-invalid block: {:#}",
+                        ErrorChain::new(source.as_ref())
+                    );
+                    let () = self
+                        .mainchain_client
+                        .invalidate_block(block_hash)
+                        .await
+                        .map_err(|err| {
+                            SyncError(task::error::Sync::JsonRpc {
+                                method: "invalidateblock".to_owned(),
+                                source: err,
+                            })
+                        })?;
+                    tip = self
+                        .mainchain_client
+                        .getbestblockhash()
+                        .await
+                        .map_err(|err| {
+                            SyncError(task::error::Sync::JsonRpc {
+                                method: "getbestblockhash".to_owned(),
+                                source: err,
+                            })
+                        })?;
+                }
+                Err(err) => return Err(err),
             }
         }
     }

--- a/lib/validator/task/error.rs
+++ b/lib/validator/task/error.rs
@@ -445,6 +445,15 @@ pub(in crate::validator) enum Sync {
     #[error("Block not in active chain: `{block_hash}`")]
     #[fatal(true)]
     BlockNotInActiveChain { block_hash: bitcoin::BlockHash },
+    /// A block that the mainchain node accepted, but that violates BIP300/301.
+    /// Not a fatal sync failure: the block is invalidated on the node, and the
+    /// sync is retried against the resulting tip.
+    #[error("Consensus-invalid block `{block_hash}` rejected during sync")]
+    #[fatal(false)]
+    BlockRejected {
+        block_hash: bitcoin::BlockHash,
+        source: Box<ConnectBlock>,
+    },
     #[error(transparent)]
     #[fatal(true)]
     CommitWriteTxn(#[from] rwtxn::error::Commit),

--- a/lib/validator/task/mod.rs
+++ b/lib/validator/task/mod.rs
@@ -2097,6 +2097,50 @@ mod tests {
         Ok(())
     }
 
+    // Regression test for the sync-path DoS: a block that the mainchain node
+    // accepts, but that is consensus-invalid per BIP300/301, must be reported as a
+    // recoverable `Sync::BlockRejected` carrying the offending block hash, so that
+    // the caller can invalidate it, rather than as a fatal error that halts a
+    // bootstrapping or catching-up enforcer.
+    #[test]
+    fn handle_block_batch_rejects_consensus_invalid_block_without_halting() -> Result<()> {
+        let (_dir, dbs) = create_test_dbs()?;
+        let mut rwtxn = dbs.write_txn().into_diagnostic()?;
+        let prev_hash = BlockHash::all_zeros();
+
+        let m8_tx = build_m8_tx(SidechainNumber(1), [0x42; 32], prev_hash);
+        let block = build_test_block(
+            prev_hash,
+            TestBlockParts {
+                extra_txs: vec![m8_tx],
+                ..Default::default()
+            },
+        );
+        let block_hash = block.block_hash();
+
+        dbs.block_hashes
+            .put_headers(&mut rwtxn, &[(block.header, 0)])
+            .into_diagnostic()?;
+
+        let (event_tx, _event_rx) = async_broadcast::broadcast(16);
+        let err = test_handler(&dbs)
+            .handle_block_batch(&mut rwtxn, std::slice::from_ref(&block), &event_tx)
+            .expect_err("consensus-invalid block must be rejected");
+
+        assert!(!err.is_fatal(), "a consensus rejection must not be fatal");
+        match err {
+            error::Sync::BlockRejected {
+                block_hash: rejected,
+                ..
+            } => assert_eq!(
+                rejected, block_hash,
+                "BlockRejected must carry the offending block hash for invalidateblock"
+            ),
+            other => panic!("expected Sync::BlockRejected, got: {other:?}"),
+        }
+        Ok(())
+    }
+
     #[test]
     fn connect_then_disconnect_restores_db_state() -> Result<()> {
         let (_dir, dbs) = create_test_dbs()?;

--- a/lib/validator/task/mod.rs
+++ b/lib/validator/task/mod.rs
@@ -11,7 +11,7 @@ use bitcoin::{
     Amount, Block, BlockHash, Network, OutPoint, Transaction, Work,
     hashes::{Hash as _, sha256d},
 };
-use error_fatality::Split as _;
+use error_fatality::{Fatality as _, Split as _};
 use fallible_iterator::{FallibleIterator, IteratorExt};
 use futures::FutureExt as _;
 use jsonrpsee::core::{
@@ -1565,10 +1565,22 @@ impl BlockHandler<'_> {
             });
 
             let start_block = Instant::now();
-            // We should not call out to `invalidateblock` in case of failures here,
-            // as that is handled by the cusf-enforcer-mempool crate.
             // FIXME: handle disconnects
-            let event = self.connect_block(rwtxn, block)?;
+            //
+            // Unlike the live path, the cusf-enforcer-mempool crate does not call
+            // `invalidateblock` during sync, it just propagates the error. Report a
+            // consensus rejection with the offending block hash, so that the caller
+            // can invalidate it. Fatal (infra/DB) errors are propagated as-is.
+            let event = match self.connect_block(rwtxn, block) {
+                Ok(event) => event,
+                Err(err) if !err.is_fatal() => {
+                    return Err(error::Sync::BlockRejected {
+                        block_hash,
+                        source: Box::new(err),
+                    });
+                }
+                Err(err) => return Err(err.into()),
+            };
 
             let connect_block_duration =
                 jiff::SignedDuration::try_from(start_block.elapsed()).unwrap_or_default();
@@ -1750,6 +1762,9 @@ impl BlockHandler<'_> {
             total_blocks_fetched += blocks.len();
 
             let mut rwtxn = dbs.write_txn()?;
+            // A `Sync::BlockRejected` error here aborts the write txn, discarding
+            // the partial batch. It is handled by the caller, which invalidates the
+            // block on the node and retries the sync.
             self.handle_block_batch(&mut rwtxn, &blocks, event_tx)?;
             rwtxn.commit()?;
         }


### PR DESCRIPTION
Found this bug by crafting a treasury-theft block and observing the enforcer halt while syncing it. The enforcer handles a consensus-invalid block (one the mainchain node accepted but that violates BIP300/301) **asymmetrically** depending on when it's seen:

- **Live path** (`cusf-enforcer-mempool`, block arrives via ZMQ): `connect_block` returns `ConnectBlockAction::Reject` and node is told to `invalidateblock` 
- **Sync path** (`handle_block_batch`, initial bootstrap / catch-up): the same `connect_block` error is propagated with a blind `?`, becomes a fatal `SyncError`, and aborts the whole task

So a block the live path cleanly rejects instead **bricks any enforcer that meets it during sync**:

- a fresh enforcer bootstrapping on a node whose active chain already contains such a block can never finish initial sync;
- an enforcer catching up after downtime / a deep reorg aborts on it.

This is cheap to trigger. A sidechain treasury is an `OP_DRIVECHAIN` output, which is **anyone-can-spend** at the script level and the node does not enforce BIP300 at consensus. So, anyone can mine a tx that spends the treasury to a plain output. The node accepts the block; `connect_block` correctly rejects it (`TreasurySpentWithoutNewCtip`), but the sync path turns that *non-fatal* rejection into a fatal halt. While the enforcer is down it can't invalidate the block, so the bad chain stands . The availability defect undermines the very protection the enforcer provides.

```
INFO  Synced block #108: `02e96351...` total_txs=1 sc_events=0
INFO  Synced block #109: `13d419da...` total_txs=2 sc_events=1
Error:   × exit-after-sync task failed
  ├─ Error handling transaction
  │   `a1d75302bbff246033bbf6bf2f86bad14142abcfcf1fbb55e475c3df64e1888c` in
  │   block `44cb0d671dd67b2b3ac50447f1597ed2d47cda9c5a23671db78849509db7def3`
  ├─ Error handling M5/M6
  ╰─ treasury UTXO for sidechain 0 is spent without creating a new treasury UTXO
```

## Fix

Make the sync path mirror the live path. `connect_block` errors already carry a fatal/non-fatal classification (`error_fatality`); the sync path now respects it:

- `handle_block_batch` surfaces a *non-fatal* `connect_block` rejection as a new recoverable `Sync::BlockRejected { block_hash, .. }` instead of a blind `?`
- `sync_blocks` calls `invalidateblock(block_hash)` on the node and returns `Ok` so the caller re-syncs to the reorged tip (exactly the live `ConnectBlockAction::Reject` behavior)
- Genuine fatal (infra/DB) errors still abort, unchanged.

## Tests

- New unit test `handle_block_batch_rejects_consensus_invalid_block_without_halting`:  asserts a consensus-invalid block is surfaced as the recoverable `Sync::BlockRejected` (carrying the offending hash), not a fatal error.
- Verified end-to-end against a drivechain-patched regtest node with a real treasury-theft block: pre-fix `--exit-after-sync` aborts (exit 1); with the fix the enforcer invalidates the block, reorgs it away, and exits cleanly.