### PR TITLE
Delete treasury utxo count key on disconnect of last treasury UTXO

### DIFF
--- a/lib/validator/dbs/mod.rs
+++ b/lib/validator/dbs/mod.rs
@@ -156,8 +156,15 @@ impl ActiveSidechainDbs {
             .delete(rwtxn, &ctip.outpoint)?;
         let treasury_utxo_count = self.treasury_utxo_count.get(rwtxn, &sidechain_number)?;
         let sequence_number = treasury_utxo_count - 1;
-        self.treasury_utxo_count
-            .put(rwtxn, &sidechain_number, &sequence_number)?;
+        // put_ctip creates this key at a count of 1 for the first treasury utxo,
+        // so disconnecting the last one must delete the key to restore the
+        // pre-deposit state, rather than leaving a stale count of 0.
+        if sequence_number == 0 {
+            let _ = self.treasury_utxo_count.delete(rwtxn, &sidechain_number)?;
+        } else {
+            self.treasury_utxo_count
+                .put(rwtxn, &sidechain_number, &sequence_number)?;
+        }
         let _ = self
             .slot_sequence_to_treasury_utxo
             .delete(rwtxn, &(sidechain_number, sequence_number))?;

--- a/lib/validator/task/mod.rs
+++ b/lib/validator/task/mod.rs
@@ -2124,6 +2124,55 @@ mod tests {
         Ok(())
     }
 
+    /// Disconnecting the only deposit to a sidechain must restore the
+    /// pre-deposit state: the treasury utxo count key is removed, not left at 0.
+    /// put_ctip creates the key at a count of 1 for the first treasury UTXO, so
+    /// delete_ctip must delete it again on disconnect.
+    #[test]
+    fn disconnect_first_deposit_removes_treasury_utxo_count() -> Result<()> {
+        let (_dir, dbs) = create_test_dbs()?;
+        let mut rwtxn = dbs.write_txn().into_diagnostic()?;
+        let sc = SidechainNumber(1);
+        dbs.active_sidechains
+            .put_sidechain(&mut rwtxn, &sc, &test_sidechain(1, 0))
+            .into_diagnostic()?;
+
+        let deposit = build_m5_deposit_tx(
+            sc,
+            OutPoint::default(),
+            Amount::ZERO,
+            Amount::from_sat(10_000),
+        );
+        let block = build_test_block(
+            BlockHash::all_zeros(),
+            TestBlockParts {
+                extra_txs: vec![deposit],
+                ..Default::default()
+            },
+        );
+        let block_hash = block.header.block_hash();
+        dbs.block_hashes
+            .put_headers(&mut rwtxn, &[(block.header, 0)])
+            .into_diagnostic()?;
+
+        let (event_tx, _) = async_broadcast::broadcast(16);
+        let _event = test_handler(&dbs)
+            .connect_block(&mut rwtxn, &block)
+            .into_diagnostic()?;
+        test_handler(&dbs)
+            .disconnect_block(&mut rwtxn, &event_tx, block_hash)
+            .into_diagnostic()?;
+
+        assert_eq!(
+            dbs.active_sidechains
+                .treasury_utxo_count
+                .try_get(&rwtxn, &sc)
+                .into_diagnostic()?,
+            None,
+        );
+        Ok(())
+    }
+
     // ── handle_m5_m6 ──
 
     #[test]


### PR DESCRIPTION
`delete_ctip` (block disconnect) decrements `treasury_utxo_count` and writes the new value back but when the count reaches 0 it writes Some(0) instead of deleting the key. `put_ctip` creates the key at a count of 1 for the first treasury UTXO of a sidechain (M5 deposit, see bip300.md), so connecting then disconnecting the first deposit leaves a stale `treasury_utxo_count` of Some(0) where it should be absent. `disconnect_block` is not an exact inverse of `connect_block` for this key.

`put_ctip` reads the count with `unwrap_or(0),` so Some(0) and absent behave the same and sequence numbering stays correct. But it leaves dangling state after a reorg and breaks the connect/disconnect round-trip invariant.

The fix deletes the key when the decremented count reaches 0; the test asserts the count key is absent after disconnecting the only deposit (fails on master).