### PR TITLE
Restore sidechain ACKs deleted by a disconnected block

### DIFF
--- a/lib/block_producer/coinbase.rs
+++ b/lib/block_producer/coinbase.rs
@@ -50,7 +50,7 @@ impl BlockProducer {
 
     /// Sidechain proposals from the *validator*: already included in a block, and
     /// therefore votable.
-    fn get_active_sidechain_proposals(
+    pub(super) fn get_active_sidechain_proposals(
         &self,
     ) -> Result<HashMap<SidechainNumber, SidechainProposal>, crate::validator::GetSidechainsError>
     {
@@ -63,7 +63,7 @@ impl BlockProducer {
         Ok(pending_proposals)
     }
 
-    fn validate_sidechain_ack(
+    pub(super) fn validate_sidechain_ack(
         &self,
         ack: &SidechainAck,
         pending_proposals: &HashMap<SidechainNumber, SidechainProposal>,
@@ -170,12 +170,10 @@ impl BlockProducer {
         }
 
         for sidechain_ack in sidechain_acks {
+            // Stale rows are pruned on block connect, not here: a template is
+            // built many times per block, and a proposal missing from the
+            // validator's pending set can come back on a reorg.
             if !self.validate_sidechain_ack(&sidechain_ack, &active_sidechain_proposals) {
-                self.db().delete_sidechain_ack(&sidechain_ack).await?;
-                tracing::info!(
-                    "Unable to handle sidechain ack, deleted: {}",
-                    sidechain_ack.sidechain_number
-                );
                 continue;
             }
             if coinbase_builder

--- a/lib/block_producer/db.rs
+++ b/lib/block_producer/db.rs
@@ -22,6 +22,9 @@ pub(crate) type StoredBundleProposals = Vec<(M6id, BlindedM6<'static>)>;
 /// accumulate undo rows forever.
 const BMM_REQUESTS_UNDO_RETAINED_BLOCKS: i64 = 100;
 
+/// As [`BMM_REQUESTS_UNDO_RETAINED_BLOCKS`], for deleted sidechain ACKs.
+const SIDECHAIN_ACKS_UNDO_RETAINED_BLOCKS: i64 = 100;
+
 /// The drivechain policy database.
 pub struct Db {
     conn: tokio::sync::Mutex<Connection>,
@@ -111,6 +114,12 @@ impl Db {
                  ack_all_proposals BOOLEAN NOT NULL);
                  INSERT INTO block_producer_settings (id, ack_all_proposals)
                  VALUES (0, TRUE);",
+            ),
+            M::up(
+                "CREATE TABLE sidechain_acks_undo
+                (block_hash BLOB NOT NULL,
+                 number INTEGER NOT NULL,
+                 data_hash BLOB NOT NULL);",
             ),
         ]);
 
@@ -436,6 +445,41 @@ impl Db {
         snapshot_and_delete_bmm_requests(&mut connection, prev_blockhash, block_hash)
     }
 
+    /// Delete the stale sidechain ACKs settled by `block_hash`, snapshotting
+    /// them into `sidechain_acks_undo` so a reorg of that block can put the
+    /// operator's ACK intent back (see [`Self::restore_sidechain_acks`]).
+    pub(crate) async fn delete_stale_sidechain_acks(
+        &self,
+        block_hash: &bitcoin::BlockHash,
+        acks: &[SidechainAck],
+    ) -> Result<(), rusqlite::Error> {
+        if acks.is_empty() {
+            return Ok(());
+        }
+        let mut connection = self.conn.lock().await;
+        snapshot_and_delete_sidechain_acks(&mut connection, block_hash, acks)
+    }
+
+    /// Restore the sidechain ACKs deleted when `block_hash` was connected.
+    /// Called when that block is disconnected by a reorg, which can re-pend the
+    /// proposals those ACKs were for.
+    pub(crate) async fn restore_sidechain_acks(
+        &self,
+        block_hash: &bitcoin::BlockHash,
+    ) -> Result<(), rusqlite::Error> {
+        let restored = {
+            let mut connection = self.conn.lock().await;
+            restore_sidechain_acks_from_undo(&mut connection, block_hash)?
+        };
+        if restored > 0 {
+            tracing::info!(
+                %block_hash,
+                "restored {restored} sidechain ACK(s) from disconnected block",
+            );
+        }
+        Ok(())
+    }
+
     /// Restore the BMM requests that were consumed when `block_hash` was
     /// generated, moving them back out of `bmm_requests_undo`. Called when
     /// `block_hash` is disconnected by a reorg, so the operator's queued BMM
@@ -456,6 +500,65 @@ impl Db {
         }
         Ok(())
     }
+}
+
+/// Snapshot `acks` into `sidechain_acks_undo` keyed by `block_hash` and delete
+/// them from `sidechain_acks`, within a single transaction. Undo rows beyond
+/// the most recent `SIDECHAIN_ACKS_UNDO_RETAINED_BLOCKS` blocks are pruned so
+/// the table stays bounded.
+fn snapshot_and_delete_sidechain_acks(
+    connection: &mut Connection,
+    block_hash: &bitcoin::BlockHash,
+    acks: &[SidechainAck],
+) -> Result<(), rusqlite::Error> {
+    let tx = connection.transaction()?;
+    for ack in acks {
+        tx.execute(
+            "INSERT INTO sidechain_acks_undo (block_hash, number, data_hash) \
+             VALUES (?1, ?2, ?3);",
+            (
+                block_hash.as_byte_array(),
+                ack.sidechain_number.0,
+                ack.description_hash.as_byte_array(),
+            ),
+        )?;
+        tx.execute(
+            "DELETE FROM sidechain_acks WHERE number = ?1 AND data_hash = ?2;",
+            (ack.sidechain_number.0, ack.description_hash.as_byte_array()),
+        )?;
+    }
+    tx.execute(
+        "DELETE FROM sidechain_acks_undo \
+         WHERE block_hash NOT IN ( \
+             SELECT block_hash FROM sidechain_acks_undo \
+             GROUP BY block_hash \
+             ORDER BY MAX(rowid) DESC \
+             LIMIT ?1 \
+         );",
+        [SIDECHAIN_ACKS_UNDO_RETAINED_BLOCKS],
+    )?;
+    tx.commit()
+}
+
+/// Restore the ACKs snapshotted for `block_hash` back into `sidechain_acks`,
+/// removing them from `sidechain_acks_undo`. Returns the number of rows
+/// restored.
+fn restore_sidechain_acks_from_undo(
+    connection: &mut Connection,
+    block_hash: &bitcoin::BlockHash,
+) -> Result<usize, rusqlite::Error> {
+    let tx = connection.transaction()?;
+    let restored = tx.execute(
+        "INSERT OR IGNORE INTO sidechain_acks (number, data_hash) \
+         SELECT number, data_hash FROM sidechain_acks_undo WHERE block_hash = ?;",
+        [block_hash.as_byte_array()],
+    )?;
+    tx.execute(
+        "DELETE FROM sidechain_acks_undo WHERE block_hash = ?;",
+        [block_hash.as_byte_array()],
+    )?;
+    tx.commit()?;
+    Ok(restored)
 }
 
 /// Drop the legacy `wallet_seeds` table once it no longer holds a seed. This

--- a/lib/block_producer/db.rs
+++ b/lib/block_producer/db.rs
@@ -656,6 +656,69 @@ fn restore_bmm_requests_from_undo(
 }
 
 #[cfg(test)]
+mod sidechain_acks_undo_tests {
+    use bitcoin::{
+        BlockHash,
+        hashes::{Hash as _, sha256d},
+    };
+
+    use super::Db;
+    use crate::types::{SidechainAck, SidechainNumber};
+
+    /// An ACK dropped because its proposal left the validator's pending set is
+    /// restored when the block that settled it is disconnected, so the operator
+    /// keeps ACKing a re-pended slot.
+    #[tokio::test]
+    async fn sidechain_ack_restored_when_settling_block_disconnected() {
+        let dir = temp_dir::TempDir::new().unwrap();
+        let db = Db::new(dir.path()).unwrap();
+        let slot = SidechainNumber(7);
+        let description_hash = sha256d::Hash::from_byte_array([0x33; 32]);
+        let block_hash = BlockHash::from_byte_array([0x44; 32]);
+        db.ack_sidechain(slot, description_hash).await.unwrap();
+
+        let ack = SidechainAck {
+            sidechain_number: slot,
+            description_hash,
+        };
+        db.delete_stale_sidechain_acks(&block_hash, &[ack])
+            .await
+            .unwrap();
+        assert!(db.get_sidechain_acks().await.unwrap().is_empty());
+
+        db.restore_sidechain_acks(&block_hash).await.unwrap();
+        let restored = db.get_sidechain_acks().await.unwrap();
+        assert_eq!(restored.len(), 1);
+        assert_eq!(restored[0].sidechain_number, slot);
+        assert_eq!(restored[0].description_hash, description_hash);
+    }
+
+    /// Restoring a block that deleted nothing is a no-op.
+    #[tokio::test]
+    async fn restoring_an_unrelated_block_restores_nothing() {
+        let dir = temp_dir::TempDir::new().unwrap();
+        let db = Db::new(dir.path()).unwrap();
+        let slot = SidechainNumber(7);
+        let description_hash = sha256d::Hash::from_byte_array([0x33; 32]);
+        db.ack_sidechain(slot, description_hash).await.unwrap();
+        db.delete_stale_sidechain_acks(
+            &BlockHash::from_byte_array([0x44; 32]),
+            &[SidechainAck {
+                sidechain_number: slot,
+                description_hash,
+            }],
+        )
+        .await
+        .unwrap();
+
+        db.restore_sidechain_acks(&BlockHash::from_byte_array([0x55; 32]))
+            .await
+            .unwrap();
+        assert!(db.get_sidechain_acks().await.unwrap().is_empty());
+    }
+}
+
+#[cfg(test)]
 mod bmm_requests_undo_tests {
     use bitcoin::hashes::Hash as _;
     use rusqlite::Connection;

--- a/lib/block_producer/mod.rs
+++ b/lib/block_producer/mod.rs
@@ -95,13 +95,41 @@ impl BlockProducer {
         self.inner.validator.clone().connect_block(block).await
     }
 
+    /// Drop the stored ACKs whose proposal is no longer pending at this block,
+    /// snapshotting them so a reorg of the block can restore the intent.
+    async fn prune_sidechain_acks(&self, block_hash: &BlockHash) -> Result<(), rusqlite::Error> {
+        let stored_acks = self.db().get_sidechain_acks().await?;
+        if stored_acks.is_empty() {
+            return Ok(());
+        }
+        let pending_proposals = match self.get_active_sidechain_proposals() {
+            Ok(pending_proposals) => pending_proposals,
+            Err(err) => {
+                tracing::error!(
+                    "failed to read pending sidechain proposals: {:#}",
+                    ErrorChain::new(&err)
+                );
+                return Ok(());
+            }
+        };
+        let stale: Vec<_> = stored_acks
+            .into_iter()
+            .filter(|ack| !self.validate_sidechain_ack(ack, &pending_proposals))
+            .collect();
+        self.db()
+            .delete_stale_sidechain_acks(block_hash, &stale)
+            .await
+    }
+
     /// Policy-table maintenance for a block the validator just accepted: drop the
     /// sidechain proposals and withdrawal bundles that this block settled, so we
     /// stop re-proposing them in later coinbases.
     pub(crate) async fn apply_connected_block_policy(
         &self,
+        block_hash: &BlockHash,
         block_info: &crate::types::BlockInfo,
     ) -> Result<(), rusqlite::Error> {
+        let () = self.prune_sidechain_acks(block_hash).await?;
         let finalized_withdrawal_bundles =
             block_info
                 .withdrawal_bundle_events()
@@ -160,7 +188,9 @@ impl CusfEnforcer for BlockProducer {
             let block_hash = block.block_hash();
             let block_infos = self.inner.validator.get_block_infos(&block_hash, 0)?;
             for (_header_info, block_info) in &block_infos {
-                let () = self.apply_connected_block_policy(block_info).await?;
+                let () = self
+                    .apply_connected_block_policy(&block_hash, block_info)
+                    .await?;
             }
         }
         Ok(res)
@@ -190,11 +220,19 @@ impl CusfEnforcer for BlockProducer {
                 ErrorChain::new(&err),
             );
         }
+        if let Err(err) = self.inner.db.restore_sidechain_acks(&block_hash).await {
+            tracing::error!(
+                %block_hash,
+                "failed to restore sidechain ACKs on block disconnect: {:#}",
+                ErrorChain::new(&err),
+            );
+        }
 
-        // Aside from `bmm_requests` (restored above), no disconnect logic is
-        // applied to the rest of the policy DB. Those tables are wiped upon
-        // generating a new block, so sidechain proposals etc. must be re-created
-        // if a block that brought one into existence is disconnected.
+        // Aside from `bmm_requests` and `sidechain_acks` (restored above), no
+        // disconnect logic is applied to the rest of the policy DB. Those tables
+        // are wiped upon generating a new block, so sidechain proposals etc.
+        // must be re-created if a block that brought one into existence is
+        // disconnected.
         Ok(res)
     }
 

--- a/lib/wallet/sync.rs
+++ b/lib/wallet/sync.rs
@@ -65,7 +65,7 @@ impl WalletInner {
         let mut wallet_write = self.write_wallet().await?;
         let () = self
             .producer
-            .apply_connected_block_policy(block_info)
+            .apply_connected_block_policy(&block.block_hash(), block_info)
             .await?;
         let mut database = self.bdk_db.lock().await;
         tracing::trace!("applying block to BDK wallet");


### PR DESCRIPTION
`extend_coinbase_txouts` deletes a stored sidechain ACK whenever `validate_sidechain_ack` returns false, that is, whenever the proposal it refers to is no longer in the validator's pending set. `disconnect_block` performs no SQLite work for `sidechain_acks`, so once a reorg re-pends that slot the operator's ACK intent is gone. With `ack_all_proposals=false` the producer simply stops emitting the M2 for that slot and the vote count stops advancing for its blocks, until the operator acks it again by hand.

This is the same gap as the one fixed for `bmm_requests` in #439, on the neighbouring table. It is also adjacent to #383, which tracks the same reorg blindness for `bundle_proposals` and `sidechain_proposals`.

There is a second problem with the current placement: template generation is a read path that runs many times per block, and it is mutating policy state based on a validator view that a reorg can take back.

## Fix

Follow the shape #439 established.

- `extend_coinbase_txouts` no longer deletes. It skips an ACK it cannot validate and leaves the row alone.
- Pruning moves to block connect, where there is a block hash to key on. `prune_sidechain_acks` drops the ACKs whose proposal is no longer pending at that block, snapshotting them into a new `sidechain_acks_undo` table first.
- `disconnect_block` restores them, alongside the existing `bmm_requests` restore. Undo rows are pruned to the most recent 100 producing blocks so the table stays bounded, matching `BMM_REQUESTS_UNDO_RETAINED_BLOCKS`.

Behaviour for an ACK stored against a proposal that is not yet on chain is unchanged: it was already dropped by the next template call, and is now dropped by the next block connect instead.
