### PR TITLE
Avoid underflow in block index data position for corrupt entries

### DIFF
--- a/lib/validator/parse_block_files.rs
+++ b/lib/validator/parse_block_files.rs
@@ -607,7 +607,10 @@ impl CDiskBlockIndex {
     pub fn adjusted_data_pos(&self) -> Option<u64> {
         // Magic bytes + size? Found by trial and error
         const ADJUST_BY: u64 = 8;
-        self.data_pos.map(|pos| pos - ADJUST_BY)
+        // `checked_sub` so a corrupt index entry with `data_pos < ADJUST_BY`
+        // yields `None` (handled as a missing data position) instead of
+        // underflowing.
+        self.data_pos.and_then(|pos| pos.checked_sub(ADJUST_BY))
     }
 
     /// Deserialize from byte slice

--- a/lib/validator/parse_block_files.rs
+++ b/lib/validator/parse_block_files.rs
@@ -870,6 +870,36 @@ mod tests {
         ));
     }
 
+    /// A corrupt `blocks/index` entry with a `data_pos` below the 8-byte file
+    /// offset adjustment must yield `None` (a missing data position), not
+    /// underflow. Reachable via `fetch_block_index` on the fast-sync path.
+    #[test]
+    fn adjusted_data_pos_does_not_underflow() {
+        let with_data_pos = |data_pos| CDiskBlockIndex {
+            version: 0,
+            height: 0,
+            status: BlockStatus::new(0),
+            tx_count: 0,
+            file_number: None,
+            data_pos,
+            undo_pos: None,
+            block_version: 0,
+            prev_block_hash: BlockHash::from_byte_array([0; 32]),
+            merkle_root: BlockHash::from_byte_array([0; 32]),
+            timestamp: 0,
+            difficulty_target: CompactTarget::from_consensus(0),
+            nonce: 0,
+        };
+        // Below the adjustment: None, not an underflow.
+        assert_eq!(with_data_pos(Some(0)).adjusted_data_pos(), None);
+        assert_eq!(with_data_pos(Some(7)).adjusted_data_pos(), None);
+        // At or above the adjustment: the adjusted position.
+        assert_eq!(with_data_pos(Some(8)).adjusted_data_pos(), Some(0));
+        assert_eq!(with_data_pos(Some(80)).adjusted_data_pos(), Some(72));
+        // No data position stays None.
+        assert_eq!(with_data_pos(None).adjusted_data_pos(), None);
+    }
+
     #[test]
     fn test_parse_real_file_with_xor_key() {
         let path =


### PR DESCRIPTION
`CDiskBlockIndex::adjusted_data_pos` computes a block's data position with an unchecked subtraction:

```rust
pub fn adjusted_data_pos(&self) -> Option<u64> {
    const ADJUST_BY: u64 = 8;
    self.data_pos.map(|pos| pos - ADJUST_BY)   // underflows if data_pos < 8
}
```

`data_pos` is read (as a Core VarInt) from a `blocks/index` LevelDB value, and this runs on the `--main-blocks-dir` fast-sync path (`fetch_block_index` → `adjusted_data_pos()` → `set_offset`). A corrupt or crafted index entry with `data_pos < 8` underflows: under overflow-checks (the test suite / CI run in debug) it **panics**; in release it **wraps** to a near-`u64::MAX` offset and returns `Some(bogus)`, which defeats the caller's `.ok_or(MissingDataPos)?` guard → a bad `set_offset` and a failed/skipped block during sync.

Same class as the block-file size underflow fixed in #403.

## Fuzzing logs

A libFuzzer harness over `CDiskBlockIndex::deserialize` + `adjusted_data_pos`, found in ~14k executions:

```
thread panicked at parse_block_files.rs: attempt to subtract with overflow
==12462== ERROR: libFuzzer: deadly signal
```