### PR TITLE
wallet: do not fail block generation when BMM request cleanup fails

### DIFF
--- a/lib/wallet/error.rs
+++ b/lib/wallet/error.rs
@@ -1072,8 +1072,6 @@ impl ToStatus for GenerateSignetBlock {
 pub enum GenerateBlock {
     #[error(transparent)]
     CoinbaseBuilder(#[from] CoinbaseMessagesError),
-    #[error("failed to delete BMM requests")]
-    DeleteBmmRequests(#[source] rusqlite::Error),
     #[error(transparent)]
     GenerateCoinbaseTxouts(#[from] GenerateCoinbaseTxouts),
     #[error(transparent)]
@@ -1099,9 +1097,7 @@ impl ToStatus for GenerateBlock {
             Self::Mine(err) => err.builder(),
             Self::SelectBlockTxs(err) => err.builder(),
             Self::TryGetMainchainTip(err) => err.builder(),
-            Self::DeleteBmmRequests(_) | Self::PushBytesBuf(_) | Self::ValidatorNotSynced => {
-                StatusBuilder::new(self)
-            }
+            Self::PushBytesBuf(_) | Self::ValidatorNotSynced => StatusBuilder::new(self),
         }
     }
 }

--- a/lib/wallet/mine.rs
+++ b/lib/wallet/mine.rs
@@ -30,6 +30,8 @@ use futures::{
 
 use crate::{
     bins::{self, CommandExt as _},
+    block_producer::db::Db,
+    errors::ErrorChain,
     messages::CoinbaseBuilder,
     wallet::{
         Wallet,
@@ -540,6 +542,20 @@ impl Wallet {
         Ok(block_hash)
     }
 
+    /// Consume the BMM requests spent by a block that has already been
+    /// submitted. A failure is logged rather than returned: the block is
+    /// irreversible, so reporting the mine as failed makes the caller retry
+    /// and mine a second block carrying the same M7 BMM accept.
+    async fn consume_bmm_requests(db: &Db, mainchain_tip: &BlockHash, block_hash: &BlockHash) {
+        if let Err(err) = db.delete_bmm_requests(mainchain_tip, block_hash).await {
+            tracing::error!(
+                %block_hash,
+                "failed to delete BMM requests for mined block: {:#}",
+                ErrorChain::new(&err),
+            );
+        }
+    }
+
     /// Build and mine a single block
     async fn generate_block(
         &self,
@@ -585,12 +601,8 @@ impl Wallet {
         );
 
         let block_hash = self.mine(&coinbase_outputs, transactions).await?;
-        self.inner
-            .producer
-            .db()
-            .delete_bmm_requests(&mainchain_tip, &block_hash)
-            .await
-            .map_err(error::GenerateBlock::DeleteBmmRequests)?;
+        let () =
+            Self::consume_bmm_requests(self.inner.producer.db(), &mainchain_tip, &block_hash).await;
         Ok(block_hash)
     }
 

--- a/lib/wallet/mine.rs
+++ b/lib/wallet/mine.rs
@@ -631,3 +631,57 @@ impl Wallet {
         .fuse()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use bitcoin::{BlockHash, hashes::Hash as _};
+
+    use crate::{
+        block_producer::db::Db,
+        types::{BmmCommitment, SidechainNumber},
+        wallet::Wallet,
+    };
+
+    /// A mined block is irreversible, so a failing BMM request cleanup must not
+    /// be reported as a failure: the caller would retry and mine the same M7
+    /// twice.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn failed_bmm_request_cleanup_is_not_propagated() {
+        let dir = temp_dir::TempDir::new().unwrap();
+        let db = Db::new(dir.path()).unwrap();
+        let prev = BlockHash::from_byte_array([0x01; 32]);
+        let mined = BlockHash::from_byte_array([0x02; 32]);
+        assert!(
+            db.insert_new_bmm_request(SidechainNumber(1), prev, BmmCommitment([0x77; 32]),)
+                .await
+                .unwrap()
+        );
+
+        // A read-only data dir makes SQLite unable to write its journal, so the
+        // DELETE really fails.
+        let mut perms = std::fs::metadata(dir.path()).unwrap().permissions();
+        std::os::unix::fs::PermissionsExt::set_mode(&mut perms, 0o500);
+        std::fs::set_permissions(dir.path(), perms.clone()).unwrap();
+
+        let delete_failed = db.delete_bmm_requests(&prev, &mined).await.is_err();
+        if delete_failed {
+            let () = Wallet::consume_bmm_requests(&db, &prev, &mined).await;
+        }
+
+        std::os::unix::fs::PermissionsExt::set_mode(&mut perms, 0o700);
+        std::fs::set_permissions(dir.path(), perms).unwrap();
+
+        // A user that can write to a read-only dir (root) cannot fail the
+        // DELETE, so there is nothing to assert.
+        if !delete_failed {
+            tracing::warn!("skipped: the DELETE could not be made to fail");
+            return;
+        }
+        assert_eq!(
+            db.get_bmm_requests(&prev).await.unwrap().len(),
+            1,
+            "the requests survive the failed cleanup"
+        );
+    }
+}


### PR DESCRIPTION
`generate_block` mines and submits the block, and only then deletes the BMM requests it consumed:

```rust
let block_hash = self.mine(&coinbase_outputs, transactions).await?;
self.inner.producer.db()
    .delete_bmm_requests(&mainchain_tip, &block_hash)
    .await
    .map_err(error::GenerateBlock::DeleteBmmRequests)?;
```

`mine` has already called `submitblock`, which is irreversible. If the delete then fails, the `?` reports the whole block generation as failed even though a block was produced, and the `bmm_requests` rows survive keyed to the old tip. A caller that reacts to that error by retrying reads the same rows back through `get_bmm_requests(old_tip)` and can mine a second mainchain block carrying the same M7 BMM accept, which breaks the at most one acceptance per sidechain block expectation. The window is bounded by how long the validator takes to advance its tip.

Reaching the double commit needs a genuine SQLite failure plus a retry inside that window, so it is not easy to trigger. Reporting a successful, irreversible operation as failed is wrong on its own.

## Fix

Move the cleanup into `Wallet::consume_bmm_requests`, which logs a delete failure instead of returning it. The block is already on the network, so generation reports success, and no caller is invited to retry an operation that already happened. The rows stay keyed to the old tip, which is the same state that #439's restore path already treats as correct after a disconnect.

The `GenerateBlock::DeleteBmmRequests` error variant is now unused and removed.
