### PR TITLE
Reject deposit value that overflows the treasury total

### DIFF
--- a/lib/messages.rs
+++ b/lib/messages.rs
@@ -1245,6 +1245,18 @@ mod tests {
         Ok(())
     }
 
+    #[test]
+    fn create_m5_deposit_output_rejects_overflow() {
+        // A deposit value that overflows the treasury total must error rather
+        // than panic on the addition.
+        let result = create_m5_deposit_output(
+            SidechainNumber(0),
+            Amount::from_sat(u64::MAX),
+            Amount::from_sat(1),
+        );
+        assert!(matches!(result, Err(AmountOverflowError)));
+    }
+
     // ── compute_m6id ──
 
     /// Build a minimal M6-shaped transaction: 1 input + OP_DRIVECHAIN treasury

--- a/lib/messages.rs
+++ b/lib/messages.rs
@@ -25,8 +25,8 @@ use crate::{
     errors::ErrorChain,
     proto::{StatusBuilder, ToStatus},
     types::{
-        BmmCommitment, M6id, OP_DRIVECHAIN, SidechainDeclaration, SidechainDescription,
-        SidechainNumber, SidechainProposal, SidechainProposalId,
+        AmountOverflowError, BmmCommitment, M6id, OP_DRIVECHAIN, SidechainDeclaration,
+        SidechainDescription, SidechainNumber, SidechainProposal, SidechainProposalId,
     },
 };
 
@@ -827,18 +827,22 @@ pub fn create_m5_deposit_output(
     sidechain_number: SidechainNumber,
     old_ctip_amount: Amount,
     deposit_amount: Amount,
-) -> TxOut {
+) -> Result<TxOut, AmountOverflowError> {
     let script_pubkey = ScriptBuf::from_bytes(vec![
         OP_DRIVECHAIN.to_u8(),
         OP_PUSHBYTES_1.to_u8(),
         sidechain_number.into(),
         OP_TRUE.to_u8(),
     ]);
-    TxOut {
+    // All deposits increase the amount locked in the OP_DRIVECHAIN output; a
+    // checked add rejects an out-of-range deposit value instead of panicking.
+    let value = old_ctip_amount
+        .checked_add(deposit_amount)
+        .ok_or(AmountOverflowError)?;
+    Ok(TxOut {
         script_pubkey,
-        // All deposits INCREASE the amount locked in the OP_DRIVECHAIN output.
-        value: old_ctip_amount + deposit_amount,
-    }
+        value,
+    })
 }
 
 pub fn create_op_return_output<Msg>(
@@ -1226,7 +1230,8 @@ mod tests {
     #[test]
     fn create_m5_deposit_output_value_and_script() -> miette::Result<()> {
         let sc = SidechainNumber(3);
-        let output = create_m5_deposit_output(sc, Amount::from_sat(5_000), Amount::from_sat(1_000));
+        let output =
+            create_m5_deposit_output(sc, Amount::from_sat(5_000), Amount::from_sat(1_000)).unwrap();
         assert_eq!(output.value, Amount::from_sat(6_000));
         let bytes = output.script_pubkey.to_bytes();
         let (_, parsed_sc) =
@@ -1234,7 +1239,8 @@ mod tests {
         assert_eq!(parsed_sc, sc);
 
         let output =
-            create_m5_deposit_output(SidechainNumber(0), Amount::ZERO, Amount::from_sat(100));
+            create_m5_deposit_output(SidechainNumber(0), Amount::ZERO, Amount::from_sat(100))
+                .unwrap();
         assert_eq!(output.value, Amount::from_sat(100));
         Ok(())
     }

--- a/lib/validator/task/mod.rs
+++ b/lib/validator/task/mod.rs
@@ -1877,7 +1877,7 @@ mod tests {
         deposit_amount: Amount,
     ) -> Transaction {
         let treasury_output =
-            create_m5_deposit_output(sidechain_number, old_ctip_value, deposit_amount);
+            create_m5_deposit_output(sidechain_number, old_ctip_value, deposit_amount).unwrap();
         let address_output = TxOut {
             script_pubkey: ScriptBuf::new_op_return(
                 bitcoin::script::PushBytesBuf::try_from(b"sidechain_address".to_vec()).unwrap(),
@@ -1911,7 +1911,7 @@ mod tests {
                 previous_output: input_outpoint,
                 ..TxIn::default()
             }],
-            output: vec![create_m5_deposit_output(slot, Amount::ZERO, value)],
+            output: vec![create_m5_deposit_output(slot, Amount::ZERO, value).unwrap()],
         }
     }
 

--- a/lib/wallet/error.rs
+++ b/lib/wallet/error.rs
@@ -713,6 +713,8 @@ pub enum CreateDeposit {
     #[error("failed to convert sidechain address to PushBytesBuf")]
     ConvertSidechainAddress(#[source] bitcoin::script::PushBytesError),
     #[error(transparent)]
+    OutputAmountOverflow(#[from] crate::types::AmountOverflowError),
+    #[error(transparent)]
     NotUnlocked(#[from] NotUnlocked),
     #[error(transparent)]
     Persistence(#[from] Persistence),
@@ -733,6 +735,7 @@ impl ToStatus for CreateDeposit {
             | Self::BroadcastNonstandardTx { .. }
             | Self::BroadcastUnsuccessful { .. }
             | Self::ConvertSidechainAddress(_) => StatusBuilder::new(self),
+            Self::OutputAmountOverflow(err) => err.builder(),
             Self::NotUnlocked(err) => err.builder(),
             Self::Persistence(err) => StatusBuilder::new(err),
             Self::Psbt(err) => err.builder(),

--- a/lib/wallet/mod.rs
+++ b/lib/wallet/mod.rs
@@ -1109,16 +1109,16 @@ impl Wallet {
         sidechain_number: SidechainNumber,
         sidechain_ctip_amount: Amount,
         value: Amount,
-    ) -> bdk_wallet::bitcoin::TxOut {
+    ) -> Result<bdk_wallet::bitcoin::TxOut, crate::types::AmountOverflowError> {
         let deposit_txout =
-            messages::create_m5_deposit_output(sidechain_number, sidechain_ctip_amount, value);
+            messages::create_m5_deposit_output(sidechain_number, sidechain_ctip_amount, value)?;
 
-        bdk_wallet::bitcoin::TxOut {
+        Ok(bdk_wallet::bitcoin::TxOut {
             script_pubkey: bdk_wallet::bitcoin::ScriptBuf::from_bytes(
                 deposit_txout.script_pubkey.to_bytes(),
             ),
             value: deposit_txout.value,
-        }
+        })
     }
 
     fn create_op_return_output<Msg>(
@@ -1400,7 +1400,7 @@ impl Wallet {
             sidechain_number,
             sidechain_ctip_amount,
             value,
-        );
+        )?;
         tracing::debug!(
             value = %op_drivechain_output.value,
             spk = %op_drivechain_output.script_pubkey.to_asm_string(),


### PR DESCRIPTION
`create_m5_deposit_output` computed the new treasury value with an unchecked add:

```rust
value: old_ctip_amount + deposit_amount,
```

`bitcoin::Amount`'s `+` is `checked_add(..).expect(..)`, so this panics when the sum overflows. `deposit_amount` comes from the gRPC `create_deposit_transaction` `value_sats` field, which is only checked for non-zero `Amount::from_sat` does not bound it, so a caller passing a large `value_sats` (such that `old_ctip + value` exceeds the max) crashes the request.

## Fix

Use a checked add and return `AmountOverflowError`, propagated through `create_deposit_op_drivechain_output` - `create_deposit` (new `CreateDeposit::OutputAmountOverflow` variant), so an out-of-range deposit is rejected with an error instead of panicking. Adds a regression test.
