### PR TITLE
[DoS] server: fix sidechain proposal age underflow in get_sidechain_proposals

### DIFF
--- a/lib/server/validator/grpc.rs
+++ b/lib/server/validator/grpc.rs
@@ -31,6 +31,14 @@ use crate::{
     types::Thresholds,
 };
 
+/// Age of a sidechain proposal at the given mainchain tip height. A proposal
+/// retained from a previous sync can have a `proposal_height` above the active
+/// tip, so this saturates instead of underflowing, matching the same
+/// computation in `validator::task`.
+fn proposal_age(mainchain_tip_height: u32, proposal_height: u32) -> u32 {
+    mainchain_tip_height.saturating_sub(proposal_height)
+}
+
 #[expect(refining_impl_trait_reachable)]
 impl ValidatorService for Server {
     async fn get_block_header_info(
@@ -331,7 +339,10 @@ impl ValidatorService for Server {
                     )),
                     vote_count: wrap_u32(sidechain.status.vote_count as u32),
                     proposal_height: wrap_u32(sidechain.status.proposal_height),
-                    proposal_age: wrap_u32(mainchain_tip_height - sidechain.status.proposal_height),
+                    proposal_age: wrap_u32(proposal_age(
+                        mainchain_tip_height,
+                        sidechain.status.proposal_height,
+                    )),
                 }
             })
             .collect();

--- a/lib/server/validator/grpc.rs
+++ b/lib/server/validator/grpc.rs
@@ -455,3 +455,20 @@ impl ValidatorService for Server {
         Ok(Response::new(StopResponse::default()))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::proposal_age;
+
+    #[test]
+    fn proposal_age_saturates_below_tip() {
+        // A proposal retained from a previous sync can sit above the active
+        // tip; its age must saturate to zero rather than underflow.
+        assert_eq!(proposal_age(10, 25), 0);
+    }
+
+    #[test]
+    fn proposal_age_is_tip_minus_proposal_height() {
+        assert_eq!(proposal_age(25, 10), 15);
+    }
+}


### PR DESCRIPTION
`get_sidechain_proposals` computes each proposal's `proposal_age` with an unchecked `u32` subtraction:

```rust
proposal_age: wrap_u32(mainchain_tip_height - sidechain.status.proposal_height),
```

When a sidechain proposal retained from a previous, non-active sync has a `proposal_height` greater than the current `mainchain_tip_height`, this subtraction underflows: it panics under overflow checks, or wraps to a garbage age in release. `get_sidechains` returns every stored proposal, so a stale proposal above the active tip is enough to trigger it.

`get_sidechain_proposals` takes an empty request, so any caller can reach this path and crash the enforcer.

## Fix

The same computation in `validator::task` already guards against this with `saturating_sub` (a proposal can have a height above the active tip after a reorg/resync). This routes the gRPC handler through a shared `proposal_age` helper that saturates instead of underflowing and adds a regression test.
