### PR TITLE
Reject non-minimal pushes when parsing coinbase messages

### DIFF
--- a/lib/messages.rs
+++ b/lib/messages.rs
@@ -8,7 +8,7 @@ use bitcoin::{
         OP_TRUE,
         all::{OP_PUSHBYTES_1, OP_RETURN},
     },
-    script::{Instruction, Instructions, PushBytesBuf},
+    script::{Instruction, PushBytesBuf},
 };
 use byteorder::{ByteOrder, LittleEndian};
 use miette::Diagnostic;
@@ -307,10 +307,10 @@ impl CoinbaseMessage {
     pub fn parse(script: &Script) -> IResult<&[u8], Self> {
         fn instruction_failure<'a>(
             err_msg: Option<&'static str>,
-            instructions: Instructions<'a>,
+            script: &'a Script,
         ) -> nom::Err<nom::error::Error<&'a [u8]>> {
             use nom::error::ContextError as _;
-            let input = instructions.as_script().as_bytes();
+            let input = script.as_bytes();
             let err = nom::error::Error {
                 input,
                 code: nom::error::ErrorKind::Fail,
@@ -321,17 +321,22 @@ impl CoinbaseMessage {
             };
             nom::Err::Failure(err)
         }
-        let mut instructions = script.instructions();
+        // Use minimal-push decoding so a coinbase message encoded with a
+        // non-minimal push (e.g. OP_PUSHDATA1 for a short payload) is rejected
+        // rather than parsed identically to its canonical form. The messages
+        // are consensus data, so accepting a second encoding of the same
+        // message is a malleability/divergence risk.
+        let mut instructions = script.instructions_minimal();
         let Some(Ok(Instruction::Op(OP_RETURN))) = instructions.next() else {
             return Err(instruction_failure(
                 Some("expected OP_RETURN instruction"),
-                instructions,
+                script,
             ));
         };
         let Some(Ok(Instruction::PushBytes(data))) = instructions.next() else {
             return Err(instruction_failure(
                 Some("expected PushBytes instruction"),
-                instructions,
+                script,
             ));
         };
         // BIP 300/301 coinbase messages are exactly `OP_RETURN <push>`. M2/M3
@@ -341,7 +346,7 @@ impl CoinbaseMessage {
         if instructions.next().is_some() {
             return Err(instruction_failure(
                 Some("unexpected trailing instructions after message"),
-                instructions,
+                script,
             ));
         }
         let input = data.as_bytes();

--- a/lib/messages.rs
+++ b/lib/messages.rs
@@ -1023,6 +1023,34 @@ mod tests {
     }
 
     #[test]
+    fn coinbase_parse_rejects_non_minimal_push() {
+        // A valid M2 message, encoded canonically (the encoder uses a minimal
+        // push), parses.
+        let minimal = ScriptBuf::try_from(M2AckSidechain {
+            sidechain_number: SidechainNumber(0),
+            description_hash: sha256d::Hash::from_byte_array([0x11; 32]),
+        })
+        .unwrap();
+        assert!(CoinbaseMessage::parse(&minimal).is_ok());
+
+        // Re-wrap the same payload with a non-minimal OP_PUSHDATA1 push. The
+        // minimal script is `OP_RETURN <OP_PUSHBYTES_n> <data>`, so the data
+        // follows the two leading bytes.
+        let data = &minimal.as_bytes()[2..];
+        let mut bytes = vec![
+            OP_RETURN.to_u8(),
+            bitcoin::opcodes::all::OP_PUSHDATA1.to_u8(),
+            data.len() as u8,
+        ];
+        bytes.extend_from_slice(data);
+        let non_minimal = ScriptBuf::from_bytes(bytes);
+        assert!(
+            CoinbaseMessage::parse(&non_minimal).is_err(),
+            "non-minimal OP_PUSHDATA1 encoding of a coinbase message must be rejected"
+        );
+    }
+
+    #[test]
     fn test_roundtrip() {
         let declaration = SidechainDeclaration {
             title: "title".to_owned(),


### PR DESCRIPTION
`CoinbaseMessage::parse` decoded the OP_RETURN payload with `Script::instructions()`, which does **not** enforce minimal pushes. As a result a coinbase BIP300/301 message (M1–M4, M7) encoded with a non-minimal push opcode e.g. `OP_PUSHDATA1 <len> <data>` for a payload that fits in a direct `OP_PUSHBYTES_n` parsed identically to its canonical form:

```rust
let mut instructions = script.instructions();
...
let Some(Ok(Instruction::PushBytes(data))) = instructions.next() else { ... };
```

Accepting a second, non-canonical encoding of the same message is a malleability / divergence risk.

## Fix

Decode with `Script::instructions_minimal()`, which rejects non-minimal pushes, so each coinbase message has a single canonical encoding. The canonically-encoded messages the wallet produces (`ScriptBuf::try_from(..)` uses minimal pushes) are unaffected; all existing parse/round-trip tests pass.

A regression test encodes a valid M2 message, confirms it parses, then re-wraps the same payload with a non-minimal `OP_PUSHDATA1` and asserts `CoinbaseMessage::parse` rejects it.
