### PR TITLE
Speed up integration tests

### DIFF
--- a/integration_tests/setup.rs
+++ b/integration_tests/setup.rs
@@ -146,32 +146,6 @@ impl SignetSetup {
         Ok(())
     }
 
-    async fn calibrate_signet(&self, signet_miner: &mut bins::SignetMiner) -> anyhow::Result<()> {
-        let calibrate_output = signet_miner
-            .command("calibrate", vec!["--seconds=1"])
-            .run_utf8()
-            .await?;
-        let nbits_hex = {
-            calibrate_output
-                .strip_prefix("nbits=")
-                .ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "Missing nbits prefix from calibration output: `{calibrate_output}`",
-                    )
-                })?
-                .split_once(" ")
-                .ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "Missing nbits suffix from calibration output: `{calibrate_output}`",
-                    )
-                })?
-                .0
-                .to_owned()
-        };
-        signet_miner.nbits = Some(hex::FromHex::from_hex(&nbits_hex)?);
-        Ok(())
-    }
-
     /// Configure signet miner to use enforcer's GBT server
     fn configure_miner(
         signet_miner: &mut bins::SignetMiner,
@@ -578,20 +552,22 @@ impl PostSetup {
                 .parse::<Address<_>>()?
                 .require_network(bitcoind.network)?
         };
-        let mut signet_miner = if let Some(signet_setup) = signet_setup.as_ref() {
-            let mut signet_miner = bins::SignetMiner {
+        let mut signet_miner = if signet_setup.is_some() {
+            Some(bins::SignetMiner {
                 path: bin_paths.signet_miner()?.clone(),
                 bitcoin_cli: bitcoin_cli.clone(),
                 bitcoin_util: bin_paths.bitcoin_util()?.clone(),
                 block_interval: None,
                 coinbase_recipient: Some(mining_address.clone()),
                 debug: false,
+                // `None` makes the miner pass `--min-nbits`, grinding at
+                // signet's floor difficulty. Calibrating for ~1s/block here
+                // instead adds ~1s of pure grinding per mined block, which
+                // dominates signet test runtime.
                 nbits: None,
                 getblocktemplate_command: None,
                 coinbasetxn: false,
-            };
-            let () = signet_setup.calibrate_signet(&mut signet_miner).await?;
-            Some(signet_miner)
+            })
         } else {
             None
         };

--- a/integration_tests/util.rs
+++ b/integration_tests/util.rs
@@ -694,6 +694,10 @@ impl Bitcoind {
     {
         let mut default_args = vec![
             "-acceptnonstdtxn".to_owned(),
+            // Skip wallet sqlite fsyncs; they otherwise dominate wallet-heavy
+            // test runtime. Only unsafe on OS crash/power loss, which never
+            // matters for throwaway test datadirs.
+            "-unsafesqlitesync=1".to_owned(),
             format!("-chain={}", self.network.to_core_arg()),
             format!("-datadir={}", self.data_dir.display()),
             format!("-bind=127.0.0.1:{}", self.listen_port),


### PR DESCRIPTION
`unsafesqlitesync=1` on Bitcoin Core and grinding lower difficulty targets on signet each yields 20-25% performance increases in the authors machine.