### PR TITLE
Reject undersized or truncated block file entries instead of panicking

### DIFF
--- a/lib/validator/parse_block_files.rs
+++ b/lib/validator/parse_block_files.rs
@@ -58,6 +58,9 @@ pub enum ParseBlockFileError {
     #[error("Block size too large: {size} bytes")]
     BlockSizeTooLarge { size: u32 },
 
+    #[error("Block size too small: {size} bytes, minimum is the 80 byte header")]
+    BlockSizeTooSmall { size: u32 },
+
     #[error("Failed to decode TX data")]
     TxDataDecode(#[source] bitcoin::consensus::encode::Error),
 
@@ -242,11 +245,18 @@ impl BlockFileParser {
             .map_err(ParseBlockFileError::UintDecode)? as usize;
 
         // Read the block header
-        let header = Header::consensus_decode(&mut self.reader).unwrap();
+        let header = Header::consensus_decode(&mut self.reader)
+            .map_err(ParseBlockFileError::HeaderDecode)?;
 
-        // Skip the rest of the block
-        let mut txdata = vec![0; size - 80];
-        bitcoin::io::Read::read_exact(&mut self.reader, &mut txdata).unwrap();
+        // Skip the rest of the block. The size covers the 80 byte header plus
+        // the transaction data, so a size below 80 is malformed and must not
+        // underflow the length calculation.
+        let txdata_len = size
+            .checked_sub(80)
+            .ok_or(ParseBlockFileError::BlockSizeTooSmall { size: size as u32 })?;
+        let mut txdata = vec![0; txdata_len];
+        bitcoin::io::Read::read_exact(&mut self.reader, &mut txdata)
+            .map_err(|e| ParseBlockFileError::Io(e.into()))?;
 
         Ok(Some(ParsedBlock {
             header,

--- a/lib/validator/parse_block_files.rs
+++ b/lib/validator/parse_block_files.rs
@@ -816,6 +816,24 @@ mod tests {
 
     use super::*;
 
+    /// A block whose declared size is below the 80 byte header length must be
+    /// rejected gracefully, not panic via a `size - 80` underflow. A truncated
+    /// or corrupt blk*.dat triggers this.
+    #[test]
+    fn next_block_rejects_undersized_block_without_panicking() {
+        use std::io::Write as _;
+        let mut bytes = REGTEST_MAGIC.to_vec();
+        bytes.extend_from_slice(&0u32.to_le_bytes()); // size = 0, below the 80 byte header
+        bytes.extend_from_slice(&[0u8; 80]); // a well-formed 80 byte header
+        let path = std::env::temp_dir().join("bip300_undersized_blk00000.dat");
+        std::fs::File::create(&path)
+            .unwrap()
+            .write_all(&bytes)
+            .unwrap();
+        let mut parser = BlockFileParser::new(None, path, Network::Regtest).unwrap();
+        assert!(parser.next_block().is_err());
+    }
+
     #[test]
     fn test_parse_real_file_with_xor_key() {
         let path =


### PR DESCRIPTION
`BlockFileParser::next_block `reads a 4‑byte size field straight from a blk*.dat and then does vec![0; size - 80]. A size < 80 (header length) underflows panic in debug, huge allocation/abort in release. The header decode (:245) and the block‑body read_exact (:249) also used .unwrap(), so a truncated/corrupt block file aborts the process rather than returning an error. When the enforcer is run with --main-blocks-dir, a single corrupt or half‑written block file therefore crashes it.

Fix: Add a `BlockSizeTooSmall` error, use checked_sub(80), and replace the two unwrap()s with the existing HeaderDecode / Io error variants. Test feeds a block with size = 0 and asserts next_block() returns an error instead of panicking (fails on master).