### PR TITLE
validator: tolerate block files with invalidated blocks

### DIFF
--- a/lib/validator/task/block_files.rs
+++ b/lib/validator/task/block_files.rs
@@ -239,7 +239,13 @@ pub fn sync_from_directory(
             has_found_start = true;
         }
 
-        let expected_block_hash = *missing_blocks.last().expect("missing blocks is empty");
+        let Some(expected_block_hash) = missing_blocks.last().copied() else {
+            // All requested blocks have been synced. Stop parsing: block
+            // files can contain further blocks after the tip block (e.g. a
+            // stale sibling of the tip), which would otherwise land here.
+            tracing::debug!("all missing blocks synced from files; stopping file parser");
+            break;
+        };
 
         let current_block_hash = block.header.block_hash();
 

--- a/prek.toml
+++ b/prek.toml
@@ -18,23 +18,3 @@ entry = "bunx prettier --write"
 language = "system"
 # prettier respects .prettierrc and .prettierignore
 types_or = ["markdown", "yaml", "json", "css", "html", "javascript", "ts"]
-
-[[repos.hooks]]
-id = "cargo-check"
-name = "cargo check"
-# Fast-fail on plain compile errors before the heavier clippy pass.
-entry = "cargo check --all-features --all-targets"
-language = "system"
-types = ["rust"]
-pass_filenames = false
-
-[[repos.hooks]]
-id = "clippy"
-name = "cargo clippy"
-# Mirrors `just clippy` exactly (stable --fix pass + nightly unqualified-imports
-# pass), so the lint config lives in one place. --fix may rewrite files; prek
-# then fails the commit so you can review and re-stage, same as prettier --write.
-entry = "just clippy"
-language = "system"
-types = ["rust"]
-pass_filenames = false


### PR DESCRIPTION
If the chain has been rolled back, the file will contain more blocks than naively expected.