### PR TITLE
wallet: avoid deadlock in `handle_connect_block`

### DIFF
--- a/lib/wallet/cusf_block_producer.rs
+++ b/lib/wallet/cusf_block_producer.rs
@@ -303,7 +303,8 @@ impl CusfEnforcer for Wallet {
                         // inputs survive a restart before the tx confirms. The
                         // locks are scoped so they are released before logging.
                         let persist_res = {
-                            let mut bdk_db_lock = inner.bdk_db.lock().await;
+                            // Lock order: wallet before `bdk_db`, see the
+                            // `bdk_db` field docs
                             let mut wallet_write = match inner.write_wallet().await {
                                 Ok(wallet_write) => wallet_write,
                                 Err(err) => {
@@ -311,6 +312,7 @@ impl CusfEnforcer for Wallet {
                                     return;
                                 }
                             };
+                            let mut bdk_db_lock = inner.bdk_db.lock().await;
                             let now = SystemTime::now()
                                 .duration_since(UNIX_EPOCH)
                                 .unwrap()

--- a/lib/wallet/mod.rs
+++ b/lib/wallet/mod.rs
@@ -105,7 +105,10 @@ struct WalletInner {
     // Unlocked, ready-to-go wallet: Some
     // Locked wallet: None
     bitcoin_wallet: async_lock::RwLock<Option<BdkWallet>>,
-    /// Persistence for the BDK wallet
+    /// Persistence for the BDK wallet.
+    ///
+    /// Lock order: when both are needed, take `bitcoin_wallet` before
+    /// `bdk_db`
     bdk_db: tokio::sync::Mutex<Persistence>,
     seed_store: SeedStore,
     /// Where block rewards go. If unset, `generate_blocks` falls back to a fresh wallet
@@ -1107,19 +1110,21 @@ impl Wallet {
             // is marked spent. Otherwise a deposit created before this tx
             // confirms can reselect the same UTXO, which Bitcoin Core rejects
             // as an RBF replacement. Mirrors `send_wallet_transaction`.
-            let mut bdk_db_lock = self.inner.bdk_db.lock().await;
             let last_seen = std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap();
-            let applied_changes = self
-                .inner
-                .write_wallet()
-                .await?
-                .with_mut(|wallet| {
-                    wallet.apply_unconfirmed_txs(vec![(tx, last_seen.as_secs())]);
-                    wallet.persist_async(&mut bdk_db_lock)
-                })
-                .await?;
+            let applied_changes = {
+                // Lock order: wallet before `bdk_db`, see the `bdk_db` field
+                // docs
+                let mut wallet_write = self.inner.write_wallet().await?;
+                let mut bdk_db_lock = self.inner.bdk_db.lock().await;
+                wallet_write
+                    .with_mut(|wallet| {
+                        wallet.apply_unconfirmed_txs(vec![(tx, last_seen.as_secs())]);
+                        wallet.persist_async(&mut bdk_db_lock)
+                    })
+                    .await?
+            };
             if applied_changes {
                 tracing::debug!(%txid, "Applied unconfirmed deposit transaction to wallet");
             } else {
@@ -1532,21 +1537,21 @@ impl Wallet {
         tracing::info!(%txid, "Broadcast send transaction in {:?}", timestamp.elapsed());
 
         // Apply the unconfirmed transaction to the wallet
-        let mut bdk_db_lock = self.inner.bdk_db.lock().await;
-
         let last_seen = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap();
 
-        let applied_changes = self
-            .inner
-            .write_wallet()
-            .await?
-            .with_mut(|wallet| {
-                wallet.apply_unconfirmed_txs(vec![(tx, last_seen.as_secs())]);
-                wallet.persist_async(&mut bdk_db_lock)
-            })
-            .await?;
+        let applied_changes = {
+            // Lock order: wallet before `bdk_db`, see the `bdk_db` field docs
+            let mut wallet_write = self.inner.write_wallet().await?;
+            let mut bdk_db_lock = self.inner.bdk_db.lock().await;
+            wallet_write
+                .with_mut(|wallet| {
+                    wallet.apply_unconfirmed_txs(vec![(tx, last_seen.as_secs())]);
+                    wallet.persist_async(&mut bdk_db_lock)
+                })
+                .await?
+        };
 
         // We used to do a sanity check here that changes were applied. However,
         // `applied_changes` may be false if the transaction was already


### PR DESCRIPTION
1. SendTransaction broadcasts a TX. Grabs `bdk_db`, waits for `bitcoin_wallet`
2. `handle_connect_block` grabs `bitcoin_wallet`, waits for `bdk_db`