### PR TITLE
wallet: do not fail ListTransactions when an input cannot be fetched

### DIFF
--- a/lib/wallet/error.rs
+++ b/lib/wallet/error.rs
@@ -1125,11 +1125,6 @@ impl ToStatus for GetWalletBalance {
 
 #[derive(Diagnostic, Debug, Error)]
 pub enum ListWalletTransactions {
-    #[error("unable to fetch wallet transaction")]
-    FetchTransaction {
-        txid: bitcoin::Txid,
-        source: BitcoinCoreRPC,
-    },
     #[error(transparent)]
     DeserializeHex(#[from] bitcoin::consensus::encode::FromHexError),
     #[error(transparent)]
@@ -1139,8 +1134,6 @@ pub enum ListWalletTransactions {
 impl ToStatus for ListWalletTransactions {
     fn builder(&self) -> StatusBuilder<'_> {
         match self {
-            Self::FetchTransaction { txid, source } => StatusBuilder::new(source)
-                .message(move |f| write!(f, "unable to fetch wallet transaction `{txid:?}`")),
             Self::DeserializeHex(err) => StatusBuilder::new(err),
             Self::NotUnlocked(err) => err.builder(),
         }

--- a/lib/wallet/mod.rs
+++ b/lib/wallet/mod.rs
@@ -1155,6 +1155,18 @@ impl Wallet {
         Ok((balance, has_synced))
     }
 
+    /// Fee for a listed wallet transaction. An input we could not resolve
+    /// leaves the input total short, so the fee is unknown and reported as
+    /// zero rather than wrong.
+    fn wallet_tx_fee(input_value: Amount, output_value: Amount, inputs_resolved: bool) -> Amount {
+        if !inputs_resolved {
+            return Amount::ZERO;
+        }
+        input_value
+            .checked_sub(output_value)
+            .unwrap_or(Amount::ZERO)
+    }
+
     #[expect(
         clippy::significant_drop_tightening,
         reason = "false positive for `bitcoin_wallet`"
@@ -1201,6 +1213,7 @@ impl Wallet {
             let mut output_value = Amount::ZERO;
             let mut received = Amount::ZERO;
             let mut sent = Amount::ZERO;
+            let mut inputs_resolved = true;
 
             // Calculate output value and received amount
             for (value, is_mine) in output_ownership {
@@ -1217,7 +1230,7 @@ impl Wallet {
                     continue;
                 }
 
-                let transaction_hex = self
+                let transaction_hex = match self
                     .inner
                     .main_client
                     // TODO: get rid of this. It's kind of absurd that we're calling out to getrawtransaction for every input.
@@ -1229,13 +1242,21 @@ impl Wallet {
                         None,
                     )
                     .await
-                    .map_err(|err| error::ListWalletTransactions::FetchTransaction {
-                        txid: input.previous_output.txid,
-                        source: error::BitcoinCoreRPC {
-                            method: "getrawtransaction".to_string(),
-                            error: err,
-                        },
-                    })?;
+                {
+                    Ok(transaction_hex) => transaction_hex,
+                    // A reorg can drop a wallet tx's ancestor from the node
+                    // while the wallet still holds the tx. One input we cannot
+                    // resolve must not fail the whole listing.
+                    Err(err) => {
+                        tracing::warn!(
+                            txid = %input.previous_output.txid,
+                            "unable to fetch wallet transaction input: {:#}",
+                            ErrorChain::new(&err),
+                        );
+                        inputs_resolved = false;
+                        continue;
+                    }
+                };
 
                 let prev_output =
                     bitcoin::consensus::encode::deserialize_hex::<Transaction>(&transaction_hex)?;
@@ -1251,9 +1272,7 @@ impl Wallet {
                 input_value += value;
             }
 
-            let fee = input_value
-                .checked_sub(output_value)
-                .unwrap_or(Amount::ZERO);
+            let fee = Self::wallet_tx_fee(input_value, output_value, inputs_resolved);
             // Calculate net wallet change (excluding fee)
             // We need to handle received and sent separately since Amount can't be negative
             let (final_received, final_sent) = if received >= sent {

--- a/lib/wallet/mod.rs
+++ b/lib/wallet/mod.rs
@@ -1980,3 +1980,28 @@ impl Wallet {
         self.inner.create_new_wallet(mnemonic, password).await
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use bitcoin::Amount;
+
+    use super::Wallet;
+
+    #[test]
+    fn wallet_tx_fee_is_zero_when_an_input_is_unresolved() {
+        // Without the skipped input the totals imply a 4000 sat fee, which
+        // would be wrong.
+        assert_eq!(
+            Wallet::wallet_tx_fee(Amount::from_sat(5_000), Amount::from_sat(1_000), false),
+            Amount::ZERO
+        );
+    }
+
+    #[test]
+    fn wallet_tx_fee_is_the_difference_when_inputs_resolve() {
+        assert_eq!(
+            Wallet::wallet_tx_fee(Amount::from_sat(5_000), Amount::from_sat(1_000), true),
+            Amount::from_sat(4_000)
+        );
+    }
+}


### PR DESCRIPTION
`list_wallet_transactions` resolves every input of every wallet transaction by calling `getrawtransaction` on Core, and propagates any RPC error with `?`. A wallet transaction whose ancestor Core no longer has is an ordinary condition: a reorg drops the funding ancestor, Core evicts the transaction from its mempool, and the BDK wallet still holds it. Core then answers `-5 No such mempool or blockchain transaction` for that one input, and the `?` aborts the whole call, so the `ListTransactions` RPC returns an error instead of a wallet view. Every other transaction in the wallet becomes invisible until the wallet state is repaired by hand.

The listing is informational, and one input it cannot price is not a reason to fail the request.

## Fix

Treat a failed input fetch as a soft condition: log it and skip that input. Because a skipped input leaves the input total short, the fee for that transaction would come out wrong, so `wallet_tx_fee` reports zero rather than a fee it cannot compute. Every other transaction in the listing keeps its correct values.
