### PR TITLE
Fix successor CTIP output index for chained M6 withdrawals

### DIFF
--- a/lib/block_producer/coinbase.rs
+++ b/lib/block_producer/coinbase.rs
@@ -260,6 +260,18 @@ impl BlockProducer {
             .ok_or(AmountUnderflowError)
     }
 
+    /// Return the CTIP created by a successful M6. BIP300 fixes the treasury
+    /// output at index zero; payout outputs always follow it.
+    fn successor_ctip(m6: &Transaction, value: Amount) -> Ctip {
+        Ctip {
+            outpoint: OutPoint {
+                txid: m6.compute_txid(),
+                vout: 0,
+            },
+            value,
+        }
+    }
+
     /// Generate the M6 suffix txs for a new block. These are fully determined by
     /// the approved bundle and the CTIP: treasury outputs are anyone-can-spend
     /// and consensus-gated, so an M6 is constructed, never signed.
@@ -284,13 +296,7 @@ impl BlockProducer {
                     let new_value =
                         Self::new_treasury_value(value, *blinded_m6.fee(), *blinded_m6.payout())?;
                     let m6 = blinded_m6.into_m6(sidechain_id, outpoint, value)?;
-                    ctip = Some(Ctip {
-                        outpoint: OutPoint {
-                            txid: m6.compute_txid(),
-                            vout: (m6.output.len() - 1) as u32,
-                        },
-                        value: new_value,
-                    });
+                    ctip = Some(Self::successor_ctip(&m6, new_value));
                     res.push(m6);
                 }
             }
@@ -301,7 +307,10 @@ impl BlockProducer {
 
 #[cfg(test)]
 mod tests {
-    use bitcoin::Amount;
+    use bitcoin::{
+        Amount, OutPoint, ScriptBuf, Transaction, TxIn, TxOut, absolute::LockTime,
+        transaction::Version,
+    };
 
     use crate::{block_producer::BlockProducer, types::AmountUnderflowError};
 
@@ -327,5 +336,33 @@ mod tests {
             BlockProducer::new_treasury_value(value, fee, payout).unwrap(),
             Amount::from_sat(39_000)
         );
+    }
+
+    #[test]
+    fn successor_ctip_is_always_m6_output_zero() {
+        let m6 = Transaction {
+            version: Version::TWO,
+            lock_time: LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint::null(),
+                ..Default::default()
+            }],
+            output: vec![
+                TxOut {
+                    value: Amount::from_sat(90_000),
+                    script_pubkey: ScriptBuf::new(),
+                },
+                TxOut {
+                    value: Amount::from_sat(9_000),
+                    script_pubkey: ScriptBuf::new(),
+                },
+            ],
+        };
+
+        let successor = BlockProducer::successor_ctip(&m6, Amount::from_sat(90_000));
+
+        assert_eq!(successor.outpoint.txid, m6.compute_txid());
+        assert_eq!(successor.outpoint.vout, 0);
+        assert_eq!(successor.value, Amount::from_sat(90_000));
     }
 }


### PR DESCRIPTION
## Summary

Fix successor CTIP tracking after constructing an M6 withdrawal transaction.

BIP300 places the replacement treasury output at `vout 0`. The block producer previously selected the transaction’s last output, which may be a withdrawal payout.

## Impact

When an M6 had multiple outputs, the block producer could use a payout output as the next CTIP. A subsequent M6 constructed in the same block would then spend the wrong output and produce an invalid transaction chain.

The block producer now always records:

```text
successor CTIP = M6 transaction ID:vout 0
```

## Testing

Added a regression test using a multi-output M6 transaction that verifies:

- the successor transaction ID matches the M6;
- the successor output index is zero;
- the updated treasury value is preserved.

Focused test: `cargo test -p bip300301_enforcer_lib successor_ctip_is_always_m6_output_zero --lib`