### PR TITLE
fix: bip300301_enforcer accepts a block with multiple distinct M1 sidechain proposals (BIP300 allows ≤1 M1/block)

### DIFF
--- a/lib/validator/task/error.rs
+++ b/lib/validator/task/error.rs
@@ -383,6 +383,11 @@ pub(in crate::validator) enum ConnectBlock {
     #[error("Multiple blocks BMM'd in sidechain slot {}", .sidechain_number.0)]
     #[fatal(false)]
     MultipleBmmBlocks { sidechain_number: SidechainNumber },
+    #[error(
+        "Block contains multiple M1 (propose sidechain) messages; at most one is permitted per block"
+    )]
+    #[fatal(false)]
+    MultipleM1Proposals,
     #[error("Block has no transactions (missing coinbase)")]
     #[fatal(false)]
     NoCoinbase,

--- a/lib/validator/task/mod.rs
+++ b/lib/validator/task/mod.rs
@@ -1090,6 +1090,14 @@ impl BlockHandler<'_> {
             }
             coinbase_messages.push(message, vout)?;
         }
+        // BIP 300: a block is invalid if "there is already an M1 in this
+        // block". Identical proposals are already rejected as a duplicate M1 by
+        // `CoinbaseMessages::push` above; reject here when the block carries more
+        // than one *distinct* M1 (`Propose Sidechain`), which is forbidden
+        // regardless of sidechain number or description.
+        if m1_sidechain_proposals.len() > 1 {
+            return Err(error::ConnectBlock::MultipleM1Proposals);
+        }
         let mut accepted_bmm_requests = BmmCommitments::new();
         let mut events = Vec::<BlockEvent>::new();
         let mut coinbase_msg_diffs = diff::DiffBuilder::new(rwtxn, dbs, height);
@@ -2639,6 +2647,60 @@ mod tests {
                      not reject the block: {e:#}"
                 )
             })?;
+        Ok(())
+    }
+
+    /// BIP 300 M1: a block is invalid if "there is already an M1 in this
+    /// block". Two *distinct* M1 proposals (different descriptions) hash to
+    /// different `SidechainProposalId`s, so per-proposal dedup alone would
+    /// accept both. `connect_block` must reject a block carrying more than one
+    /// M1, regardless of slot or description.
+    #[test]
+    fn connect_block_rejects_multiple_distinct_m1s() -> Result<()> {
+        let (_dir, dbs) = create_test_dbs()?;
+        let mut rwtxn = dbs.write_txn().into_diagnostic()?;
+        let prev_hash = BlockHash::all_zeros();
+
+        let m1_a: ScriptBuf = M1ProposeSidechain {
+            sidechain_number: SidechainNumber(7),
+            description: SidechainDescription(b"cc-alpha".to_vec()),
+        }
+        .try_into()
+        .into_diagnostic()?;
+        let m1_b: ScriptBuf = M1ProposeSidechain {
+            sidechain_number: SidechainNumber(7),
+            description: SidechainDescription(b"cc-beta".to_vec()),
+        }
+        .try_into()
+        .into_diagnostic()?;
+        let block = build_test_block(
+            prev_hash,
+            TestBlockParts {
+                extra_coinbase_outputs: vec![
+                    TxOut {
+                        script_pubkey: m1_a,
+                        value: Amount::ZERO,
+                    },
+                    TxOut {
+                        script_pubkey: m1_b,
+                        value: Amount::ZERO,
+                    },
+                ],
+                ..Default::default()
+            },
+        );
+
+        dbs.block_hashes
+            .put_headers(&mut rwtxn, &[(block.header, 0)])
+            .into_diagnostic()?;
+
+        let err = test_handler(&dbs)
+            .connect_block(&mut rwtxn, &block)
+            .expect_err("a block carrying two distinct M1 proposals must be rejected");
+        assert!(
+            matches!(err, error::ConnectBlock::MultipleM1Proposals),
+            "expected rejection due to multiple M1 proposals, got: {err:?}"
+        );
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

connect_block now rejects blocks carrying >1 distinct M1 via a new ConnectBlock::MultipleM1Proposals error (reverted the builder-breaking messages.rs push change); added a targeted regression test.

## The bug

bip300301_enforcer accepts a block with multiple distinct M1 sidechain proposals (BIP300 allows ≤1 M1/block)

Severity: Medium. Finding (access-controlled): https://giaki3003.tech/#/findings/20260616-2115-claudeclaw-confirm-openclaw-enforcer-multiple-distinct-m1-accepted

## Stack

Part of a stacked series for `bip300301_enforcer` (fix 1 of 6). First in the stack (based on `master`).