### PR TITLE
[DoS] Reject oversized block file entries instead of allocating unbounded memory

### DIFF
--- a/lib/validator/parse_block_files.rs
+++ b/lib/validator/parse_block_files.rs
@@ -31,6 +31,11 @@ const TESTNET_MAGIC: [u8; 4] = [0x0B, 0x11, 0x09, 0x07];
 const SIGNET_MAGIC: [u8; 4] = [0x0A, 0x03, 0xCF, 0x40];
 const REGTEST_MAGIC: [u8; 4] = [0xFA, 0xBF, 0xB5, 0xDA];
 
+/// Consensus maximum serialized block size (Bitcoin Core's
+/// `MAX_BLOCK_SERIALIZED_SIZE`). A block file entry declaring a larger size is
+/// malformed.
+const MAX_BLOCK_SERIALIZED_SIZE: usize = 4_000_000;
+
 #[derive(Debug, Diagnostic, Error)]
 #[error("error parsing block number {index} in file {file_path}")]
 pub struct ParseAllBlocksError {
@@ -243,6 +248,13 @@ impl BlockFileParser {
 
         let size = u32::consensus_decode(&mut self.reader)
             .map_err(ParseBlockFileError::UintDecode)? as usize;
+
+        // Reject an oversized entry before allocating. Without this bound the
+        // `size` prefix drives an unbounded `vec![0; size - 80]` (up to ~4 GiB),
+        // exhausting memory on a corrupt or crafted block file.
+        if size > MAX_BLOCK_SERIALIZED_SIZE {
+            return Err(ParseBlockFileError::BlockSizeTooLarge { size: size as u32 });
+        }
 
         // Read the block header
         let header = Header::consensus_decode(&mut self.reader)

--- a/lib/validator/parse_block_files.rs
+++ b/lib/validator/parse_block_files.rs
@@ -846,6 +846,27 @@ mod tests {
         assert!(parser.next_block().is_err());
     }
 
+    /// A block whose declared size exceeds the consensus maximum must be
+    /// rejected before allocating, not exhaust memory via an unbounded
+    /// `vec![0; size - 80]`. A corrupt or crafted blk*.dat triggers this.
+    #[test]
+    fn next_block_rejects_oversized_block_without_allocating() {
+        use std::io::Write as _;
+        let mut bytes = REGTEST_MAGIC.to_vec();
+        bytes.extend_from_slice(&u32::MAX.to_le_bytes()); // size ~4 GiB, above the max
+        bytes.extend_from_slice(&[0u8; 80]); // a well-formed 80 byte header
+        let path = std::env::temp_dir().join("bip300_oversized_blk00000.dat");
+        std::fs::File::create(&path)
+            .unwrap()
+            .write_all(&bytes)
+            .unwrap();
+        let mut parser = BlockFileParser::new(None, path, Network::Regtest).unwrap();
+        assert!(matches!(
+            parser.next_block(),
+            Err(ParseBlockFileError::BlockSizeTooLarge { size }) if size == u32::MAX
+        ));
+    }
+
     #[test]
     fn test_parse_real_file_with_xor_key() {
         let path =


### PR DESCRIPTION
`BlockFileParser::next_block` reads a block entry's `size` as a `u32` and then allocates the transaction buffer from it with **no upper bound**:

```rust
let size = u32::consensus_decode(&mut self.reader)? as usize;   // no maximum
let header = Header::consensus_decode(&mut self.reader)?;
let txdata_len = size.checked_sub(80)                           // underflow guarded (#403)
    .ok_or(ParseBlockFileError::BlockSizeTooSmall { .. })?;
let mut txdata = vec![0; txdata_len];                           // up to ~4 GiB
```

The undersize case is already handled (`BlockSizeTooSmall`, #403), but the oversize case is not: a `size` near `u32::MAX` drives `vec![0; size - 80]` up to ~4 GiB. The intended guard, `ParseBlockFileError::BlockSizeTooLarge`, is defined but never constructed so it is dead code.

This path feeds the blocks-directory fast-sync (`--main-blocks-dir`). A corrupt or crafted `blk*.dat` entry just the 8-byte magic+size prefix plus an 80-byte header exhausts memory and takes the enforcer down (mining halt). Same reachability class as the undersize fix in #403.

## Fuzzing logs

A libFuzzer harness over `BlockFileParser::next_block` with libFuzzer's default memory limit as the oracle. It found a crashing input in <9k executions:

```
INFO: Running .../block_file_parse -rss_limit_mb=2048 -malloc_limit_mb=2048
#8717  NEW    cov: 148 ft: 205 corp: 13/499b ...
==1944570== ERROR: libFuzzer: out-of-memory (malloc(4106404466))
SUMMARY: libFuzzer: out-of-memory
Test unit written to .../artifacts/block_file_parse/oom-ef035ecf...
```

The 85-byte reproducer, after the 4-byte regtest magic, carries a little-endian `size = 0xF4C2C2C2` (4,106,404,546), so `txdata_len = size - 80 = 4,106,404,466` → `malloc(4106404466)` (~4.1 GiB). Any `size` above the consensus maximum triggers it.

## Fix

Bound `size` to the consensus maximum serialized block size before allocating, wiring the existing `BlockSizeTooLarge` variant:

```rust
if size > MAX_BLOCK_SERIALIZED_SIZE {   // 4_000_000
    return Err(ParseBlockFileError::BlockSizeTooLarge { size: size as u32 });
}
```