### PR TITLE
Add `prek` config

### DIFF
--- a/prek.toml
+++ b/prek.toml
@@ -1,0 +1,40 @@
+# Pre-commit hooks, run via prek (https://prek.j178.dev)
+[[repos]]
+repo = "local"
+
+[[repos.hooks]]
+id = "cargo-fmt"
+name = "cargo +nightly fmt"
+# nightly: rustfmt.toml uses nightly-only import-sorting options
+entry = "cargo +nightly fmt --all --"
+language = "system"
+types = ["rust"]
+pass_filenames = false
+
+[[repos.hooks]]
+id = "prettier"
+name = "prettier"
+entry = "bunx prettier --write"
+language = "system"
+# prettier respects .prettierrc and .prettierignore
+types_or = ["markdown", "yaml", "json", "css", "html", "javascript", "ts"]
+
+[[repos.hooks]]
+id = "cargo-check"
+name = "cargo check"
+# Fast-fail on plain compile errors before the heavier clippy pass.
+entry = "cargo check --all-features --all-targets"
+language = "system"
+types = ["rust"]
+pass_filenames = false
+
+[[repos.hooks]]
+id = "clippy"
+name = "cargo clippy"
+# Mirrors `just clippy` exactly (stable --fix pass + nightly unqualified-imports
+# pass), so the lint config lives in one place. --fix may rewrite files; prek
+# then fails the commit so you can review and re-stage, same as prettier --write.
+entry = "just clippy"
+language = "system"
+types = ["rust"]
+pass_filenames = false


### PR DESCRIPTION
`prek` is a snappy implementation of git pre-commit hooks that make it easy to avoid common mistakes prior to pushing.