### PR TITLE
Send BMM transaction to own node via `sendrawtransaction`

### DIFF
--- a/integration_tests/test_peer_bmm_request.rs
+++ b/integration_tests/test_peer_bmm_request.rs
@@ -100,8 +100,10 @@ impl PreSetup {
         res_tx: mpsc::UnboundedSender<anyhow::Result<()>>,
     ) -> anyhow::Result<PostSetup> {
         let sender = {
+            // Use a hostname rather than an IP to exercise DNS resolution of
+            // p2p broadcast addresses
             let enforcer_args = vec![format!(
-                "--p2p-broadcast-addr=127.0.0.1:{}",
+                "--p2p-broadcast-addr=localhost:{}",
                 self.miner.reserved_ports.bitcoind_listen.port()
             )];
             let setup_opts: SetupOpts = SetupOpts {
@@ -236,6 +238,16 @@ async fn test_peer_bmm_request_task(mut post_setup: PostSetup) -> anyhow::Result
         anyhow::bail!("Failed to create BMM critical data tx")
     };
     tracing::info!(%bmm_request_txid, "Created BMM request tx successfully");
+    // In addition to the p2p broadcast, the enforcer submits the BMM request
+    // to its own node via `sendrawtransaction`, so it should be in the
+    // sender node's mempool immediately
+    let sender_mempool_entry = post_setup
+        .sender
+        .bitcoin_cli
+        .command::<String, _, _, _, _>([], "getmempoolentry", [bmm_request_txid.clone()])
+        .run_utf8()
+        .await?;
+    tracing::debug!(%sender_mempool_entry);
     // Wait for mempool inclusion / p2p broadcast.
     // This can take >5s sometimes, for unknown reasons.
     sleep(std::time::Duration::from_secs(10)).await;
@@ -246,6 +258,19 @@ async fn test_peer_bmm_request_task(mut post_setup: PostSetup) -> anyhow::Result
         .run_utf8()
         .await?;
     tracing::debug!(%mempool_entry);
+    // Check that the tx entered the sender node's mempool via RPC broadcast,
+    // rather than via p2p relay from the miner node
+    let sender_enforcer_stdout = std::fs::read_to_string(
+        post_setup
+            .sender
+            .directories
+            .enforcer_dir
+            .join("stdout.txt"),
+    )?;
+    anyhow::ensure!(
+        sender_enforcer_stdout.contains("Broadcast BMM request transaction via RPC to own node"),
+        "Expected sender enforcer to broadcast the BMM request tx via RPC to its own node"
+    );
     // Mine a block and check that the BMM request worked
     let () = mine::mine_check_block_events::<_, DummySidechain>(
         &mut post_setup.miner,

--- a/lib/cli.rs
+++ b/lib/cli.rs
@@ -456,11 +456,12 @@ pub struct Config {
     #[arg(long)]
     pub node_zmq_addr_sequence: Option<String>,
     /// Broadcast Deposit/Withdrawal/BMM request txs via p2p to this peer.
+    /// Accepts `IP:PORT` or `HOST:PORT`
     /// On L2L Signet, txs are broadcast to the signet mining server by
     /// default.
     /// This option can be specified multiple times.
     #[arg(long)]
-    pub p2p_broadcast_addr: Vec<SocketAddr>,
+    pub p2p_broadcast_addr: Vec<crate::p2p::BroadcastAddr>,
     /// Serve RPCs such as `getblocktemplate` on this address
     #[arg(default_value_t = DEFAULT_SERVE_RPC_ADDR, long)]
     pub serve_rpc_addr: SocketAddr,

--- a/lib/p2p.rs
+++ b/lib/p2p.rs
@@ -1,6 +1,6 @@
 //! P2P related functions and types
 
-use std::net::{Ipv4Addr, SocketAddrV4};
+use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 
 use bitcoin::p2p::Magic;
 
@@ -19,26 +19,141 @@ pub const fn default_p2p_broadcast_addr(
     }
 }
 
+/// A peer address for p2p tx broadcast: either a socket address, or a
+/// `HOST:PORT` pair that is resolved via DNS at broadcast time.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum BroadcastAddr {
+    Sock(SocketAddr),
+    Host { host: String, port: u16 },
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ParseBroadcastAddrError {
+    #[error("expected `IP:PORT` or `HOST:PORT`, got `{0}`")]
+    MissingPort(String),
+    #[error("invalid host in broadcast address `{0}`")]
+    InvalidHost(String),
+    #[error("invalid port in broadcast address `{addr}`")]
+    InvalidPort {
+        addr: String,
+        source: std::num::ParseIntError,
+    },
+}
+
+impl std::str::FromStr for BroadcastAddr {
+    type Err = ParseBroadcastAddrError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if let Ok(sock) = s.parse::<SocketAddr>() {
+            return Ok(Self::Sock(sock));
+        }
+        let (host, port) = s
+            .rsplit_once(':')
+            .ok_or_else(|| ParseBroadcastAddrError::MissingPort(s.to_owned()))?;
+        // A colon in the host means an IPv6 address, which must be bracketed
+        // and is handled by the `SocketAddr` parse above.
+        if host.is_empty() || host.contains([':', '[', ']']) {
+            return Err(ParseBroadcastAddrError::InvalidHost(s.to_owned()));
+        }
+        let port = port
+            .parse::<u16>()
+            .map_err(|source| ParseBroadcastAddrError::InvalidPort {
+                addr: s.to_owned(),
+                source,
+            })?;
+        Ok(Self::Host {
+            host: host.to_owned(),
+            port,
+        })
+    }
+}
+
+impl std::fmt::Display for BroadcastAddr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Sock(sock) => sock.fmt(f),
+            Self::Host { host, port } => write!(f, "{host}:{port}"),
+        }
+    }
+}
+
+impl From<SocketAddr> for BroadcastAddr {
+    fn from(sock: SocketAddr) -> Self {
+        Self::Sock(sock)
+    }
+}
+
+impl From<SocketAddrV4> for BroadcastAddr {
+    fn from(sock: SocketAddrV4) -> Self {
+        Self::Sock(sock.into())
+    }
+}
+
+impl BroadcastAddr {
+    async fn resolve(&self) -> Result<Vec<SocketAddr>, std::io::Error> {
+        match self {
+            Self::Sock(sock) => Ok(vec![*sock]),
+            Self::Host { host, port } => {
+                let addrs = tokio::net::lookup_host((host.as_str(), *port)).await?;
+                Ok(addrs.collect())
+            }
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum BroadcastNonstandardTxError {
+    #[error("failed to resolve p2p broadcast address `{addr}`")]
+    Resolve {
+        addr: BroadcastAddr,
+        source: std::io::Error,
+    },
+    #[error("p2p broadcast address `{addr}` resolved to no addresses")]
+    ResolvedEmpty { addr: BroadcastAddr },
+    #[error(transparent)]
+    Send(#[from] bitcoin_send_tx_p2p::Error),
+}
+
 /// Broadcasts a non-standard transaction directly to a specified node via
 /// p2p.
 /// Returns `true` if submitted successfully, `false` on timeout.
 /// Note that if the specified node already has the tx, the broadcast will
 /// time out.
 pub async fn broadcast_nonstandard_tx(
-    p2p_address: std::net::SocketAddr,
+    p2p_address: BroadcastAddr,
     block_height: i32,
     magic: Magic,
     tx: bitcoin::Transaction,
-) -> Result<bool, bitcoin_send_tx_p2p::Error> {
+) -> Result<bool, BroadcastNonstandardTxError> {
     use bitcoin_send_tx_p2p::{Config, Error, send_tx_p2p_over_clearnet};
-    let mut config = Config::default();
-    config.block_height = block_height;
-    config.magic = magic;
-    match send_tx_p2p_over_clearnet(p2p_address, tx, Some(config)).await {
-        Ok(()) => Ok(true),
-        Err(Error::Timeout(_)) => Ok(false),
-        Err(err) => Err(err),
+    let socket_addrs =
+        p2p_address
+            .resolve()
+            .await
+            .map_err(|source| BroadcastNonstandardTxError::Resolve {
+                addr: p2p_address.clone(),
+                source,
+            })?;
+    if socket_addrs.is_empty() {
+        return Err(BroadcastNonstandardTxError::ResolvedEmpty { addr: p2p_address });
     }
+    // A hostname may resolve to multiple addresses (e.g. `localhost` to both
+    // `127.0.0.1` and `::1`) of which only some accept connections, so try
+    // each in order until one connects.
+    let mut last_err = None;
+    for socket_addr in socket_addrs {
+        let mut config = Config::default();
+        config.block_height = block_height;
+        config.magic = magic;
+        match send_tx_p2p_over_clearnet(socket_addr, tx.clone(), Some(config)).await {
+            Ok(()) => return Ok(true),
+            Err(Error::Timeout(_)) => return Ok(false),
+            Err(err) => last_err = Some(err),
+        }
+    }
+    Err(last_err
+        .expect("socket_addrs is non-empty, so at least one send was attempted")
+        .into())
 }
 
 // https://github.com/kallewoof/bips/blob/master/bip-0325.mediawiki#message-start
@@ -82,6 +197,41 @@ mod tests {
             bitcoin::ScriptBuf::from_hex("a91484fa7c2460891fe5212cb08432e21a4207909aa987").unwrap();
         let magic = compute_signet_magic(signet_challenge.as_script());
         assert_eq!(magic, Magic::from_bytes([0xe4, 0x09, 0xe9, 0x68]));
+    }
+
+    #[test]
+    fn test_parse_broadcast_addr() {
+        assert_eq!(
+            "127.0.0.1:8333".parse::<BroadcastAddr>().unwrap(),
+            BroadcastAddr::Sock("127.0.0.1:8333".parse().unwrap()),
+        );
+        assert_eq!(
+            "[::1]:8333".parse::<BroadcastAddr>().unwrap(),
+            BroadcastAddr::Sock("[::1]:8333".parse().unwrap()),
+        );
+        assert_eq!(
+            "example.com:38333".parse::<BroadcastAddr>().unwrap(),
+            BroadcastAddr::Host {
+                host: "example.com".to_owned(),
+                port: 38333,
+            },
+        );
+        assert_eq!(
+            "localhost:8333".parse::<BroadcastAddr>().unwrap(),
+            BroadcastAddr::Host {
+                host: "localhost".to_owned(),
+                port: 8333,
+            },
+        );
+        // no port
+        assert!("example.com".parse::<BroadcastAddr>().is_err());
+        // invalid port
+        assert!("example.com:notaport".parse::<BroadcastAddr>().is_err());
+        assert!("example.com:99999".parse::<BroadcastAddr>().is_err());
+        // empty host
+        assert!(":8333".parse::<BroadcastAddr>().is_err());
+        // unbracketed IPv6
+        assert!("::1:8333".parse::<BroadcastAddr>().is_err());
     }
 
     // For challenges >= 253 bytes the length prefix must be a CompactSize, not a

--- a/lib/rpc_client.rs
+++ b/lib/rpc_client.rs
@@ -80,6 +80,53 @@ pub fn create_client(conf: &NodeRpcConfig) -> Result<HttpClient, Error> {
     Ok(client)
 }
 
+// Note: there's a `broadcast` method on `bitcoin_blockchain`. We're NOT using that,
+// because we're broadcasting transactions that "burn" bitcoin (from a BIP-300/1 unaware
+// perspective). To get around this we have to pass a `maxburnamount` parameter, and
+// that's not possible if going through the ElectrumBlockchain interface.
+//
+// For the interested reader, the flow of ElectrumBlockchain::broadcast is this:
+// 1. Send the raw TX from our Electrum client
+// 2. Electrum server implements this by sending it into Bitcoin Core
+// 3. Bitcoin Core responds with an error, because we're burning money.
+const MAX_BURN_AMOUNT: f64 = 21_000_000.0;
+
+/// Broadcasts a transaction to the Bitcoin network via `sendrawtransaction`,
+/// tolerating call errors for which `tolerate_rejection` returns `true`.
+/// Returns `Some(txid)` if broadcast successfully, `None` if the tx was
+/// rejected but the rejection is tolerated. All other errors are returned
+/// as-is.
+async fn broadcast_transaction_with_tolerance<RpcClient>(
+    rpc_client: &RpcClient,
+    tx: &bdk_wallet::bitcoin::Transaction,
+    tolerate_rejection: impl FnOnce(i32, &str) -> bool,
+) -> Result<Option<bitcoin::Txid>, ClientError>
+where
+    RpcClient: MainClient + Sync,
+{
+    let encoded_tx = bitcoin::consensus::encode::serialize_hex(tx);
+    match rpc_client
+        .send_raw_transaction(encoded_tx, None, Some(MAX_BURN_AMOUNT))
+        .await
+    {
+        Ok(txid) => {
+            tracing::debug!(%txid, "broadcast tx successfully");
+            Ok(Some(txid))
+        }
+        Err(ClientError::Call(err)) if tolerate_rejection(err.code(), err.message()) => {
+            tracing::warn!(
+                reason = %err.message(),
+                "node rejected tx, tolerated",
+            );
+            Ok(None)
+        }
+        Err(err) => {
+            tracing::error!("failed to broadcast tx: {:#}", ErrorChain::new(&err));
+            Err(err)
+        }
+    }
+}
+
 /// Broadcasts a transaction to the Bitcoin network.
 /// Returns `Some(txid)` if broadcast successfully, `None` if the tx failed to
 /// broadcast due to the node not supporting OP_DRIVECHAIN
@@ -90,46 +137,38 @@ pub async fn broadcast_transaction<RpcClient>(
 where
     RpcClient: MainClient + Sync,
 {
-    // Note: there's a `broadcast` method on `bitcoin_blockchain`. We're NOT using that,
-    // because we're broadcasting transactions that "burn" bitcoin (from a BIP-300/1 unaware
-    // perspective). To get around this we have to pass a `maxburnamount` parameter, and
-    // that's not possible if going through the ElectrumBlockchain interface.
-    //
-    // For the interested reader, the flow of ElectrumBlockchain::broadcast is this:
-    // 1. Send the raw TX from our Electrum client
-    // 2. Electrum server implements this by sending it into Bitcoin Core
-    // 3. Bitcoin Core responds with an error, because we're burning money.
-    const MAX_BURN_AMOUNT: f64 = 21_000_000.0;
-    let encoded_tx = bitcoin::consensus::encode::serialize_hex(tx);
-    match rpc_client
-        .send_raw_transaction(encoded_tx, None, Some(MAX_BURN_AMOUNT))
-        .await
-    {
-        Ok(txid) => {
-            tracing::debug!(%txid, "broadcast tx successfully");
-            Ok(Some(txid))
-        }
-        Err(err) => {
-            const OP_DRIVECHAIN_NOT_SUPPORTED_ERR_MSG: &str =
-                "non-mandatory-script-verify-flag (NOPx reserved for soft-fork upgrades)";
-            // Bitcoind v30.0 changed the error message
-            const OP_DRIVECHAIN_NOT_SUPPORTED_ERR_MSG_V30_0: &str =
-                "mempool-script-verify-flag-failed (NOPx reserved for soft-fork upgrades)";
-            fn contains_op_drivechain_not_supported(msg: &str) -> bool {
-                msg.contains(OP_DRIVECHAIN_NOT_SUPPORTED_ERR_MSG)
-                    || msg.contains(OP_DRIVECHAIN_NOT_SUPPORTED_ERR_MSG_V30_0)
-            }
-            match err {
-                // We used to check the exact error message. Looks like this slightly varies across versions. Therefore
-                // use a substring check.
-                ClientError::Call(err) if contains_op_drivechain_not_supported(err.message()) => {
-                    Ok(None)
-                }
-                err => {
-                    tracing::error!("failed to broadcast tx: {:#}", ErrorChain::new(&err));
-                    Err(err)
-                }
-            }
-        }
-    }
+    const OP_DRIVECHAIN_NOT_SUPPORTED_ERR_MSG: &str =
+        "non-mandatory-script-verify-flag (NOPx reserved for soft-fork upgrades)";
+    // Bitcoind v30.0 changed the error message
+    const OP_DRIVECHAIN_NOT_SUPPORTED_ERR_MSG_V30_0: &str =
+        "mempool-script-verify-flag-failed (NOPx reserved for soft-fork upgrades)";
+    // We used to check the exact error message. Looks like this slightly
+    // varies across versions. Therefore use a substring check.
+    broadcast_transaction_with_tolerance(rpc_client, tx, |_code, msg| {
+        msg.contains(OP_DRIVECHAIN_NOT_SUPPORTED_ERR_MSG)
+            || msg.contains(OP_DRIVECHAIN_NOT_SUPPORTED_ERR_MSG_V30_0)
+    })
+    .await
+}
+
+/// `RPC_VERIFY_REJECTED`: transaction was rejected by the node's mempool
+/// policy (e.g. non-standardness) or by network rules.
+const BITCOIN_CORE_RPC_TRANSACTION_REJECTED: i32 = -26;
+
+/// Broadcasts a transaction to the Bitcoin network, tolerating rejection from
+/// the node's mempool (Bitcoin Core RPC error -26, e.g. due to
+/// non-standardness).
+/// Returns `Some(txid)` if broadcast successfully, `None` if the node
+/// rejected the tx from its mempool. All other errors are returned as-is.
+pub async fn broadcast_transaction_tolerate_mempool_rejection<RpcClient>(
+    rpc_client: &RpcClient,
+    tx: &bdk_wallet::bitcoin::Transaction,
+) -> Result<Option<bitcoin::Txid>, ClientError>
+where
+    RpcClient: MainClient + Sync,
+{
+    broadcast_transaction_with_tolerance(rpc_client, tx, |code, _msg| {
+        code == BITCOIN_CORE_RPC_TRANSACTION_REJECTED
+    })
+    .await
 }

--- a/lib/wallet/error.rs
+++ b/lib/wallet/error.rs
@@ -722,8 +722,8 @@ pub enum CreateDeposit {
     BroadcastTx(#[source] jsonrpsee::core::ClientError),
     #[error("failed to broadcast nonstandard tx to {peer_addr}")]
     BroadcastNonstandardTx {
-        peer_addr: std::net::SocketAddr,
-        source: bitcoin_send_tx_p2p::Error,
+        peer_addr: crate::p2p::BroadcastAddr,
+        source: crate::p2p::BroadcastNonstandardTxError,
     },
     #[error("broadcast deposit transaction failed: {txid}")]
     BroadcastUnsuccessful { txid: bitcoin::Txid },
@@ -1251,7 +1251,9 @@ pub(in crate::wallet) enum CreateBmmRequestInner {
     #[error("failed to build BMM tx")]
     BuildBmmTx(#[from] BuildBmmTx),
     #[error("failed to broadcast nonstandard tx")]
-    BroadcastNonstandardTx(#[source] bitcoin_send_tx_p2p::Error),
+    BroadcastNonstandardTx(#[source] crate::p2p::BroadcastNonstandardTxError),
+    #[error("failed to broadcast BMM request tx via RPC")]
+    BroadcastTxRpc(#[source] JsonRpcError),
     #[error("broadcast deposit transaction failed: {txid}")]
     BroadcastUnsuccessful { txid: bitcoin::Txid },
     #[error(transparent)]
@@ -1269,6 +1271,7 @@ impl ToStatus for CreateBmmRequestInner {
             Self::GetHeaderInfo(err) => err.builder(),
             Self::SignTx(err) => StatusBuilder::with_code(self, err.builder()),
             Self::BroadcastNonstandardTx(_)
+            | Self::BroadcastTxRpc(_)
             | Self::BroadcastUnsuccessful { .. }
             | Self::Rusqlite(_) => StatusBuilder::new(self),
         }

--- a/lib/wallet/mod.rs
+++ b/lib/wallet/mod.rs
@@ -982,10 +982,10 @@ impl Wallet {
         Ok(psbt)
     }
 
-    fn p2p_broadcast_addrs(&self) -> Box<dyn Iterator<Item = std::net::SocketAddr> + '_> {
+    fn p2p_broadcast_addrs(&self) -> Box<dyn Iterator<Item = crate::p2p::BroadcastAddr> + '_> {
         let network = self.inner.validator().network();
         let magic = self.inner.magic;
-        let p2p_broadcast_addrs = self.inner.config.p2p_broadcast_addr.iter().copied();
+        let p2p_broadcast_addrs = self.inner.config.p2p_broadcast_addr.iter().cloned();
         match crate::p2p::default_p2p_broadcast_addr(network, magic.to_bytes()) {
             Some(default_addr) => {
                 if magic.to_bytes() == crate::p2p::SIGNET_MAGIC_BYTES {
@@ -1081,12 +1081,15 @@ impl Wallet {
             .p2p_broadcast_addrs()
             .map(|peer_addr| {
                 crate::p2p::broadcast_nonstandard_tx(
-                    peer_addr,
+                    peer_addr.clone(),
                     block_height as i32,
                     self.inner.magic,
                     tx.clone(),
                 )
-                .map_ok(move |result| (peer_addr, result))
+                .map_ok({
+                    let peer_addr = peer_addr.clone();
+                    move |result| (peer_addr, result)
+                })
                 .map_err(move |source| {
                     error::CreateDeposit::BroadcastNonstandardTx { peer_addr, source }
                 })
@@ -1692,7 +1695,8 @@ impl Wallet {
         Ok(psbt)
     }
 
-    /// Creates a BMM request transaction. Broadcasts via p2p whitelist only.
+    /// Creates a BMM request transaction. Broadcasts via the p2p whitelist,
+    /// and via RPC to our own node (tolerating rejection due to non-standardness).
     /// Returns `Some(tx)` if the BMM request was stored, `None` if the BMM
     /// request was not stored due to pre-existing request with the same
     /// `sidechain_number` and `prev_mainchain_block_hash`.
@@ -1765,6 +1769,25 @@ impl Wallet {
                 return Err(err.into());
             }
             None => {}
+        }
+        // Submit to our own node via RPC as well. This must happen after the
+        // p2p broadcast: if a peer received the tx via relay from our node
+        // first, the p2p broadcast to it would time out. Unpatched nodes may
+        // reject the BMM request as non-standard. That is tolerated.
+        tracing::debug!(%txid, "Broadcasting BMM request transaction to own node via RPC...");
+        match crate::rpc_client::broadcast_transaction_tolerate_mempool_rejection(
+            &self.inner.main_client,
+            &tx,
+        )
+        .await
+        .map_err(error::CreateBmmRequestInner::BroadcastTxRpc)?
+        {
+            Some(_) => {
+                tracing::info!(%txid, "Broadcast BMM request transaction via RPC to own node");
+            }
+            None => {
+                tracing::info!(%txid, "Own node rejected BMM request transaction from its mempool");
+            }
         }
         if stored { Ok(Some(tx)) } else { Ok(None) }
     }


### PR DESCRIPTION
For nodes that tolerate BMM transactions we want to get the TX into the node's own mempool, which in turn will make it broadcast the TX across the broader P2P network. Tolerate rejections for nodes that don't like these TXs.

Also allow hostnames in CLI P2P broadcast addr opt.