### PR TITLE
Use treasury vout 0 for chained CTIP in generate_suffix_txs

### DIFF
--- a/lib/types.rs
+++ b/lib/types.rs
@@ -1198,6 +1198,39 @@ mod tests {
         );
     }
 
+    /// `into_m6` overwrites the first output with the new treasury (CTIP), so
+    /// the CTIP lives at output index 0 — the validator enforces the same via
+    /// `InvalidM6::TreasuryOutputIndex`. The wallet's chained-CTIP logic in
+    /// `generate_suffix_txs` must therefore reference vout 0, not the last
+    /// output (a payout).
+    #[test]
+    fn into_m6_places_treasury_output_at_index_0() {
+        use bitcoin::{Amount, OutPoint, Txid, hashes::Hash as _};
+        let blinded = BlindedM6::try_from(Cow::Owned(blinded_m6_tx())).unwrap();
+        let sidechain_number = SidechainNumber(1);
+        let m6 = blinded
+            .into_m6(
+                sidechain_number,
+                OutPoint {
+                    txid: Txid::all_zeros(),
+                    vout: 0,
+                },
+                Amount::from_sat(100_000),
+            )
+            .unwrap();
+        let treasury_spk = super::op_drivechain_script(sidechain_number);
+        assert_eq!(
+            m6.output[0].script_pubkey, treasury_spk,
+            "into_m6 must place the new treasury (CTIP) at output index 0"
+        );
+        assert!(m6.output.len() > 1);
+        assert_ne!(
+            m6.output[m6.output.len() - 1].script_pubkey,
+            treasury_spk,
+            "last output is a payout; a chained CTIP must use vout 0, not len-1"
+        );
+    }
+
     /// Regression: an empty description (a valid M1 carries an arbitrary,
     /// possibly empty, `rest`-encoded description) must return an error, not
     /// panic indexing `input[0]` while building the version error.

--- a/lib/wallet/mine.rs
+++ b/lib/wallet/mine.rs
@@ -252,7 +252,9 @@ impl Wallet {
                     ctip = Some(Ctip {
                         outpoint: OutPoint {
                             txid: m6.compute_txid(),
-                            vout: (m6.output.len() - 1) as u32,
+                            // into_m6 places the new treasury output at index 0,
+                            // and the validator requires the CTIP at vout 0.
+                            vout: 0,
                         },
                         value: new_value,
                     });


### PR DESCRIPTION
When a sidechain has more than one approved withdrawal bundle in a block, `generate_suffix_txs` chains the next M6's input to the previous M6's newly-created treasury (CTIP), but records that outpoint at the wrong vout:

```rust
let m6 = blinded_m6.into_m6(sidechain_id, outpoint, value)?;
ctip = Some(Ctip {
    outpoint: OutPoint {
        txid: m6.compute_txid(),
        vout: (m6.output.len() - 1) as u32,
    },
    value: new_value,
});
```

`into_m6` overwrites `output[0]` with the new treasury output, so the CTIP is at index 0, not `len - 1`. A valid blinded M6 has a non-zero payout, so `output.len() >= 2` and `len - 1 >= 1` always points at a payout output. The validator also enforces the CTIP at vout 0 (`InvalidM6::TreasuryOutputIndex`). The second M6 therefore spends a non-treasury output, so the block the wallet produces is self-rejected and block production fails.

## Fix

Use `vout: 0` for the chained CTIP outpoint. Adds a test asserting `into_m6` places the treasury output at index 0 (the invariant the fix relies on and the one the validator enforces).
