### PR TITLE
Implement wallet birthdays, checkpoint sync

### DIFF
--- a/lib/wallet/cusf_block_producer.rs
+++ b/lib/wallet/cusf_block_producer.rs
@@ -46,6 +46,31 @@ async fn sync_wallet_to_tip(
         wallet.inner.set_last_synced_now().await;
         return Ok(());
     }
+    // Blocks mined before the wallet's keys existed provably cannot contain
+    // wallet transactions, so the block-by-block replay below is pure waste
+    // below the wallet's birthday.
+    const BIRTHDAY_REORG_MARGIN: u32 = 100;
+    let wallet_tip = if let Some(birthday_height) = wallet.inner.birthday_height().await {
+        let skip_below = birthday_height
+            .saturating_sub(BIRTHDAY_REORG_MARGIN)
+            .min(new_tip_height);
+
+        if wallet_tip.height < skip_below {
+            tracing::info!(
+                wallet_tip_height = wallet_tip.height,
+                %birthday_height,
+                %skip_below,
+                %new_tip_height,
+                "fast-forwarding wallet chain to just below its birthday"
+            );
+            let () = wallet.inner.fast_forward_chain(Some(skip_below)).await?;
+            wallet.inner.get_tip().await?
+        } else {
+            wallet_tip
+        }
+    } else {
+        wallet_tip
+    };
     // If the wallet tip is higher than the block height we need to connect the missing blocks.
     // We have logic for that below. We therefore use max() here to ensure that the loop
     // will run at least once (thereby triggering the logic for missing blocks).

--- a/lib/wallet/error.rs
+++ b/lib/wallet/error.rs
@@ -484,6 +484,8 @@ impl ToStatus for InitWalletFromMnemonic {
 pub enum CreateNewWallet {
     #[error(transparent)]
     EncryptMnemonic(#[from] EncryptMnemonic),
+    #[error("failed to fetch the node tip for the wallet birthday")]
+    FetchBirthdayHeight(#[source] BitcoinCoreRPC),
     #[error("failed to generate mnemonic")]
     GenerateMnemonic(#[from] bdk_wallet::bip39::Error),
     #[error(transparent)]
@@ -522,6 +524,7 @@ impl ToStatus for CreateNewWallet {
     fn builder(&self) -> StatusBuilder<'_> {
         match self {
             Self::EncryptMnemonic(err) => err.builder(),
+            Self::FetchBirthdayHeight(err) => err.builder(),
             Self::GenerateMnemonic(_) => StatusBuilder::new(self),
             Self::InitFromMnemonic(err) => err.builder(),
             // `AlreadyExists` never lands here: `From<InsertSeed>` maps it to
@@ -863,6 +866,8 @@ where
 pub(in crate::wallet) enum SyncWalletToTipInner {
     #[error("failed to connect missing block to wallet")]
     ConnectMissingBlock(#[from] ConnectMissingBlock),
+    #[error("failed to fast-forward wallet chain to tip")]
+    FastForward(#[from] FullScan),
     #[error("unable to fetch block from mainchain")]
     #[diagnostic(code(fetch_block_error))]
     GetBlock(#[source] BitcoinCoreRPC),

--- a/lib/wallet/mod.rs
+++ b/lib/wallet/mod.rs
@@ -22,7 +22,7 @@ use bitcoin::{
     script::PushBytesBuf,
 };
 use bitcoin_jsonrpsee::{
-    client::{GetRawTransactionClient, GetRawTransactionVerbose},
+    client::{GetRawTransactionClient, GetRawTransactionVerbose, MainClient as _},
     jsonrpsee::http_client::HttpClient,
 };
 use either::Either;
@@ -442,12 +442,28 @@ impl WalletInner {
         mnemonic: Option<Mnemonic>,
         password: Option<&str>,
     ) -> Result<(), error::CreateNewWallet> {
-        let mnemonic = match mnemonic {
-            Some(mnemonic) => mnemonic,
+        let (mnemonic, generated) = match mnemonic {
+            Some(mnemonic) => (mnemonic, false),
             None => {
                 tracing::info!("create new wallet: no mnemonic provided, generating fresh");
-                new_mnemonic()?
+                (new_mnemonic()?, true)
             }
+        };
+
+        let birthday_height = if generated {
+            let info = self
+                .main_client
+                .get_blockchain_info()
+                .await
+                .map_err(|err| {
+                    error::CreateNewWallet::FetchBirthdayHeight(error::BitcoinCoreRPC {
+                        method: "getblockchaininfo".to_owned(),
+                        error: err,
+                    })
+                })?;
+            Some(info.blocks)
+        } else {
+            None
         };
 
         match password {
@@ -455,7 +471,7 @@ impl WalletInner {
                 tracing::info!("create new wallet: persisting encrypted mnemonic");
                 let encrypted = EncryptedMnemonic::encrypt(&mnemonic, password)?;
                 self.seed_store
-                    .insert_seed(Seed::Encrypted(&encrypted))
+                    .insert_seed(Seed::Encrypted(&encrypted), birthday_height)
                     .await?;
             }
             None => {
@@ -463,7 +479,7 @@ impl WalletInner {
                     "create new wallet: no password provided, persisting plaintext mnemonic"
                 );
                 self.seed_store
-                    .insert_seed(Seed::Plaintext(&mnemonic))
+                    .insert_seed(Seed::Plaintext(&mnemonic), birthday_height)
                     .await?;
             }
         }

--- a/lib/wallet/seed_store.rs
+++ b/lib/wallet/seed_store.rs
@@ -49,6 +49,10 @@ struct SeedFile {
     version: u32,
     /// Informational only. Carried over from the legacy DB on migration.
     created_at: std::time::SystemTime,
+    /// The node's tip height when this seed was generated `None` for restored
+    /// seeds.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    birthday_height: Option<u32>,
     seed: StoredSeed,
 }
 
@@ -95,10 +99,19 @@ impl SeedStore {
         Ok(Some(seed))
     }
 
-    /// Persist the seed for a newly created wallet.
+    /// The wallet's birthday height, if one was recorded at creation.
+    pub(in crate::wallet) async fn read_birthday_height(
+        &self,
+    ) -> Result<Option<u32>, error::ReadSeed> {
+        Ok(read_seed_file(&self.path)?.and_then(|seed_file| seed_file.birthday_height))
+    }
+
+    /// Persist the seed for a newly created wallet. `birthday_height` must
+    /// only be `Some` for freshly GENERATED seeds (see [`SeedFile`]).
     pub(in crate::wallet) async fn insert_seed(
         &self,
         seed: Seed<'_>,
+        birthday_height: Option<u32>,
     ) -> Result<(), error::InsertSeed> {
         let _guard = self.insert_lock.lock().await;
         if self.path.exists() {
@@ -107,6 +120,7 @@ impl SeedStore {
         let seed_file = SeedFile {
             version: CURRENT_VERSION,
             created_at: std::time::SystemTime::now(),
+            birthday_height,
             seed: match seed {
                 Seed::Plaintext(mnemonic) => StoredSeed::Plaintext {
                     mnemonic: mnemonic.to_string(),
@@ -208,6 +222,8 @@ fn migrate_legacy_seed(path: &Path, data_dir: &Path) -> Result<(), error::InitSe
                 .unwrap_or_default();
             let seed_file = SeedFile {
                 version: CURRENT_VERSION,
+                // Legacy wallets have unknowable history: no birthday.
+                birthday_height: None,
                 created_at: created_at
                     .and_then(|secs| {
                         let secs = u64::try_from(secs).ok()?;
@@ -431,7 +447,10 @@ mod tests {
         let dir = temp_dir("migrate-mismatch");
         let store = SeedStore::new(&dir).unwrap();
         let mnemonic = Mnemonic::parse_in(Language::English, TEST_MNEMONIC).unwrap();
-        store.insert_seed(Seed::Plaintext(&mnemonic)).await.unwrap();
+        store
+            .insert_seed(Seed::Plaintext(&mnemonic), None)
+            .await
+            .unwrap();
         drop(store);
 
         // A different valid mnemonic in the legacy store.
@@ -515,12 +534,53 @@ mod tests {
         let store = SeedStore::new(&dir).unwrap();
         let mnemonic = Mnemonic::parse_in(Language::English, TEST_MNEMONIC).unwrap();
 
-        store.insert_seed(Seed::Plaintext(&mnemonic)).await.unwrap();
+        store
+            .insert_seed(Seed::Plaintext(&mnemonic), None)
+            .await
+            .unwrap();
         let err = store
-            .insert_seed(Seed::Plaintext(&mnemonic))
+            .insert_seed(Seed::Plaintext(&mnemonic), None)
             .await
             .expect_err("second insert must fail");
         assert!(matches!(err, error::InsertSeed::AlreadyExists));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// A recorded birthday round-trips; absence stays absent; and a seed
+    /// file written before the field existed reads back as `None`.
+    #[tokio::test]
+    async fn birthday_height_roundtrip_and_backcompat() {
+        let dir = temp_dir("birthday");
+        let store = SeedStore::new(&dir).unwrap();
+        let mnemonic = Mnemonic::parse_in(Language::English, TEST_MNEMONIC).unwrap();
+        store
+            .insert_seed(Seed::Plaintext(&mnemonic), Some(958_537))
+            .await
+            .unwrap();
+        assert_eq!(
+            store.read_birthday_height().await.unwrap(),
+            Some(958_537),
+            "birthday must round-trip"
+        );
+        drop(store);
+        std::fs::remove_dir_all(&dir).ok();
+
+        // Restored seed: no birthday.
+        let dir = temp_dir("birthday-none");
+        let store = SeedStore::new(&dir).unwrap();
+        store
+            .insert_seed(Seed::Plaintext(&mnemonic), None)
+            .await
+            .unwrap();
+        assert_eq!(store.read_birthday_height().await.unwrap(), None);
+
+        // Pre-birthday seed file (field absent entirely) must parse as None.
+        let raw = std::fs::read_to_string(dir.join("seed.json")).unwrap();
+        assert!(
+            !raw.contains("birthday_height"),
+            "None must not be serialized"
+        );
+        assert!(store.read_mnemonic().await.unwrap().is_some());
         std::fs::remove_dir_all(&dir).ok();
     }
 
@@ -533,7 +593,10 @@ mod tests {
         let dir = temp_dir("permissions");
         let store = SeedStore::new(&dir).unwrap();
         let mnemonic = Mnemonic::parse_in(Language::English, TEST_MNEMONIC).unwrap();
-        store.insert_seed(Seed::Plaintext(&mnemonic)).await.unwrap();
+        store
+            .insert_seed(Seed::Plaintext(&mnemonic), None)
+            .await
+            .unwrap();
 
         let mode = std::fs::metadata(dir.join("seed.json"))
             .unwrap()

--- a/lib/wallet/sync.rs
+++ b/lib/wallet/sync.rs
@@ -104,6 +104,61 @@ impl WalletInner {
         let mut last_sync_write = self.last_sync.write().await;
         *last_sync_write = Some(SystemTime::now());
     }
+
+    /// The wallet's recorded birthday height, if any. Read errors are
+    /// downgraded to `None`. The fallback is merely a slower (full) sync.
+    pub(in crate::wallet) async fn birthday_height(&self) -> Option<u32> {
+        match self.seed_store.read_birthday_height().await {
+            Ok(birthday_height) => birthday_height,
+            Err(err) => {
+                tracing::warn!(
+                    "failed to read wallet birthday; syncing from genesis: {:#}",
+                    crate::errors::ErrorChain::new(&err)
+                );
+                None
+            }
+        }
+    }
+
+    /// Fast-forward the wallet's local chain up to `up_to_height` (or the
+    /// validator tip) by applying one checkpoint update built from validator
+    /// headers, instead of connecting every missing block individually.
+    pub(in crate::wallet) async fn fast_forward_chain(
+        &self,
+        up_to_height: Option<u32>,
+    ) -> Result<(), error::FullScan> {
+        let start = Instant::now();
+        let mut wallet_write = self.write_wallet().await?;
+        let mut bdk_db = self.bdk_db.lock().await;
+
+        let checkpoint = {
+            let local_chain = wallet_write.local_chain();
+            self.get_chain_checkpoint(local_chain, up_to_height).await?
+        };
+        let tip_height = checkpoint.height();
+
+        let update = bdk_wallet::Update {
+            chain: Some(checkpoint),
+            ..Default::default()
+        };
+        wallet_write
+            .with_mut(|wallet| {
+                wallet
+                    .apply_update(update)
+                    .map(|()| wallet.persist_async(&mut bdk_db))
+            })
+            .map_err(error::FullScan::CannotConnect)?
+            .await
+            .map_err(|err| error::FullScan::PersistWallet(error::SqliteError::from(err)))?;
+
+        drop(wallet_write);
+        tracing::info!(
+            %tip_height,
+            "fast-forwarded wallet chain to tip in {:?}",
+            start.elapsed()
+        );
+        Ok(())
+    }
     /// Sync the wallet, returning a write guard on last_sync, wallet, and database
     /// if wallet was not locked.
     /// Does not commit changes.
@@ -214,12 +269,16 @@ impl WalletInner {
     async fn get_chain_checkpoint(
         &self,
         local_chain: &bdk_chain::local_chain::LocalChain,
+        up_to_height: Option<u32>,
     ) -> miette::Result<bdk_chain::CheckPoint, error::FullScan> {
         let start = Instant::now();
-        let headers = self
+        let mut headers = self
             .validator()
             .list_headers(local_chain.tip().height())
             .map_err(error::FullScan::ListHeaders)?;
+        if let Some(up_to_height) = up_to_height {
+            headers.retain(|(height, _)| *height <= up_to_height);
+        }
 
         tracing::debug!(
             "listed {} headers since height {} in {:?}: {} -> {}",
@@ -325,7 +384,7 @@ impl WalletInner {
         }
 
         let local_chain = wallet_write.local_chain();
-        let checkpoint = self.get_chain_checkpoint(local_chain).await?;
+        let checkpoint = self.get_chain_checkpoint(local_chain, None).await?;
         let request = wallet_write
             .start_sync_with_revealed_spks()
             .chain_tip(checkpoint);


### PR DESCRIPTION
Skips over block-by-block wallet syncs when dealing with provably too old data.