### PR TITLE
[DoS] validator: reject blocks with no coinbase instead of panicking in connect_block

### DIFF
--- a/lib/validator/task/error.rs
+++ b/lib/validator/task/error.rs
@@ -375,6 +375,9 @@ pub(in crate::validator) enum ConnectBlock {
     #[error("Multiple blocks BMM'd in sidechain slot {}", .sidechain_number.0)]
     #[fatal(false)]
     MultipleBmmBlocks { sidechain_number: SidechainNumber },
+    #[error("Block has no transactions (missing coinbase)")]
+    #[fatal(false)]
+    NoCoinbase,
     #[error(transparent)]
     #[fatal(true)]
     PutBlockInfo(#[from] dbs::block_hash_dbs_error::PutBlockInfo),

--- a/lib/validator/task/mod.rs
+++ b/lib/validator/task/mod.rs
@@ -2091,6 +2091,32 @@ mod tests {
     }
 
     #[test]
+    fn connect_block_rejects_empty_block_without_panicking() -> Result<()> {
+        let (_dir, dbs) = create_test_dbs()?;
+        let mut rwtxn = dbs.write_txn().into_diagnostic()?;
+        let prev_hash = BlockHash::all_zeros();
+
+        // A block whose txdata is empty (no coinbase) is reachable via the
+        // block-file sync path from a crafted blk*.dat. Indexing txdata[0]
+        // would panic; connect_block must reject it instead.
+        let mut block = build_test_block(prev_hash, TestBlockParts::default());
+        block.txdata.clear();
+
+        dbs.block_hashes
+            .put_headers(&mut rwtxn, &[(block.header, 0)])
+            .into_diagnostic()?;
+
+        assert!(
+            matches!(
+                test_handler(&dbs).connect_block(&mut rwtxn, &block),
+                Err(error::ConnectBlock::NoCoinbase)
+            ),
+            "connect_block must reject an empty block, not panic"
+        );
+        Ok(())
+    }
+
+    #[test]
     fn connect_then_disconnect_restores_db_state() -> Result<()> {
         let (_dir, dbs) = create_test_dbs()?;
         let mut rwtxn = dbs.write_txn().into_diagnostic()?;

--- a/lib/validator/task/mod.rs
+++ b/lib/validator/task/mod.rs
@@ -1049,7 +1049,9 @@ impl BlockHandler<'_> {
 
         tracing::trace!("starting block processing");
         let height = dbs.block_hashes.height().get(rwtxn, &block.block_hash())?;
-        let coinbase = &block.txdata[0];
+        let Some(coinbase) = block.txdata.first() else {
+            return Err(error::ConnectBlock::NoCoinbase);
+        };
         let mut coinbase_messages = CoinbaseMessages::default();
         // map of sidechain proposals to first vout
         let mut m1_sidechain_proposals = HashMap::new();


### PR DESCRIPTION
`connect_block` reads the coinbase with an unchecked index:

```rust
let coinbase = &block.txdata[0];
```

A block whose `txdata` is empty makes this panic with `index out of bounds: the len is 0 but the index is 0`, aborting the enforcer. There is no emptiness check and no merkle validation before the index.

The block-file sync path (`--main-blocks-dir`) is the trigger. `BlockFileParser::next_block` reads a `u32` size, an 80-byte header, then `txdata_len = size.checked_sub(80)` (the guard added in #403). With `size = 81` and a single `0x00` body byte, `txdata_len = 1` and `Vec::<Transaction>::consensus_decode(&[0x00])` returns `Ok(vec![])` an empty transaction list. The block hash is computed from the header alone, so a crafted `blk*.dat` can copy a genuine, expected block's real 80-byte header and pass through to `connect_block`, which then panics.

This is distinct from #403 (which only guards `size < 80`) and #396 (which reclassifies returned errors and cannot catch a panic).

## Fix

Reject a block with no coinbase via a new non-fatal `ConnectBlock::NoCoinbase` error instead of indexing. Includes a regression test that connects an empty-`txdata` block and asserts it is rejected rather than panicking.

