### PR TITLE
Broadcast sync events only after committing the batch

### DIFF
--- a/lib/validator/cusf_enforcer.rs
+++ b/lib/validator/cusf_enforcer.rs
@@ -423,8 +423,10 @@ impl CusfEnforcer for Validator {
     ) -> Result<DisconnectBlockAction, Self::DisconnectBlockError> {
         let mut rwtxn = self.dbs.write_txn()?;
         let handler = BlockHandler::new(&self.dbs, self.network, self.network_params);
-        let () = handler.disconnect_block(&mut rwtxn, &self.events_tx, block_hash)?;
+        let mut events = Vec::new();
+        let () = handler.disconnect_block(&mut rwtxn, &mut events, block_hash)?;
         rwtxn.commit()?;
+        crate::validator::task::broadcast_events(&self.events_tx, events);
         Ok(DisconnectBlockAction::default())
     }
 

--- a/lib/validator/task/block_files.rs
+++ b/lib/validator/task/block_files.rs
@@ -97,9 +97,8 @@ fn process_cached_blocks(
 
             // Check if we should process batch
             if pending_blocks.len() >= BLOCKS_DIR_CONNECT_BATCH_SIZE || missing_blocks.is_empty() {
-                let mut rwtxn: RwTxn<'_> = dbs.write_txn()?;
-                handler.handle_block_batch(&mut rwtxn, pending_blocks, event_tx)?;
-                rwtxn.commit()?;
+                let rwtxn: RwTxn<'_> = dbs.write_txn()?;
+                handler.handle_block_batch_and_commit(rwtxn, pending_blocks, event_tx)?;
 
                 *total_handled_blocks += pending_blocks.len();
                 pending_blocks.clear();
@@ -198,9 +197,8 @@ pub fn sync_from_directory(
                     "syncing pending batch of {} blocks before shutdown",
                     pending_blocks.len()
                 );
-                let mut rwtxn = dbs.write_txn()?;
-                handler.handle_block_batch(&mut rwtxn, &pending_blocks, event_tx)?;
-                rwtxn.commit()?;
+                let rwtxn = dbs.write_txn()?;
+                handler.handle_block_batch_and_commit(rwtxn, &pending_blocks, event_tx)?;
             }
             return Err(error::Sync::Shutdown);
         }
@@ -268,9 +266,8 @@ pub fn sync_from_directory(
 
             // Check if we should process the current batch
             if pending_blocks.len() >= BLOCKS_DIR_CONNECT_BATCH_SIZE || missing_blocks.is_empty() {
-                let mut rwtxn = dbs.write_txn()?;
-                handler.handle_block_batch(&mut rwtxn, &pending_blocks, event_tx)?;
-                rwtxn.commit()?;
+                let rwtxn = dbs.write_txn()?;
+                handler.handle_block_batch_and_commit(rwtxn, &pending_blocks, event_tx)?;
 
                 total_handled_blocks += pending_blocks.len();
                 pending_blocks.clear();
@@ -309,9 +306,8 @@ pub fn sync_from_directory(
                         "syncing pending batch of {} blocks before aborting blocks dir sync",
                         pending_blocks.len()
                     );
-                    let mut rwtxn = dbs.write_txn()?;
-                    handler.handle_block_batch(&mut rwtxn, &pending_blocks, event_tx)?;
-                    rwtxn.commit()?;
+                    let rwtxn = dbs.write_txn()?;
+                    handler.handle_block_batch_and_commit(rwtxn, &pending_blocks, event_tx)?;
 
                     total_handled_blocks += pending_blocks.len();
                     pending_blocks.clear(); // Clear to avoid double processing
@@ -339,9 +335,8 @@ pub fn sync_from_directory(
             "handling final batch of {} blocks at end of file sync",
             pending_blocks.len()
         );
-        let mut rwtxn = dbs.write_txn()?;
-        handler.handle_block_batch(&mut rwtxn, &pending_blocks, event_tx)?;
-        rwtxn.commit()?;
+        let rwtxn = dbs.write_txn()?;
+        handler.handle_block_batch_and_commit(rwtxn, &pending_blocks, event_tx)?;
 
         total_handled_blocks += pending_blocks.len();
     }

--- a/lib/validator/task/mod.rs
+++ b/lib/validator/task/mod.rs
@@ -2275,6 +2275,75 @@ mod tests {
         Ok(())
     }
 
+    /// A batch that fails partway must not leave events behind for state the
+    /// aborted txn rolled back.
+    #[test]
+    fn failed_batch_broadcasts_no_events() -> Result<()> {
+        let (_dir, dbs) = create_test_dbs()?;
+        let sc = SidechainNumber(1);
+        {
+            let mut rwtxn = dbs.write_txn().into_diagnostic()?;
+            dbs.active_sidechains
+                .put_sidechain(&mut rwtxn, &sc, &test_sidechain(1, 0))
+                .into_diagnostic()?;
+            dbs.active_sidechains
+                .put_ctip(
+                    &mut rwtxn,
+                    sc,
+                    &Ctip {
+                        outpoint: OutPoint {
+                            txid: Txid::from_byte_array([0x11; 32]),
+                            vout: 0,
+                        },
+                        value: Amount::from_sat(5_000),
+                    },
+                )
+                .into_diagnostic()?;
+            rwtxn.commit().into_diagnostic()?;
+        }
+
+        let block_a = build_test_block(BlockHash::all_zeros(), TestBlockParts::default());
+        // Spends an outpoint that is not the tracked CTIP, so this block fails
+        // with `OldCtipUnspent`.
+        let block_b = build_test_block(
+            block_a.header.block_hash(),
+            TestBlockParts {
+                extra_txs: vec![build_m5_deposit_tx(
+                    sc,
+                    OutPoint::default(),
+                    Amount::from_sat(5_000),
+                    Amount::from_sat(1_000),
+                )],
+                ..Default::default()
+            },
+        );
+        {
+            let mut rwtxn = dbs.write_txn().into_diagnostic()?;
+            dbs.block_hashes
+                .put_headers(&mut rwtxn, &[(block_a.header, 0), (block_b.header, 1)])
+                .into_diagnostic()?;
+            rwtxn.commit().into_diagnostic()?;
+        }
+
+        let (event_tx, mut event_rx) = async_broadcast::broadcast(16);
+        let rwtxn = dbs.write_txn().into_diagnostic()?;
+        let res =
+            test_handler(&dbs).handle_block_batch_and_commit(rwtxn, &[block_a, block_b], &event_tx);
+        assert!(res.is_err(), "batch with an invalid block must fail");
+        assert!(
+            event_rx.try_recv().is_err(),
+            "no event may be delivered for a batch that never committed"
+        );
+        let rotxn = dbs.read_txn().into_diagnostic()?;
+        assert!(
+            dbs.current_chain_tip
+                .try_get(&rotxn, &())
+                .into_diagnostic()?
+                .is_none()
+        );
+        Ok(())
+    }
+
     #[test]
     fn connect_then_disconnect_restores_db_state() -> Result<()> {
         let (_dir, dbs) = create_test_dbs()?;

--- a/lib/validator/task/mod.rs
+++ b/lib/validator/task/mod.rs
@@ -1304,7 +1304,7 @@ impl BlockHandler<'_> {
     pub(in crate::validator) fn disconnect_block(
         &self,
         rwtxn: &mut RwTxn,
-        event_tx: &Sender<Event>,
+        events: &mut Vec<Event>,
         block_hash: BlockHash,
     ) -> Result<(), error::DisconnectBlock> {
         let dbs = self.dbs;
@@ -1333,9 +1333,15 @@ impl BlockHandler<'_> {
         } else {
             dbs.current_chain_tip.delete(rwtxn, &())?;
         }
-        let event = Event::DisconnectBlock { block_hash };
-        let _send_err: Result<Option<_>, TrySendError<_>> = event_tx.try_broadcast(event);
+        events.push(Event::DisconnectBlock { block_hash });
         Ok(())
+    }
+}
+
+/// Deliver events that a committed DB tx has already made durable.
+pub(in crate::validator) fn broadcast_events(event_tx: &Sender<Event>, events: Vec<Event>) {
+    for event in events {
+        let _send_err: Result<Option<_>, TrySendError<_>> = event_tx.try_broadcast(event);
     }
 }
 
@@ -1606,11 +1612,27 @@ where
 }
 
 impl BlockHandler<'_> {
-    pub(in crate::validator) fn handle_block_batch<'a>(
+    /// Handle a batch of blocks and commit, broadcasting the batch's events
+    /// only once the commit has succeeded. A later block in the batch can fail
+    /// and abort the txn, so events must not be sent from within the batch.
+    pub(in crate::validator) fn handle_block_batch_and_commit(
+        &self,
+        mut rwtxn: RwTxn<'_>,
+        blocks: &[Block],
+        event_tx: &Sender<Event>,
+    ) -> Result<(), error::Sync> {
+        let mut events = Vec::new();
+        let () = self.handle_block_batch(&mut rwtxn, blocks, &mut events)?;
+        let () = rwtxn.commit()?;
+        broadcast_events(event_tx, events);
+        Ok(())
+    }
+
+    fn handle_block_batch<'a>(
         &self,
         rwtxn: &mut RwTxn<'a>,
         blocks: &[Block],
-        event_tx: &Sender<Event>,
+        events: &mut Vec<Event>,
     ) -> Result<(), error::Sync> {
         let dbs = self.dbs;
         let start = Instant::now();
@@ -1687,7 +1709,7 @@ impl BlockHandler<'_> {
             }
             // Events should only ever be sent after committing DB txs, see
             // https://github.com/LayerTwo-Labs/bip300301_enforcer/pull/185
-            let _send_err: Result<Option<_>, TrySendError<_>> = event_tx.try_broadcast(event);
+            events.push(event);
         }
 
         tracing::info!(
@@ -1737,15 +1759,17 @@ impl BlockHandler<'_> {
                     tracing::info!(
                         "Disconnecting tip {current_enforcer_tip} -> {last_common_ancestor}"
                     );
+                    let mut events = Vec::new();
                     while current_enforcer_tip != last_common_ancestor {
                         let () =
-                            self.disconnect_block(&mut rwtxn, event_tx, current_enforcer_tip)?;
+                            self.disconnect_block(&mut rwtxn, &mut events, current_enforcer_tip)?;
                         current_enforcer_tip = dbs
                             .current_chain_tip
                             .try_get(&rwtxn, &())?
                             .unwrap_or_else(BlockHash::all_zeros);
                     }
                     rwtxn.commit()?;
+                    broadcast_events(event_tx, events);
                 } else {
                     rwtxn.abort();
                 }
@@ -1814,9 +1838,8 @@ impl BlockHandler<'_> {
             let blocks = fetch_blocks_batch(main_rpc_client, chunk).await?;
             total_blocks_fetched += blocks.len();
 
-            let mut rwtxn = dbs.write_txn()?;
-            self.handle_block_batch(&mut rwtxn, &blocks, event_tx)?;
-            rwtxn.commit()?;
+            let rwtxn = dbs.write_txn()?;
+            self.handle_block_batch_and_commit(rwtxn, &blocks, event_tx)?;
         }
 
         tracing::info!(
@@ -2270,7 +2293,7 @@ mod tests {
                 .is_none()
         );
 
-        let (event_tx, _) = async_broadcast::broadcast(16);
+        let mut events = Vec::new();
         let handler = test_handler(&dbs);
         let _event = handler
             .connect_block(&mut rwtxn, &block)
@@ -2283,7 +2306,7 @@ mod tests {
         );
 
         handler
-            .disconnect_block(&mut rwtxn, &event_tx, block_hash)
+            .disconnect_block(&mut rwtxn, &mut events, block_hash)
             .into_diagnostic()?;
         assert!(
             dbs.current_chain_tip


### PR DESCRIPTION
`handle_block_batch` broadcasts each block's `ConnectBlock` or `DisconnectBlock` event from inside the batch loop, while the caller commits the shared `rwtxn` only after the whole batch has been handled. The comment immediately above the `try_broadcast` call states the invariant it breaks:

> Events should only ever be sent after committing DB txs, see https://github.com/LayerTwo-Labs/bip300301_enforcer/pull/185

If a later block in the batch fails, the error propagates and the transaction is aborted, but the earlier blocks' events have already been delivered. Subscribers see a `ConnectBlock` for state that was rolled back, and see it again, out of order, when the batch is retried. The reorg path in `sync_blocks` has the same shape: it disconnects blocks in a loop that broadcasts as it goes, then commits afterwards. So does the real time `disconnect_block` in `cusf_enforcer.rs`.

This is a notification ordering defect only. The validator DB rolls back correctly, so there is no consensus, funds or mining impact.

## Fix

`handle_block_batch` and `disconnect_block` now collect their events into a `Vec` instead of broadcasting them. A new `handle_block_batch_and_commit` takes the `RwTxn` by value, commits it, and only then broadcasts, so the batch call sites cannot get the order wrong. The sync reorg loop and the real time disconnect path do the same: commit, then broadcast.
