### PR TITLE
block producer: better wait for block connection

### DIFF
--- a/lib/block_producer/error.rs
+++ b/lib/block_producer/error.rs
@@ -224,8 +224,37 @@ impl ToStatus for FinalizeBlock {
     }
 }
 
+/// Waiting for the validator's connect-block pipeline to process a block
+/// that was just submitted to Bitcoin Core.
+#[derive(Debug, Diagnostic, Error)]
+pub enum AwaitBlockConnection {
+    #[error(
+        "timed out waiting for validator to connect block `{block_hash}` after {timeout:?}: \
+         the enforcer has fallen behind Bitcoin Core, or rejected the block"
+    )]
+    Timeout {
+        block_hash: bitcoin::BlockHash,
+        timeout: std::time::Duration,
+    },
+    #[error(transparent)]
+    TryGetBlockInfos(#[from] crate::validator::TryGetBlockInfosError),
+}
+
+impl ToStatus for AwaitBlockConnection {
+    fn builder(&self) -> StatusBuilder<'_> {
+        match self {
+            err @ Self::Timeout { .. } => {
+                StatusBuilder::new(err).code(connectrpc::ErrorCode::DeadlineExceeded)
+            }
+            Self::TryGetBlockInfos(_) => StatusBuilder::new(self),
+        }
+    }
+}
+
 #[derive(Debug, Diagnostic, Error)]
 pub enum Mine {
+    #[error(transparent)]
+    AwaitBlockConnection(#[from] AwaitBlockConnection),
     #[error(transparent)]
     BitcoinCoreRPC(#[from] BitcoinCoreRPC),
     #[error(transparent)]
@@ -240,6 +269,7 @@ pub enum Mine {
 impl ToStatus for Mine {
     fn builder(&self) -> StatusBuilder<'_> {
         match self {
+            Self::AwaitBlockConnection(err) => err.builder(),
             Self::BitcoinCoreRPC(err) => err.builder(),
             Self::EncodeBlock(err) => err.builder(),
             Self::FinalizeBlock(err) => err.builder(),
@@ -331,6 +361,8 @@ impl ToStatus for GetSignetMinerPath {
 
 #[derive(Diagnostic, Debug, Error)]
 pub enum GenerateSignetBlock {
+    #[error(transparent)]
+    AwaitBlockConnection(#[from] AwaitBlockConnection),
     #[error("failed to fetch most recent block hash")]
     FetchMostRecentBlockHash(#[source] BitcoinCoreRPC),
     #[error(transparent)]
@@ -348,6 +380,7 @@ pub enum GenerateSignetBlock {
 impl ToStatus for GenerateSignetBlock {
     fn builder(&self) -> StatusBuilder<'_> {
         match self {
+            Self::AwaitBlockConnection(err) => err.builder(),
             Self::FetchMostRecentBlockHash(err) => StatusBuilder::with_code(self, err.builder()),
             Self::GetHeaderInfo(err) => err.builder(),
             Self::GetMainchainTip(err) => err.builder(),

--- a/lib/block_producer/mine.rs
+++ b/lib/block_producer/mine.rs
@@ -239,8 +239,43 @@ impl BlockProducer {
         }
         let block_hash = block.header.block_hash();
         tracing::info!(%block_hash, %transaction_count, "Submitted block");
-        tokio::time::sleep(Duration::from_millis(500)).await;
+        let () = self.await_block_connection(block_hash).await?;
         Ok(block_hash)
+    }
+
+    /// Wait until the validator has processed `block_hash`. A successful
+    /// `submitblock` only means Bitcoin Core accepted the block. The
+    /// enforcer syncs it asynchronously, so returning before the validator
+    /// has caught up would let the next block template build on a stale
+    /// tip, which again would lead to Bitcoin Core rejecting blocks as duplicate.
+    async fn await_block_connection(
+        &self,
+        block_hash: BlockHash,
+    ) -> Result<(), error::AwaitBlockConnection> {
+        const TIMEOUT: Duration = Duration::from_secs(10);
+        const POLL_INTERVAL: Duration = Duration::from_millis(25);
+        let poll = async {
+            loop {
+                // Block info is written in the same DB transaction that
+                // advances the validator tip, so once it is present the
+                // validator's view includes `block_hash`, even if the tip
+                // has since moved past it.
+                if self
+                    .validator()
+                    .try_get_block_infos(&block_hash, 0)?
+                    .is_some()
+                {
+                    return Ok(());
+                }
+                tokio::time::sleep(POLL_INTERVAL).await;
+            }
+        };
+        tokio::time::timeout(TIMEOUT, poll)
+            .await
+            .map_err(|_elapsed| error::AwaitBlockConnection::Timeout {
+                block_hash,
+                timeout: TIMEOUT,
+            })?
     }
 
     fn check_has_binary(&self, binary: &Path) -> Result<(), error::MissingBinary> {
@@ -542,6 +577,8 @@ impl BlockProducer {
         })?;
 
         tracing::info!("Generated signet block: {}", block_hash);
+
+        let () = self.await_block_connection(block_hash).await?;
 
         Ok(block_hash)
     }


### PR DESCRIPTION
Under high load (i.e. integration tests) block templates would create invalid blocks for a very short time.