### PR TITLE
fix: Enforcer accepts BMM M7/M8 for inactive sidechain slot

### DIFF
--- a/integration_tests/integration_test.rs
+++ b/integration_tests/integration_test.rs
@@ -896,6 +896,19 @@ pub fn tests(
         },
         crate::test_inactive_drivechain_output::test_inactive_slot_drivechain_output,
     ));
+    // Needs a mempool and the GBT server: the point is that the enforcer's own
+    // block template picks up an inactive-slot BMM request.
+    async_trials.push(new_trial_with_setup(
+        "inactive_slot_bmm_request".to_string(),
+        TestSetupComponents {
+            bin_paths: bin_paths.clone(),
+            network: Network::Regtest,
+            mode: Mode::GetBlockTemplate,
+            file_registry: file_registry.clone(),
+            failure_collector: failure_collector.clone(),
+        },
+        crate::test_inactive_slot_bmm_request::test_inactive_slot_bmm_request,
+    ));
     async_trials.push(new_trial_with_setup(
         "consecutive_deposits".to_string(),
         TestSetupComponents {

--- a/integration_tests/lib.rs
+++ b/integration_tests/lib.rs
@@ -8,6 +8,7 @@ mod test_consecutive_deposits;
 mod test_file_based_block_parser;
 mod test_generate_to_address;
 mod test_inactive_drivechain_output;
+mod test_inactive_slot_bmm_request;
 mod test_invalid_block;
 mod test_peer_bmm_request;
 mod test_seed_migration;

--- a/integration_tests/mine.rs
+++ b/integration_tests/mine.rs
@@ -67,7 +67,7 @@ pub enum MineGbtError {
     Var(#[from] Arc<VarError>),
 }
 
-async fn mine_gbt(post_setup: &mut PostSetup) -> Result<bitcoin::BlockHash, MineGbtError> {
+pub async fn mine_gbt(post_setup: &mut PostSetup) -> Result<bitcoin::BlockHash, MineGbtError> {
     use cusf_enforcer_mempool::server::RpcClient;
     let mut gbt_request = bitcoin_jsonrpsee::client::BlockTemplateRequest::default();
     gbt_request.capabilities.insert("coinbasetxn".to_owned());

--- a/integration_tests/test_inactive_slot_bmm_request.rs
+++ b/integration_tests/test_inactive_slot_bmm_request.rs
@@ -1,0 +1,217 @@
+//! An M8 (BMM request) for an inactive sidechain slot is an ordinary,
+//! standard, fee-paying transaction: `OP_RETURN PUSHBYTES_68 00BF00 <S> <H>
+//! <P>` at vout 0 is nulldata that Bitcoin Core relays and mines. Anyone can
+//! broadcast one naming a slot with no active sidechain.
+//!
+//! The enforcer accepts it into its mempool mirror
+//! (`Validator::validate_tx` passes `accepted_bmm_requests = None`, so slot
+//! activity is never consulted), and the block producer then pairs every M8 in
+//! the template with an M7 BMM accept in the coinbase
+//! (`BlockProducer::finalize_block_template`). So the enforcer's own block
+//! template contains the M8 *and* an M7 for the inactive slot.
+//!
+//! This test asserts the enforcer accepts the block it just produced. It is a
+//! regression test for a consensus rule that rejects a coinbase M7 naming an
+//! inactive slot: with that rule, the enforcer poisons its own template and
+//! `invalidateblock`s its own block, so mining stalls for as long as the M8
+//! sits in the mempool. Dropping the M7 from the coinbase does not help — then
+//! the M8 has no matching commitment and the block is rejected with
+//! `NotAcceptedByMiners` instead.
+
+use std::{str::FromStr as _, time::Duration};
+
+use bip300301_enforcer_lib::{
+    bins::CommandExt as _,
+    messages::M8BmmRequest,
+    types::{BmmCommitment, SidechainNumber},
+};
+use bitcoin::{
+    Amount, BlockHash, OutPoint, Transaction, TxIn, TxOut, Txid, consensus::encode::serialize_hex,
+    hashes::Hash as _, transaction::Version,
+};
+use serde::Deserialize;
+use tokio::time::sleep;
+
+use crate::{
+    block_verdict::{Expect, assert_enforcer_verdict},
+    mine::mine_gbt,
+    setup::PostSetup,
+};
+
+/// No sidechain is ever proposed in this test, so every slot is inactive.
+const INACTIVE_SLOT: SidechainNumber = SidechainNumber(99);
+
+const FUNDING_BLOCKS: u32 = 101;
+
+const TX_FEE: Amount = Amount::from_sat(1_000);
+
+const TIMEOUT: Duration = Duration::from_secs(30);
+
+#[derive(Deserialize)]
+struct Utxo {
+    txid: String,
+    vout: u32,
+    amount: f64,
+}
+
+#[derive(Deserialize)]
+struct SignResult {
+    hex: String,
+    complete: bool,
+}
+
+/// Poll the enforcer's `getblocktemplate` until `txid` is included, so the test
+/// mines a block that is known to contain the BMM request rather than racing
+/// the mempool mirror.
+///
+/// `getblocktemplate` itself must keep working: `finalize_block_template`
+/// dry-run-connects the candidate block, so a consensus rule that rejects the
+/// coinbase it just built surfaces here as an RPC error, and the node cannot
+/// mine at all for as long as the BMM request sits in the mempool.
+async fn wait_for_template_tx(post_setup: &PostSetup, txid: Txid) -> anyhow::Result<()> {
+    use cusf_enforcer_mempool::server::RpcClient as _;
+    let deadline = tokio::time::Instant::now() + TIMEOUT;
+    loop {
+        let mut request = bitcoin_jsonrpsee::client::BlockTemplateRequest::default();
+        request.capabilities.insert("coinbasetxn".to_owned());
+        let template = post_setup
+            .gbt_client
+            .get_block_template(request)
+            .await
+            .map_err(|err| {
+                anyhow::anyhow!(
+                    "the enforcer cannot build a block template while BMM request `{txid}` \
+                     is in the mempool: {err}"
+                )
+            })?;
+        if template.transactions.iter().any(|tx| tx.txid == txid) {
+            return Ok(());
+        }
+        anyhow::ensure!(
+            tokio::time::Instant::now() < deadline,
+            "timed out waiting for BMM request `{txid}` to enter the enforcer's block template"
+        );
+        sleep(Duration::from_millis(250)).await;
+    }
+}
+
+pub async fn test_inactive_slot_bmm_request(mut post_setup: PostSetup) -> anyhow::Result<()> {
+    let mining_address = post_setup.mining_address.to_string();
+
+    // Fund the bitcoind wallet, which stands in for an arbitrary third party
+    // broadcasting the BMM request. These blocks carry no coinbase messages.
+    post_setup
+        .bitcoin_cli
+        .command::<String, _, _, _, _>(
+            [],
+            "generatetoaddress",
+            [FUNDING_BLOCKS.to_string(), mining_address],
+        )
+        .run_utf8()
+        .await?;
+
+    let tip = post_setup
+        .bitcoin_cli
+        .command::<String, _, String, _, _>([], "getbestblockhash", [])
+        .run_utf8()
+        .await?
+        .trim()
+        .parse::<BlockHash>()?;
+    // An M8 is only valid against the current tip, so wait for the enforcer to
+    // validate up to it before broadcasting.
+    let () = assert_enforcer_verdict(&mut post_setup, tip, Expect::Accepted, TIMEOUT).await?;
+
+    let utxos: Vec<Utxo> = {
+        let json = post_setup
+            .bitcoin_cli
+            .command::<String, _, String, _, _>([], "listunspent", [])
+            .run_utf8()
+            .await?;
+        serde_json::from_str(&json)?
+    };
+    let (utxo, input_value) = utxos
+        .into_iter()
+        .find_map(|u| {
+            let amount = Amount::from_btc(u.amount).ok()?;
+            (amount > TX_FEE).then_some((u, amount))
+        })
+        .ok_or_else(|| anyhow::anyhow!("no spendable UTXO in bitcoind wallet"))?;
+
+    let change_address = post_setup
+        .bitcoin_cli
+        .command::<String, _, String, _, _>([], "getnewaddress", [])
+        .run_utf8()
+        .await?;
+    let change_address = bitcoin::Address::from_str(change_address.trim())?
+        .require_network(post_setup.network.into())?;
+
+    // BIP 301 M8: output 0 is `OP_RETURN [tag] <S> <H> <P>`. `S` names a slot
+    // with no active sidechain.
+    let sidechain_block_hash = BmmCommitment(
+        bitcoin::hashes::sha256::Hash::hash(b"inactive slot bmm request").to_byte_array(),
+    );
+    let unsigned_tx = Transaction {
+        version: Version::TWO,
+        lock_time: bitcoin::locktime::absolute::LockTime::ZERO,
+        input: vec![TxIn {
+            previous_output: OutPoint {
+                txid: Txid::from_str(&utxo.txid)?,
+                vout: utxo.vout,
+            },
+            ..TxIn::default()
+        }],
+        output: vec![
+            TxOut {
+                script_pubkey: M8BmmRequest::script_pubkey(
+                    INACTIVE_SLOT,
+                    sidechain_block_hash,
+                    tip,
+                )?,
+                value: Amount::ZERO,
+            },
+            TxOut {
+                script_pubkey: change_address.script_pubkey(),
+                value: input_value - TX_FEE,
+            },
+        ],
+    };
+
+    let signed_hex = {
+        let json = post_setup
+            .bitcoin_cli
+            .command::<String, _, _, _, _>(
+                [],
+                "signrawtransactionwithwallet",
+                [serialize_hex(&unsigned_tx)],
+            )
+            .run_utf8()
+            .await?;
+        let signed: SignResult = serde_json::from_str(&json)?;
+        anyhow::ensure!(signed.complete, "signrawtransactionwithwallet incomplete");
+        signed.hex
+    };
+
+    // The M8 is standard nulldata, so plain relay is enough — no `generateblock`
+    // escape hatch is needed to get it mined.
+    let bmm_request_txid = post_setup
+        .bitcoin_cli
+        .command::<String, _, _, _, _>([], "sendrawtransaction", [signed_hex])
+        .run_utf8()
+        .await?
+        .trim()
+        .parse::<Txid>()?;
+    tracing::info!(
+        %bmm_request_txid,
+        %INACTIVE_SLOT,
+        "broadcast BMM request for an inactive sidechain slot"
+    );
+
+    let () = wait_for_template_tx(&post_setup, bmm_request_txid).await?;
+
+    // Mine the enforcer's own template.
+    let block_hash = mine_gbt(&mut post_setup).await?;
+    tracing::info!(%block_hash, "mined block containing the inactive-slot BMM request");
+
+    // The enforcer must accept the block it just produced.
+    assert_enforcer_verdict(&mut post_setup, block_hash, Expect::Accepted, TIMEOUT).await
+}

--- a/lib/block_producer/coinbase.rs
+++ b/lib/block_producer/coinbase.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, hash_map};
 
 use bitcoin::{Amount, BlockHash, OutPoint, Transaction, TxOut};
 use fallible_iterator::{FallibleIterator as _, IteratorExt as _};
@@ -6,7 +6,10 @@ use fallible_iterator::{FallibleIterator as _, IteratorExt as _};
 use crate::{
     block_producer::{BlockProducer, BundleProposals, error},
     messages::{CoinbaseBuilder, M4AckBundles},
-    types::{AmountUnderflowError, Ctip, SidechainAck, SidechainNumber, SidechainProposal},
+    types::{
+        AmountUnderflowError, Ctip, SidechainAck, SidechainNumber, SidechainProposal,
+        SidechainProposalId,
+    },
 };
 
 impl BlockProducer {
@@ -124,18 +127,59 @@ impl BlockProducer {
         }
 
         // Sidechain proposals that already exist in the chain,
-        // or will already be proposed in coinbase txouts
-        let proposed_sidechains = self
+        // or will already be proposed in coinbase txouts, and their vote
+        // counts AFTER processing M2 messages
+        let mut proposed_sidechains =
+            {
+                let mut proposed_sidechains =
+                    HashMap::<_, _>::from_iter(self.validator().get_sidechains()?.into_iter().map(
+                        |(proposal_id, sidechain)| (proposal_id, sidechain.status.vote_count),
+                    ));
+                for (sidechain_number, description_hash) in coinbase_builder.messages().m2_acks() {
+                    let proposal_id = SidechainProposalId {
+                        sidechain_number,
+                        description_hash,
+                    };
+                    if let Some(vote_count) = proposed_sidechains.get_mut(&proposal_id) {
+                        *vote_count = vote_count.saturating_add(1);
+                    }
+                }
+                proposed_sidechains.extend(
+                    coinbase_builder
+                        .messages()
+                        .m1_sidechain_proposal_ids()
+                        .into_iter()
+                        .map(|proposal_id| (proposal_id, 0)),
+                );
+                proposed_sidechains
+            };
+
+        let unused_sidechain_slot_activation_threshold = self
             .validator()
-            .get_sidechains()?
-            .into_iter()
-            .map(|(sidechain_proposal_id, _)| sidechain_proposal_id)
-            .chain(coinbase_builder.messages().m1_sidechain_proposal_ids())
-            .collect::<HashSet<_>>();
+            .network_params()
+            .thresholds
+            .unused_sidechain_slot_activation_threshold;
+
+        // Sidechain slots that are active or will be after applying
+        // M2 (ACK Proposal) messages
+        let mut active_sidechain_slots: HashSet<_> = proposed_sidechains
+            .iter()
+            .filter_map(|(proposal_id, vote_count)| {
+                if *vote_count >= unused_sidechain_slot_activation_threshold {
+                    Some(proposal_id.sidechain_number)
+                } else {
+                    None
+                }
+            })
+            .collect();
 
         for sidechain_proposal in sidechain_proposals {
-            if !proposed_sidechains.contains(&sidechain_proposal.compute_id()) {
-                coinbase_builder.propose_sidechain(sidechain_proposal)?;
+            match proposed_sidechains.entry(sidechain_proposal.compute_id()) {
+                hash_map::Entry::Occupied(_) => (),
+                hash_map::Entry::Vacant(entry) => {
+                    coinbase_builder.propose_sidechain(sidechain_proposal)?;
+                    entry.insert(0);
+                }
             }
         }
 
@@ -195,6 +239,16 @@ impl BlockProducer {
                 sidechain_ack.sidechain_number,
                 sidechain_ack.description_hash,
             )?;
+            let proposal_id = SidechainProposalId {
+                sidechain_number: sidechain_ack.sidechain_number,
+                description_hash: sidechain_ack.description_hash,
+            };
+            if let Some(vote_count) = proposed_sidechains.get_mut(&proposal_id) {
+                *vote_count = vote_count.saturating_add(1);
+                if *vote_count >= unused_sidechain_slot_activation_threshold {
+                    active_sidechain_slots.insert(proposal_id.sidechain_number);
+                }
+            }
         }
 
         let bmm_hashes = self.db().get_bmm_requests(&mainchain_tip).await?;
@@ -203,9 +257,11 @@ impl BlockProducer {
                 .messages()
                 .m7_bmm_accept_slot_vout(&sidechain_number)
                 .is_some()
+                || !active_sidechain_slots.contains(&sidechain_number)
             {
                 continue;
             }
+
             tracing::info!(
                 "Adding BMM accept for SC {} with hash: {}",
                 sidechain_number,

--- a/lib/messages.rs
+++ b/lib/messages.rs
@@ -454,7 +454,8 @@ pub struct CoinbaseMessages {
     /// Coinbase messages, with vout index
     messages: Vec<(CoinbaseMessage, usize)>,
     m1_sidechain_proposal_id_to_index: HashMap<SidechainProposalId, usize>,
-    m2_ack_slot_to_index: HashMap<SidechainNumber, usize>,
+    /// Maps M2 ack slots to description hash and index
+    m2_ack_slot_to_description_hash_index: HashMap<SidechainNumber, (sha256d::Hash, usize)>,
     m4_index: Option<usize>,
     /// Maps M7 slots to commitment and index
     m7_slot_to_commitment_index: HashMap<SidechainNumber, (BmmCommitment, usize)>,
@@ -469,11 +470,26 @@ impl CoinbaseMessages {
     }
 
     pub fn m2_ack_slot_vout(&self, slot: &SidechainNumber) -> Option<usize> {
-        self.m2_ack_slot_to_index.get(slot).copied()
+        self.m2_ack_slot_to_description_hash_index
+            .get(slot)
+            .map(|(_description_hash, idx)| *idx)
     }
 
     pub fn m2_ack_slots(&self) -> HashSet<SidechainNumber> {
-        self.m2_ack_slot_to_index.keys().copied().collect()
+        self.m2_ack_slot_to_description_hash_index
+            .keys()
+            .copied()
+            .collect()
+    }
+
+    /// Returns a map of sidechain numbers to ACK'd description hashes
+    pub fn m2_acks(&self) -> HashMap<SidechainNumber, sha256d::Hash> {
+        self.m2_ack_slot_to_description_hash_index
+            .iter()
+            .map(|(sidechain_number, (description_hash, _idx))| {
+                (*sidechain_number, *description_hash)
+            })
+            .collect()
     }
 
     pub fn m4_exists(&self) -> bool {
@@ -518,13 +534,23 @@ impl CoinbaseMessages {
                 }
             }
             CoinbaseMessage::M2AckSidechain(m2) => {
-                match self.m2_ack_slot_to_index.entry(m2.sidechain_number) {
-                    hash_map::Entry::Occupied(entry) => Err(CoinbaseMessagesError::DuplicateM2 {
-                        index: *entry.get(),
-                        slot: m2.sidechain_number,
-                    }),
+                let M2AckSidechain {
+                    sidechain_number,
+                    description_hash,
+                } = m2;
+                match self
+                    .m2_ack_slot_to_description_hash_index
+                    .entry(*sidechain_number)
+                {
+                    hash_map::Entry::Occupied(entry) => {
+                        let (_description_hash, index) = entry.get();
+                        Err(CoinbaseMessagesError::DuplicateM2 {
+                            index: *index,
+                            slot: *sidechain_number,
+                        })
+                    }
                     hash_map::Entry::Vacant(entry) => {
-                        entry.insert(vout);
+                        entry.insert((*description_hash, vout));
                         self.messages.push((msg, vout));
                         Ok(())
                     }

--- a/lib/validator/task/error.rs
+++ b/lib/validator/task/error.rs
@@ -356,7 +356,7 @@ pub(in crate::validator) enum ConnectBlock {
         tip: bitcoin::BlockHash,
         tip_height: u32,
     },
-    #[error("BMM commitment for sidechain slot {} which is inactive", .sidechain_number.0)]
+    #[error("BMM commitment for inactive sidechain slot {sidechain_number}")]
     #[fatal(false)]
     BmmAcceptInactiveSidechain { sidechain_number: SidechainNumber },
     #[error(transparent)]

--- a/lib/validator/task/error.rs
+++ b/lib/validator/task/error.rs
@@ -356,6 +356,9 @@ pub(in crate::validator) enum ConnectBlock {
         tip: bitcoin::BlockHash,
         tip_height: u32,
     },
+    #[error("BMM commitment for sidechain slot {} which is inactive", .sidechain_number.0)]
+    #[fatal(false)]
+    BmmAcceptInactiveSidechain { sidechain_number: SidechainNumber },
     #[error(transparent)]
     #[fatal(false)]
     CoinbaseMessages(#[from] CoinbaseMessagesError),

--- a/lib/validator/task/mod.rs
+++ b/lib/validator/task/mod.rs
@@ -952,6 +952,19 @@ impl BlockHandler<'_> {
                 sidechain_number,
                 sidechain_block_hash,
             }) => {
+                // A BMM commitment only makes sense for an active sidechain slot.
+                // Mirror the M3 (propose bundle) guard and reject a block that
+                // BMMs a slot with no active sidechain.
+                if !self
+                    .dbs
+                    .active_sidechains
+                    .sidechain()
+                    .contains_key(rotxn, &sidechain_number)?
+                {
+                    return Err(error::ConnectBlock::BmmAcceptInactiveSidechain {
+                        sidechain_number,
+                    });
+                }
                 if accepted_bmm_requests.contains_key(&sidechain_number) {
                     return Err(error::ConnectBlock::MultipleBmmBlocks { sidechain_number });
                 }
@@ -2669,6 +2682,54 @@ mod tests {
         test_handler(&dbs)
             .connect_block(&mut rwtxn, &block)
             .into_diagnostic()?;
+        Ok(())
+    }
+
+    /// A BMM commitment (M7 in the coinbase, paired with a matching M8) only
+    /// makes sense for an active sidechain slot. Mirroring the M3 (propose
+    /// bundle) guard, `connect_block` must reject a block that BMMs an inactive
+    /// slot instead of silently recording the commitment.
+    #[test]
+    fn connect_block_rejects_m7_m8_for_inactive_sidechain_slot() -> Result<()> {
+        let (_dir, dbs) = create_test_dbs()?;
+        let mut rwtxn = dbs.write_txn().into_diagnostic()?;
+        let prev_hash = BlockHash::all_zeros();
+        let inactive_slot = SidechainNumber(99);
+
+        let m7_script: ScriptBuf = M7BmmAccept {
+            sidechain_number: inactive_slot,
+            sidechain_block_hash: BmmCommitment([0x42; 32]),
+        }
+        .try_into()
+        .into_diagnostic()?;
+        let m8_tx = build_m8_tx(inactive_slot, [0x42; 32], prev_hash);
+        let block = build_test_block(
+            prev_hash,
+            TestBlockParts {
+                extra_coinbase_outputs: vec![TxOut {
+                    script_pubkey: m7_script,
+                    value: Amount::ZERO,
+                }],
+                extra_txs: vec![m8_tx],
+            },
+        );
+
+        dbs.block_hashes
+            .put_headers(&mut rwtxn, &[(block.header, 0)])
+            .into_diagnostic()?;
+
+        let err = test_handler(&dbs)
+            .connect_block(&mut rwtxn, &block)
+            .expect_err("a block BMMing an inactive sidechain slot must be rejected");
+        assert!(
+            matches!(
+                err,
+                error::ConnectBlock::BmmAcceptInactiveSidechain {
+                    sidechain_number
+                } if sidechain_number == inactive_slot
+            ),
+            "expected rejection due to inactive-slot BMM, got: {err:?}"
+        );
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

Added an active-sidechain guard to the M7 (BMM accept) coinbase-message arm plus a new non-fatal `ConnectBlock::BmmAcceptInactiveSidechain` error and a regression test, so blocks BMMing an inactive sidechain slot are now rejected instead of silently accepted.

## The bug

Enforcer accepts BMM M7/M8 for inactive sidechain slot

Severity: Low. Finding (access-controlled): https://giaki3003.tech/#/findings/20260619-0619-glmclaw-confirm-kimiclaw-bip300301_enforcer-m7-m8-inactive-sidechain-slot

## Stack

Part of a stacked series for `bip300301_enforcer` (fix 4 of 6). Builds on https://github.com/LayerTwo-Labs/bip300301_enforcer/pull/439 — best merged bottom-up; I'll rebase to keep each diff minimal as earlier ones land.