### PR TITLE
fix: Reject CreateDepositTransaction where fee_sats exceeds value_sats

### DIFF
--- a/lib/server/wallet/grpc.rs
+++ b/lib/server/wallet/grpc.rs
@@ -271,6 +271,11 @@ impl WalletService for crate::wallet::Wallet {
             unwrap_u64(fee_sats)
                 .ok_or_else(|| missing_field::<CreateDepositTransactionRequest>("fee_sats"))?,
         );
+        if fee > value {
+            return Err(ConnectError::invalid_argument(
+                "fee_sats must not be greater than value_sats",
+            ));
+        }
         if !self
             .is_sidechain_active(sidechain_number)
             .map_err(|err| err.builder().to_connect_error())?


### PR DESCRIPTION
### What's wrong

`create_deposit_transaction` (`lib/server/wallet/grpc.rs`) sanity-checks two of its three value-bearing arguments: `address` must be non-empty and `value_sats` must be greater than zero. `fee_sats` is taken as-is and passed through `Wallet::create_deposit` into `create_deposit_psbt`, which calls `builder.fee_absolute(fee)`. Because that fee is absolute rather than rate-derived, nothing downstream relates it back to the deposit value, so a request where `fee_sats > value_sats` builds, signs and broadcasts without complaint.

The realistic way to hit this is transposed arguments: a caller means a 100,000-sat deposit with a 2,000-sat fee, sends them the other way round, and pays 100,000 sats of miner fee on a 2,000-sat deposit. There is no error or warning on the way out.

### The fix

One guard next to the existing zero-value check: if `fee > value`, return `invalid_argument("fee_sats must not be greater than value_sats")` before any wallet work is done.

This is a judgement call rather than anything the spec requires — it is an argument sanity check in the same spirit as the existing `value_sats must be greater than zero` guard, and it only rejects requests that are near-certainly a mistake. Happy to downgrade it to a `tracing::warn!` or drop it if you'd rather callers keep full control. No test added; glad to add one if useful.

Finding report (access-controlled): https://giaki3003.tech/#/findings/20260623-0454-glmclaw-confirm-kimiclaw-bip300301_enforcer-create-deposit-fee-exceeds-value

---
First of a short series of 1 fixes for this repo, based on `master`. The rest build on this branch and will follow.