### PR TITLE
Reject M5 deposit with no address OP_RETURN output

### DIFF
--- a/integration_tests/test_invalid_block.rs
+++ b/integration_tests/test_invalid_block.rs
@@ -1,13 +1,13 @@
-use std::time::Duration;
+use std::{str::FromStr as _, time::Duration};
 
 use bip300301_enforcer_lib::{
     bins::CommandExt as _,
     messages::{M1ProposeSidechain, M2AckSidechain, M4AckBundles, M7BmmAccept},
-    types::{BmmCommitment, SidechainDescription},
+    types::{BmmCommitment, SidechainDescription, op_drivechain_script},
 };
 use bitcoin::{
     Amount, Block, BlockHash, CompactTarget, OutPoint, ScriptBuf, Sequence, Transaction, TxIn,
-    TxMerkleNode, TxOut, Witness,
+    TxMerkleNode, TxOut, Txid, Witness,
     block::Header,
     consensus::encode::{deserialize_hex, serialize_hex},
     hashes::{Hash as _, sha256d},
@@ -127,6 +127,18 @@ pub async fn test_invalid_block(mut post_setup: PostSetup) -> anyhow::Result<()>
         }
     }
 
+    // An M5 deposit is a regular (non-coinbase) transaction, so unlike the
+    // coinbase-message cases above it can't be expressed as an extra coinbase
+    // output. It's mined as a raw tx via `generateblock` instead.
+    const M5_CASE: &str = "m5_missing_address";
+    match run_m5_missing_address_case(&mut post_setup).await {
+        Ok(()) => tracing::info!(case = M5_CASE, "case passed"),
+        Err(err) => {
+            tracing::error!(case = M5_CASE, "case failed: {err:#}");
+            failures.push(format!("{M5_CASE}: {err:#}"));
+        }
+    }
+
     if !failures.is_empty() {
         anyhow::bail!(
             "invalid_block cases failed:\n  - {}",
@@ -152,6 +164,128 @@ async fn run_case(post_setup: &mut PostSetup, case: &BadBlockCase) -> anyhow::Re
         Duration::from_secs(10),
     )
     .await
+}
+
+/// Blocks mined to give bitcoind's wallet a mature, spendable coinbase UTXO to
+/// fund the M5 deposit transaction (coinbase outputs need 100 confirmations).
+const M5_FUNDING_BLOCKS: u32 = 101;
+
+const M5_TX_FEE: Amount = Amount::from_sat(1_000);
+
+#[derive(Deserialize)]
+struct Utxo {
+    txid: String,
+    vout: u32,
+    amount: f64,
+}
+
+#[derive(Deserialize)]
+struct SignResult {
+    hex: String,
+    complete: bool,
+}
+
+#[derive(Deserialize)]
+struct GenerateBlockResult {
+    hash: String,
+}
+
+async fn run_m5_missing_address_case(post_setup: &mut PostSetup) -> anyhow::Result<()> {
+    let bad_block_hash = submit_m5_missing_address_block(post_setup).await?;
+    tracing::info!(%bad_block_hash, "submitted bad M5 deposit block");
+
+    // Without the fix the enforcer accepts this deposit with an empty address;
+    // with the fix it rejects the block because the address OP_RETURN output
+    // required by BIP 300 M5 is missing.
+    assert_enforcer_verdict(
+        post_setup,
+        bad_block_hash,
+        Expect::Rejected {
+            log_contains: "has no address OP_RETURN output",
+        },
+        Duration::from_secs(10),
+    )
+    .await
+}
+
+/// Build, sign, and mine (via `generateblock`) an M5 deposit for the active
+/// DummySidechain slot whose transaction creates the treasury UTXO but omits
+/// the address OP_RETURN output that must immediately follow it.
+async fn submit_m5_missing_address_block(post_setup: &PostSetup) -> anyhow::Result<BlockHash> {
+    let mining_address = post_setup.mining_address.to_string();
+
+    // Ensure bitcoind's wallet has a mature UTXO to spend into the deposit.
+    post_setup
+        .bitcoin_cli
+        .command::<String, _, _, _, _>(
+            [],
+            "generatetoaddress",
+            [M5_FUNDING_BLOCKS.to_string(), mining_address.clone()],
+        )
+        .run_utf8()
+        .await?;
+
+    let utxos: Vec<Utxo> = {
+        let json = post_setup
+            .bitcoin_cli
+            .command::<String, _, String, _, _>([], "listunspent", [])
+            .run_utf8()
+            .await?;
+        serde_json::from_str(&json)?
+    };
+    let (utxo, input_value) = utxos
+        .into_iter()
+        .find_map(|u| {
+            let amount = Amount::from_btc(u.amount).ok()?;
+            (amount > M5_TX_FEE).then_some((u, amount))
+        })
+        .ok_or_else(|| anyhow::anyhow!("no spendable UTXO in bitcoind wallet"))?;
+
+    // The deposit's sole output is a positive-value OP_DRIVECHAIN output for the
+    // active slot: it raises the treasury value (so it's an M5, not an M6), but
+    // there is nothing at vout+1 to carry the deposit address.
+    let unsigned_tx = Transaction {
+        version: Version::TWO,
+        lock_time: bitcoin::locktime::absolute::LockTime::ZERO,
+        input: vec![TxIn {
+            previous_output: OutPoint {
+                txid: Txid::from_str(&utxo.txid)?,
+                vout: utxo.vout,
+            },
+            ..TxIn::default()
+        }],
+        output: vec![TxOut {
+            script_pubkey: op_drivechain_script(DummySidechain::SIDECHAIN_NUMBER),
+            value: input_value - M5_TX_FEE,
+        }],
+    };
+
+    let signed_hex = {
+        let json = post_setup
+            .bitcoin_cli
+            .command::<String, _, _, _, _>(
+                [],
+                "signrawtransactionwithwallet",
+                [serialize_hex(&unsigned_tx)],
+            )
+            .run_utf8()
+            .await?;
+        let signed: SignResult = serde_json::from_str(&json)?;
+        anyhow::ensure!(signed.complete, "signrawtransactionwithwallet incomplete");
+        signed.hex
+    };
+
+    // `generateblock` mines a block containing the raw tx, bypassing mempool
+    // standardness (which rejects OP_DRIVECHAIN as non-standard) while still
+    // enforcing consensus rules.
+    let txs_arg = serde_json::to_string(&[signed_hex])?;
+    let json = post_setup
+        .bitcoin_cli
+        .command::<String, _, _, _, _>([], "generateblock", [mining_address, txs_arg])
+        .run_utf8()
+        .await?;
+    let result: GenerateBlockResult = serde_json::from_str(&json)?;
+    Ok(BlockHash::from_str(&result.hash)?)
 }
 
 async fn submit_invalid_block(

--- a/lib/validator/task/error.rs
+++ b/lib/validator/task/error.rs
@@ -245,6 +245,14 @@ pub(in crate::validator) enum HandleM5M6 {
     #[error(transparent)]
     #[fatal(false)]
     M6id(#[from] crate::messages::M6idError),
+    /// BIP 300 M5: a transaction with a treasury UTXO output and no address
+    /// OP_RETURN output immediately after it must be considered invalid.
+    #[error(
+        "M5 deposit for sidechain {} has no address OP_RETURN output",
+        .sidechain_number.0
+    )]
+    #[fatal(false)]
+    MissingDepositAddress { sidechain_number: SidechainNumber },
     #[error("Multiple OP_DRIVECHAIN outputs for sidechain {0}")]
     #[fatal(false)]
     MultipleOpDrivechainOutputs(SidechainNumber),

--- a/lib/validator/task/mod.rs
+++ b/lib/validator/task/mod.rs
@@ -799,13 +799,17 @@ impl BlockHandler<'_> {
                 }
                 // M5
                 Ordering::Greater => {
-                    let address = if let Some(address_output) =
+                    // BIP 300 requires the address OP_RETURN output immediately
+                    // after the treasury UTXO; a deposit without it is invalid.
+                    let Some(address_output) =
                         transaction.output.get(new_ctip.outpoint.vout as usize + 1)
-                    {
+                    else {
+                        return Err(error::HandleM5M6::MissingDepositAddress { sidechain_number });
+                    };
+                    let Some(address) =
                         crate::messages::try_parse_op_return_address(&address_output.script_pubkey)
-                            .unwrap_or_default()
-                    } else {
-                        Vec::new()
+                    else {
+                        return Err(error::HandleM5M6::MissingDepositAddress { sidechain_number });
                     };
                     let sequence_number = dbs
                         .treasury_utxo_count

--- a/lib/validator/task/mod.rs
+++ b/lib/validator/task/mod.rs
@@ -2246,6 +2246,56 @@ mod tests {
     }
 
     #[test]
+    fn handle_m5_m6_rejects_deposit_without_address_output() -> Result<()> {
+        let (_dir, dbs) = create_test_dbs()?;
+        let mut rwtxn = dbs.write_txn().into_diagnostic()?;
+        let sc = SidechainNumber(1);
+        dbs.active_sidechains
+            .put_sidechain(&mut rwtxn, &sc, &test_sidechain(1, 0))
+            .into_diagnostic()?;
+        let old_outpoint = OutPoint {
+            txid: Txid::from_byte_array([0x11; 32]),
+            vout: 0,
+        };
+        let old_value = Amount::from_sat(5_000);
+        dbs.active_sidechains
+            .put_ctip(
+                &mut rwtxn,
+                sc,
+                &Ctip {
+                    outpoint: old_outpoint,
+                    value: old_value,
+                },
+            )
+            .into_diagnostic()?;
+
+        // A deposit that creates the treasury UTXO but omits the required
+        // address OP_RETURN output. Per BIP300 it must be rejected, not
+        // accepted with an empty address.
+        let treasury_output =
+            create_m5_deposit_output(sc, old_value, Amount::from_sat(3_000)).unwrap();
+        let tx = Transaction {
+            version: bitcoin::transaction::Version::TWO,
+            lock_time: bitcoin::locktime::absolute::LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: old_outpoint,
+                ..TxIn::default()
+            }],
+            output: vec![treasury_output],
+        };
+
+        assert!(
+            matches!(
+                test_handler(&dbs).handle_m5_m6(&rwtxn, Cow::Borrowed(&tx)),
+                Err(error::HandleM5M6::MissingDepositAddress { sidechain_number })
+                    if sidechain_number == sc
+            ),
+            "M5 deposit without an address OP_RETURN output must be rejected"
+        );
+        Ok(())
+    }
+
+    #[test]
     fn handle_m5_m6_old_ctip_unspent_is_not_fatal() -> Result<()> {
         let (_dir, dbs) = create_test_dbs()?;
         let mut rwtxn = dbs.write_txn().into_diagnostic()?;


### PR DESCRIPTION
BIP300 requires the address `OP_RETURN` output immediately after the treasury UTXO in an M5 deposit, and states:

> If an M5 transaction has a UTXO treasury output and no address OP_RETURN output, then it MUST be considered invalid by the BIP300 enforcer software.

https://github.com/LayerTwo-Labs/bip300_bip301_specifications/blob/master/bip300.md#L581-L582

`handle_m5_m6` instead derives the address defensively and never rejects:

```rust
let address = if let Some(address_output) =
    transaction.output.get(new_ctip.outpoint.vout as usize + 1)
{
    crate::messages::try_parse_op_return_address(&address_output.script_pubkey)
        .unwrap_or_default()
} else {
    Vec::new()
};
```

When the output after the treasury is absent, or is not a valid `OP_RETURN <push>` (e.g. a P2WPKH payment, or an `OP_RETURN` with multiple pushes), `try_parse_op_return_address` returns `None`, `.unwrap_or_default()` yields an empty address, and the deposit is still accepted and the CTIP advanced. A miner can mine such a transaction; a spec-compliant enforcer rejects it, so the two diverge on block validity.

## Fix

Reject the deposit with a new non-fatal `HandleM5M6::MissingDepositAddress` error when the address output is absent or does not parse as an `OP_RETURN` push (an `OP_RETURN` with an empty push is still accepted, since address contents are up to the sidechain). Includes a regression test; the existing valid-deposit tests still pass.

