### PR TITLE
Expand integration test matrix with drynet3

### DIFF
--- a/.github/workflows/check_lint_build_release.yaml
+++ b/.github/workflows/check_lint_build_release.yaml
@@ -141,11 +141,14 @@ jobs:
       - name: Check for unused dependencies
         run: cargo shear --deny-warnings
 
-  # Parses `CI_BITCOIN_CORE_VERSIONS` out of `lib/version.rs` and emits
+  # Parses `CI_BITCOIN_CORE_VERSIONS` out of `lib/version.rs` and the
+  # drynet tag out of `scripts/setup_integration_tests.sh`, and emits
   # the integration-test matrix. Keeping the list of stock versions in
   # source means the Rust-side `SUPPORTED_BITCOIN_CORE_MAJORS` and the CI
   # matrix can't drift — a unit test (`ci_versions_match_majors`) asserts
-  # the two are consistent.
+  # the two are consistent. The drynet tag lives in the setup script so
+  # local `just test-it --bitcoind drynetN` runs and CI exercise the same
+  # release.
   compute-integration-matrix:
     name: Compute integration-test matrix
     runs-on: ubuntu-latest
@@ -154,7 +157,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Parse CI_BITCOIN_CORE_VERSIONS from lib/version.rs
+      - name: Build matrix from lib/version.rs + setup_integration_tests.sh
         id: build
         run: |
           set -euo pipefail
@@ -171,18 +174,29 @@ jobs:
               exit 1
             fi
           done
-          ITEMS='{"flavor":"patched"}'
+          DRYNET_TAG=$(grep -oE '^DRYNET_DEFAULT_REVISION="[^"]+"' scripts/setup_integration_tests.sh | cut -d'"' -f2)
+          if [ -z "$DRYNET_TAG" ]; then
+            echo "could not parse DRYNET_DEFAULT_REVISION from scripts/setup_integration_tests.sh" >&2
+            exit 1
+          fi
+          # Every entry carries a display `name` plus either `zip` (a
+          # drivechain-patched build fetched from releases.drivechain.info,
+          # runs the full suite) or `version` (a stock release fetched from
+          # bitcoincore.org, skips drivechain-consensus tests). Steps key
+          # off those fields, not off which entry they are. `grpc_checks`
+          # marks the one entry that also runs the flavor-independent gRPC
+          # reflection checks.
+          ITEMS='{"name":"bitcoin-patched","zip":"L1-bitcoin-patched-latest","grpc_checks":true}'
+          ITEMS="$ITEMS,{\"name\":\"ecash-bitcoin $DRYNET_TAG\",\"zip\":\"L1-ecash-bitcoin-$DRYNET_TAG\"}"
           for v in $VERSIONS; do
-            ITEMS="$ITEMS,{\"flavor\":\"stock\",\"version\":\"$v\"}"
+            ITEMS="$ITEMS,{\"name\":\"Bitcoin Core $v\",\"version\":\"$v\"}"
           done
           MATRIX="{\"include\":[${ITEMS}]}"
           echo "matrix=${MATRIX}" >> "$GITHUB_OUTPUT"
           echo "$MATRIX"
 
   integration-test:
-    name:
-      Integration test (${{ matrix.flavor == 'patched' && 'bitcoin-patched' ||
-      format('Bitcoin Core {0}', matrix.version) }})
+    name: Integration test (${{ matrix.name }})
     needs: compute-integration-matrix
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -193,21 +207,22 @@ jobs:
       ELECTRS_VERSION: v3.2.0
       GRPCURL_VERSION: "1.9.3"
     steps:
-      - name: Download Bitcoin Core (patched)
-        if: matrix.flavor == 'patched'
+      - name: Download drivechain-patched Bitcoin Core (${{ matrix.name }})
+        if: matrix.zip
         run: |
           pushd ..
-          wget https://releases.drivechain.info/L1-bitcoin-patched-latest-x86_64-unknown-linux-gnu.zip
-          unzip L1-bitcoin-patched-latest-x86_64-unknown-linux-gnu.zip
-          rm L1-bitcoin-patched-latest-x86_64-unknown-linux-gnu.zip
-          mv L1-bitcoin-patched-latest-x86_64-unknown-linux-gnu bitcoin-bins
+          DIR='${{ matrix.zip }}-x86_64-unknown-linux-gnu'
+          wget "https://releases.drivechain.info/${DIR}.zip"
+          unzip "${DIR}.zip"
+          rm "${DIR}.zip"
+          mv "${DIR}" bitcoin-bins
           chmod +x bitcoin-bins/bitcoind
           chmod +x bitcoin-bins/bitcoin-cli
           chmod +x bitcoin-bins/bitcoin-util
           popd
 
       - name: Download Bitcoin Core (stock ${{ matrix.version }})
-        if: matrix.flavor == 'stock'
+        if: matrix.version
         run: |
           pushd ..
           VERSION='${{ matrix.version }}'
@@ -227,9 +242,9 @@ jobs:
           tests)
         # `test_peer_bmm_request` exercises a cross-binary p2p path via
         # `BITCOIND_UNPATCHED`. For the stock matrix we reuse the same
-        # stock binary; for the patched job we still want a stock 30.2
-        # alongside the patched binaries.
-        if: matrix.flavor == 'patched'
+        # stock binary; for the drivechain-patched jobs we still want a
+        # stock 30.2 alongside the patched binaries.
+        if: matrix.zip
         run: |
           pushd ..
           wget https://bitcoincore.org/bin/bitcoin-core-30.2/bitcoin-30.2-x86_64-linux-gnu.tar.gz
@@ -246,10 +261,10 @@ jobs:
         # requires `SIGNET_MINER` to point at the script. Stock Bitcoin
         # Core tarballs don't ship `contrib/signet/miner`, and the
         # patched variant's `--getblocktemplate-command` support is what
-        # our signet tests rely on — so we fetch it here for both flavors.
+        # our signet tests rely on — so we fetch it here for every flavor.
         run: |
           pushd ..
-          git clone https://github.com/LayerTwo-Labs/bitcoin-patched.git
+          git clone --depth 1 https://github.com/LayerTwo-Labs/bitcoin-patched.git
           popd
 
       - name: Cache electrs binary
@@ -287,13 +302,13 @@ jobs:
       # build; gated to a single matrix entry since the result does not
       # depend on the Bitcoin Core flavor.
       - name: Install buf
-        if: matrix.flavor == 'patched'
+        if: matrix.grpc_checks
         uses: bufbuild/buf-action@v1
         with:
           setup_only: true
 
       - name: Cache grpcurl
-        if: matrix.flavor == 'patched'
+        if: matrix.grpc_checks
         id: cache-grpcurl
         uses: actions/cache@v6
         with:
@@ -302,7 +317,7 @@ jobs:
 
       - name: Install grpcurl
         if: |
-          matrix.flavor == 'patched' &&
+          matrix.grpc_checks &&
           steps.cache-grpcurl.outputs.cache-hit != 'true'
         run: |
           mkdir -p ~/grpcurl-bin
@@ -310,7 +325,7 @@ jobs:
           tar -xzf "grpcurl_${GRPCURL_VERSION}_linux_x86_64.tar.gz" -C ~/grpcurl-bin grpcurl
 
       - name: Verify gRPC reflection (grpcurl + buf curl)
-        if: matrix.flavor == 'patched'
+        if: matrix.grpc_checks
         run: |
           export PATH="$HOME/grpcurl-bin:$PATH"
           export BITCOIND='../bitcoin-bins/bitcoind'
@@ -321,9 +336,19 @@ jobs:
         # Stock Bitcoin Core rejects drivechain deposit transactions with
         # `mempool-script-verify-flag-failed (NOPx reserved for soft-fork
         # upgrades)` — the consensus rules repurposing those opcodes only
-        # live in bitcoin-patched — so we skip `deposit_withdraw_roundtrip`
-        # on stock. The remaining tests exercise RPC, block-parser, p2p,
-        # and mempool integration with upstream Bitcoin Core.
+        # live in the drivechain-patched builds — so we skip
+        # `deposit_withdraw_roundtrip` on stock. The remaining tests
+        # exercise RPC, block-parser, p2p, and mempool integration with
+        # upstream Bitcoin Core. Drivechain-patched builds (`matrix.zip`
+        # entries) run the full suite.
+        #
+        # BITCOIND_HAS_DRIVECHAIN=0 tells the harness that BITCOIND is a
+        # stock build, so it spawns it with -acceptnonstdtxn. Patched
+        # builds run with real standardness policy — with the flag,
+        # IsStandardTx is disabled and a patched build whose OP_DRIVECHAIN
+        # outputs classify as non-standard would pass the deposit test
+        # here while rejecting deposits with -26 "scriptpubkey" in
+        # production, where chain=main forbids the flag.
         run: |
           export BIP300301_ENFORCER='target/debug/bip300301_enforcer'
           export BITCOIND='../bitcoin-bins/bitcoind'
@@ -337,12 +362,14 @@ jobs:
           # them as artifacts when a test fails.
           export TMPDIR="$RUNNER_TEMP/it-logs"
           mkdir -p "$TMPDIR"
-          if [ '${{ matrix.flavor }}' = 'patched' ]; then
-            export BITCOIND_UNPATCHED='../bitcoin-unpatched-bins/bitcoind'
-            cargo run --example integration_tests
-          else
+          if [ -n '${{ matrix.version }}' ]; then
             export BITCOIND_UNPATCHED='../bitcoin-bins/bitcoind'
+            export BITCOIND_HAS_DRIVECHAIN=0
             cargo run --example integration_tests -- --skip deposit_withdraw_roundtrip
+          else
+            export BITCOIND_UNPATCHED='../bitcoin-unpatched-bins/bitcoind'
+            export BITCOIND_HAS_DRIVECHAIN=1
+            cargo run --example integration_tests
           fi
 
       - name: Upload integration test logs
@@ -353,9 +380,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v7
         with:
-          name:
-            integration-test-logs-${{ matrix.flavor == 'patched' && 'patched' ||
-            format('stock-{0}', matrix.version) }}
+          name: integration-test-logs-${{ matrix.name }}
           path: |
             ${{ runner.temp }}/it-logs/**/*.txt
             ${{ runner.temp }}/it-logs/**/*.log

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,5 @@ bip300301_enforcer.mdb
 datadir
 datadir-sync-benchmark*
 sync_analysis
-integrationtests.env
+integrationtests*.env
 local.just

--- a/Justfile
+++ b/Justfile
@@ -59,13 +59,10 @@ fmt:
     bunx prettier --write .
     buf format -w proto
 
-# Run integration tests
+# Run integration tests. `--bitcoind` selects the Bitcoin Core build
+# (default: bitcoin-patched): bitcoin-patched, unpatched (newest stock),
+# stock-X.Y (a specific stock release), drynetN, or all (every flavor in
+# the CI matrix, continuing past failures); remaining args go to the test
+# runner.
 test-it *args='':
-    #!/usr/bin/env bash
-    set -euo pipefail
-    if [ ! -f '{{ justfile_directory() }}/integrationtests.env' ]; then
-        '{{ justfile_directory() }}/scripts/setup_integration_tests.sh'
-    fi
-    cargo build
-    env BIP300301_ENFORCER_INTEGRATION_TEST_ENV='{{ justfile_directory() }}/integrationtests.env' \
-        cargo run --example integration_tests -- {{ args }}
+    '{{ justfile_directory() }}/scripts/run_integration_tests.sh' {{ args }}

--- a/README.md
+++ b/README.md
@@ -190,6 +190,17 @@ Integration tests can be run using
 $ cargo run --example integration_tests -- <TEST ARGS>
 ```
 
+or via the just recipe, which downloads the required binaries and writes the env
+files on first run. `--bitcoind` selects the Bitcoin Core build to run against:
+
+```bash
+$ just test-it                            # against bitcoin-patched (default)
+$ just test-it --bitcoind unpatched       # against the newest stock Bitcoin Core
+$ just test-it --bitcoind stock-30.2      # against a specific stock release
+$ just test-it --bitcoind drynet3         # against the ecash-com/bitcoin drynet fork
+$ just test-it --bitcoind all             # against every flavor in the CI matrix
+```
+
 # Profiling
 
 ```bash

--- a/integration_tests/example.env
+++ b/integration_tests/example.env
@@ -1,5 +1,9 @@
 BIP300301_ENFORCER='target/debug/bip300301_enforcer'
 BITCOIND='../bitcoin-patched/build/src/bitcoind'
+# Whether BITCOIND is a drivechain-patched build. Stock builds ('0') are
+# spawned with -acceptnonstdtxn; patched builds ('1', the default) run
+# with real standardness policy so OP_DRIVECHAIN policy bugs surface.
+BITCOIND_HAS_DRIVECHAIN='1'
 BITCOIND_UNPATCHED='../bitcoin/build/src/bitcoind'
 BITCOIN_CLI='../bitcoin/build/src/bitcoin-cli'
 BITCOIN_UTIL='../bitcoin/build/src/bitcoin-util'

--- a/integration_tests/setup.rs
+++ b/integration_tests/setup.rs
@@ -240,14 +240,15 @@ impl ReservedPorts {
 }
 
 pub fn new_bitcoind(
-    bitcoind_path: PathBuf,
+    bin_paths: &BinPaths,
+    bitcoind_kind: BitcoindKind,
     data_dir: PathBuf,
     reserved_ports: &ReservedPorts,
     network: Network,
     signet_setup: Option<&SignetSetup>,
-) -> Bitcoind {
-    Bitcoind {
-        path: bitcoind_path,
+) -> Result<Bitcoind, crate::util::VarError> {
+    Ok(Bitcoind {
+        path: bitcoind_path(bin_paths, bitcoind_kind)?.clone(),
         data_dir,
         listen_port: reserved_ports.bitcoind_listen.port(),
         network: network.into(),
@@ -259,9 +260,10 @@ pub fn new_bitcoind(
         signet_challenge: signet_setup
             .as_ref()
             .map(|setup| setup.signet_challenge.clone()),
+        accept_nonstd_txns: bitcoind_kind.accept_nonstd_txns(),
         txindex: true,
         zmq_sequence_port: reserved_ports.bitcoind_zmq_sequence.port(),
-    }
+    })
 }
 
 /// Waits for a TCP port to become available by attempting to connect periodically.
@@ -487,6 +489,24 @@ pub enum BitcoindKind {
     Unpatched,
 }
 
+impl BitcoindKind {
+    /// Whether nodes of this kind run with `-acceptnonstdtxn`. Only
+    /// genuinely stock Bitcoin Core gets the flag — on drivechain-patched
+    /// builds OP_DRIVECHAIN txs are supposed to be *standard*, and running
+    /// them with standardness disabled would mask policy regressions that
+    /// break deposits on mainnet (where the flag is unavailable).
+    pub fn accept_nonstd_txns(self) -> bool {
+        match self {
+            // `BITCOIND_UNPATCHED` always points at a stock release.
+            Self::Unpatched => true,
+            // `BITCOIND` is drivechain-patched unless the run says
+            // otherwise: the stock flavors (env files and CI matrix
+            // entries) set `BITCOIND_HAS_DRIVECHAIN=0`.
+            Self::Patched => std::env::var("BITCOIND_HAS_DRIVECHAIN").is_ok_and(|v| v == "0"),
+        }
+    }
+}
+
 fn bitcoind_path(
     bin_paths: &BinPaths,
     bitcoind_kind: BitcoindKind,
@@ -585,12 +605,13 @@ impl PostSetup {
 
         tracing::debug!("Starting bitcoin node");
         let mut bitcoind = new_bitcoind(
-            bitcoind_path(bin_paths, opts.bitcoind_kind)?.clone(),
+            bin_paths,
+            opts.bitcoind_kind,
             dirs.bitcoin_dir.clone(),
             &reserved_ports,
             network,
             signet_setup.as_ref(),
-        );
+        )?;
         bitcoind.txindex = enable_wallet;
         let bitcoind_task =
             bitcoind.spawn_command_with_args::<String, _, _, _, _>([], opts.bitcoind_args, {

--- a/integration_tests/test_file_based_block_parser.rs
+++ b/integration_tests/test_file_based_block_parser.rs
@@ -8,7 +8,8 @@ use futures::channel::mpsc;
 
 use crate::{
     setup::{
-        PreSetup, new_bitcoind, wait_for_bitcoind_ready, wait_for_port, wait_for_validator_synced,
+        BitcoindKind, PreSetup, new_bitcoind, wait_for_bitcoind_ready, wait_for_port,
+        wait_for_validator_synced,
     },
     util::Enforcer,
 };
@@ -17,12 +18,13 @@ pub async fn test_file_based_block_parser(setup: PreSetup) -> anyhow::Result<()>
     let (res_tx, _) = mpsc::unbounded::<anyhow::Result<()>>();
 
     let bitcoind = new_bitcoind(
-        setup.bin_paths.bitcoind()?.clone(),
+        &setup.bin_paths,
+        BitcoindKind::Patched,
         setup.directories.bitcoin_dir.clone(),
         &setup.reserved_ports,
         setup.network,
         None,
-    );
+    )?;
 
     tracing::info!("Starting bitcoind for the first time");
     let first_bitcoind = bitcoind.spawn_command_with_args::<String, String, _, _, _>([], [], {

--- a/integration_tests/util.rs
+++ b/integration_tests/util.rs
@@ -660,6 +660,9 @@ pub struct Bitcoind {
     pub rpc_port: u16,
     pub rpc_host: String,
     pub signet_challenge: Option<bitcoin::ScriptBuf>,
+    /// Add `-acceptnonstdtxn`. Only set for stock Bitcoin Core nodes; see
+    /// [`crate::setup::BitcoindKind::accept_nonstd_txns`].
+    pub accept_nonstd_txns: bool,
     pub txindex: bool,
     pub zmq_sequence_port: u16,
 }
@@ -693,7 +696,6 @@ impl Bitcoind {
         F: FnOnce(anyhow::Error) + Send + 'static,
     {
         let mut default_args = vec![
-            "-acceptnonstdtxn".to_owned(),
             // Skip wallet sqlite fsyncs; they otherwise dominate wallet-heavy
             // test runtime. Only unsafe on OS crash/power loss, which never
             // matters for throwaway test datadirs.
@@ -708,6 +710,9 @@ impl Bitcoind {
             "-server".to_owned(),
             format!("-zmqpubsequence=tcp://127.0.0.1:{}", self.zmq_sequence_port),
         ];
+        if self.accept_nonstd_txns {
+            default_args.push("-acceptnonstdtxn".to_owned());
+        }
         match self.onion_ports {
             Some((listen_port, control_port)) => {
                 default_args.push(format!("-bind=127.0.0.1:{listen_port}=onion"));

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Run the integration tests against a chosen Bitcoin Core build.
+#
+# Usage: run_integration_tests.sh [--bitcoind FLAVOR] [test-runner args...]
+#
+# FLAVOR is one of (default: bitcoin-patched):
+#   bitcoin-patched  LayerTwo-Labs bitcoin-patched
+#   unpatched        newest stock Bitcoin Core release
+#   stock-X.Y        a specific stock release from CI_BITCOIN_CORE_VERSIONS
+#   drynetN          the ecash-com/bitcoin drynet fork at that tag
+#   all              every flavor in the CI matrix, continuing past failures
+#
+# Remaining args go to the test runner. Missing dependencies are downloaded
+# via setup_integration_tests.sh on first use.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+flavor='bitcoin-patched'
+rest=()
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --bitcoind=*) flavor="${1#*=}"; shift ;;
+        --bitcoind) flavor="${2:?--bitcoind requires a value}"; shift 2 ;;
+        *) rest+=("$1"); shift ;;
+    esac
+done
+
+if [ "$flavor" = 'all' ]; then
+    # Mirror the CI matrix. Like CI's fail-fast: false, run every flavor,
+    # then print a per-flavor summary. Passing is the base case — only
+    # failed and skipped tests are listed by name.
+    flavors=($("$REPO_ROOT/scripts/setup_integration_tests.sh" --print-flavors))
+    if [ ${#flavors[@]} -eq 0 ]; then
+        echo 'setup_integration_tests.sh --print-flavors returned nothing' >&2
+        exit 1
+    fi
+    logdir=$(mktemp -d)
+    trap 'rm -rf "$logdir"' EXIT
+    summary="$logdir/summary"
+    : > "$summary"
+    overall=0
+    for f in "${flavors[@]}"; do
+        echo "=== integration tests (--bitcoind $f) ==="
+        log="$logdir/$f.log"
+        if "${BASH_SOURCE[0]}" --bitcoind "$f" ${rest[@]+"${rest[@]}"} 2>&1 | tee "$log"; then
+            status=0
+        else
+            status=1
+            overall=1
+        fi
+        # Summarize from the run's output: libtest's result line, per-test
+        # FAILED lines, and the `skipped: ` lines emitted below.
+        passed=$(grep -aoE '[0-9]+ passed' "$log" | tail -1 || true)
+        n_skipped=$(grep -ac '^skipped: ' "$log" || true)
+        n_failed=$(grep -acE ' \.\.\. FAILED$' "$log" || true)
+        line="$f: ${passed:-0 passed}"
+        [ "$n_skipped" -gt 0 ] && line="$line, $n_skipped skipped"
+        if [ "$status" -ne 0 ]; then
+            if [ "$n_failed" -gt 0 ]; then
+                line="$line, $n_failed FAILED"
+            else
+                line="$line, FAILED without test results (see its output above)"
+            fi
+        fi
+        echo "$line" >> "$summary"
+        # `[^ ] *` trims the padding libtest inserts between name and dots.
+        sed -n 's/^test \(.*[^ ]\) *\.\.\. FAILED$/    FAILED: \1/p' "$log" >> "$summary"
+        sed -n 's/^skipped: \(.*\)/    skipped: \1/p' "$log" >> "$summary"
+    done
+    echo
+    echo '=== flavor summary ==='
+    cat "$summary"
+    exit "$overall"
+fi
+
+setup_env=()
+skip_patterns=()
+env_file="integrationtests.$flavor.env"
+case "$flavor" in
+    bitcoin-patched) env_file='integrationtests.env' ;;
+    unpatched | stock-*)
+        # Stock Bitcoin Core lacks the drivechain consensus rules
+        # (BIP300 opcodes), matching the stock CI matrix entries.
+        skip_patterns=('deposit_withdraw_roundtrip')
+        ;;
+    drynet*) setup_env=("DRYNET_REVISION=$flavor") ;;
+    *)
+        echo "unknown --bitcoind flavor '$flavor' (expected bitcoin-patched, unpatched, stock-X.Y, drynetN, or all)" >&2
+        exit 1
+        ;;
+esac
+
+# The env files use paths relative to the repo root (see
+# setup_integration_tests.sh), and the tests expect to run from there.
+cd "$REPO_ROOT"
+
+if [ ! -f "$env_file" ]; then
+    env ${setup_env[@]+"${setup_env[@]}"} "$REPO_ROOT/scripts/setup_integration_tests.sh"
+fi
+cargo build
+
+run_tests() {
+    env BIP300301_ENFORCER_INTEGRATION_TEST_ENV="$REPO_ROOT/$env_file" \
+        cargo run --example integration_tests -- "$@"
+}
+
+skip_args=()
+if [ ${#skip_patterns[@]} -gt 0 ]; then
+    # Name the tests this flavor's skip patterns exclude (on top of any
+    # user-supplied filter); `--skip` is substring matching, so a listing
+    # filtered by the pattern is exactly the excluded set. The `skipped: `
+    # prefix is what the `--bitcoind all` summary parses.
+    listing=$(run_tests --list ${rest[@]+"${rest[@]}"} | sed -n 's/: test$//p')
+    for pattern in "${skip_patterns[@]}"; do
+        skip_args+=('--skip' "$pattern")
+        printf '%s\n' "$listing" | grep -aF "$pattern" | sed 's/^/skipped: /' || true
+    done
+fi
+
+run_tests ${rest[@]+"${rest[@]}"} ${skip_args[@]+"${skip_args[@]}"}

--- a/scripts/setup_integration_tests.sh
+++ b/scripts/setup_integration_tests.sh
@@ -29,59 +29,110 @@ fi
 BITCOIN_VERSION="${ALL_BITCOIN_VERSIONS%%$'\n'*}"
 ELECTRS_VERSION="v3.2.0"
 PATCHED_REVISION="latest"
+# Drivechain-patched Bitcoin Core fork from ecash-com/bitcoin. Bump when a
+# new drynet tag is published on releases.drivechain.info. CI parses this
+# literal out of this script (see compute-integration-matrix in
+# .github/workflows/check_lint_build_release.yaml) — keep the
+# `DRYNET_DEFAULT_REVISION="..."` shape. Override with the DRYNET_REVISION
+# env var (`just test-it --bitcoind drynetN` does this) to fetch a
+# different tag.
+DRYNET_DEFAULT_REVISION="drynet3"
+DRYNET_REVISION="${DRYNET_REVISION:-$DRYNET_DEFAULT_REVISION}"
+
+# Print the `--bitcoind` flavor of each CI matrix entry, one per line, and
+# exit. Lets run_integration_tests.sh (`--bitcoind all`) reuse this
+# script's parsing instead of re-grepping the constants.
+if [ "${1:-}" = '--print-flavors' ]; then
+    echo 'bitcoin-patched'
+    echo "$DRYNET_DEFAULT_REVISION"
+    for v in $ALL_BITCOIN_VERSIONS; do
+        echo "stock-$v"
+    done
+    exit 0
+fi
 
 PATCHED_DIR="$DEPS_DIR/bitcoin-patched-$PATCHED_REVISION"
+DRYNET_DIR="$DEPS_DIR/bitcoin-ecash-$DRYNET_REVISION"
 UNPATCHED_DIR="$DEPS_DIR/bitcoin-stock-$BITCOIN_VERSION"
 SIGNET_REPO_DIR="$DEPS_DIR/bitcoin-patched-repo"
 ELECTRS_DIR="$DEPS_DIR/electrs-$ELECTRS_VERSION"
 
 # `releases.drivechain.info` only publishes patched bitcoin for
 # x86_64-{linux,darwin,windows}. arm64 falls back to the x86_64 darwin
-# build (Rosetta). Stock Bitcoin Core has native arm64 builds.
+# build (Rosetta). Stock Bitcoin Core and the ecash drynet builds have
+# native arm64 darwin builds.
 OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
 ARCH="$(uname -m)"
 case "$OS-$ARCH" in
-    linux-x86_64)  STOCK_TARGET="x86_64-linux-gnu";    PATCHED_TARGET="x86_64-unknown-linux-gnu" ;;
-    darwin-x86_64) STOCK_TARGET="x86_64-apple-darwin"; PATCHED_TARGET="x86_64-apple-darwin" ;;
-    darwin-arm64)  STOCK_TARGET="arm64-apple-darwin";  PATCHED_TARGET="x86_64-apple-darwin" ;;
+    linux-x86_64)  STOCK_TARGET="x86_64-linux-gnu";    PATCHED_TARGET="x86_64-unknown-linux-gnu"; DRYNET_TARGET="x86_64-unknown-linux-gnu" ;;
+    darwin-x86_64) STOCK_TARGET="x86_64-apple-darwin"; PATCHED_TARGET="x86_64-apple-darwin";      DRYNET_TARGET="x86_64-apple-darwin" ;;
+    darwin-arm64)  STOCK_TARGET="arm64-apple-darwin";  PATCHED_TARGET="x86_64-apple-darwin";      DRYNET_TARGET="aarch64-apple-darwin" ;;
     *) echo "Unsupported platform: $OS-$ARCH (no patched binary published)" >&2; exit 1 ;;
 esac
 
 mkdir -p "$DEPS_DIR"
 
+# Download `$1.zip` from releases.drivechain.info (the zip unpacks to a
+# directory named after its basename) and install the bitcoin binaries at
+# `$2`.
+fetch_drivechain_zip() {
+    local zip_name="$1" dest_dir="$2"
+    TMP=$(mktemp -d)
+    trap 'rm -rf "$TMP"' EXIT
+    curl -# -fL "https://releases.drivechain.info/$zip_name.zip" -o "$TMP/bins.zip"
+    unzip -q "$TMP/bins.zip" -d "$TMP"
+    rm -rf "$dest_dir"
+    mv "$TMP/$zip_name" "$dest_dir"
+    chmod +x "$dest_dir"/bitcoind "$dest_dir"/bitcoin-cli "$dest_dir"/bitcoin-util
+    rm -rf "$TMP"
+    trap - EXIT
+}
+
+# Download the stock Bitcoin Core `$1` release tarball from bitcoincore.org
+# and install its bin/ at `$2`.
+fetch_stock_tarball() {
+    local version="$1" dest_dir="$2"
+    TMP=$(mktemp -d)
+    trap 'rm -rf "$TMP"' EXIT
+    local tarball="bitcoin-$version-$STOCK_TARGET.tar.gz"
+    curl -# -fL "https://bitcoincore.org/bin/bitcoin-core-$version/$tarball" -o "$TMP/$tarball"
+    tar -C "$TMP" -xf "$TMP/$tarball"
+    rm -rf "$dest_dir"
+    mv "$TMP/bitcoin-$version/bin" "$dest_dir"
+    chmod +x "$dest_dir"/bitcoind "$dest_dir"/bitcoin-cli "$dest_dir"/bitcoin-util
+    rm -rf "$TMP"
+    trap - EXIT
+}
+
 # --- Patched Bitcoin Core ---
 if [ ! -x "$PATCHED_DIR/bitcoind" ]; then
     echo "Downloading patched bitcoin ($PATCHED_TARGET)..."
-    TMP=$(mktemp -d)
-    trap 'rm -rf "$TMP"' EXIT
-    ZIP="L1-bitcoin-patched-$PATCHED_REVISION-$PATCHED_TARGET.zip"
-    curl -# -fL "https://releases.drivechain.info/$ZIP" -o "$TMP/patched.zip"
-    unzip -q "$TMP/patched.zip" -d "$TMP"
-    rm -rf "$PATCHED_DIR"
-    mv "$TMP/L1-bitcoin-patched-$PATCHED_REVISION-$PATCHED_TARGET" "$PATCHED_DIR"
-    chmod +x "$PATCHED_DIR"/bitcoind "$PATCHED_DIR"/bitcoin-cli "$PATCHED_DIR"/bitcoin-util
-    rm -rf "$TMP"
-    trap - EXIT
+    fetch_drivechain_zip "L1-bitcoin-patched-$PATCHED_REVISION-$PATCHED_TARGET" "$PATCHED_DIR"
 else
     echo "Patched bitcoin: cached"
 fi
 
-# --- Stock Bitcoin Core (BITCOIND_UNPATCHED) ---
-if [ ! -x "$UNPATCHED_DIR/bitcoind" ]; then
-    echo "Downloading stock Bitcoin Core $BITCOIN_VERSION ($STOCK_TARGET)..."
-    TMP=$(mktemp -d)
-    trap 'rm -rf "$TMP"' EXIT
-    TARBALL="bitcoin-$BITCOIN_VERSION-$STOCK_TARGET.tar.gz"
-    curl -# -fL "https://bitcoincore.org/bin/bitcoin-core-$BITCOIN_VERSION/$TARBALL" -o "$TMP/$TARBALL"
-    tar -C "$TMP" -xf "$TMP/$TARBALL"
-    rm -rf "$UNPATCHED_DIR"
-    mv "$TMP/bitcoin-$BITCOIN_VERSION/bin" "$UNPATCHED_DIR"
-    chmod +x "$UNPATCHED_DIR"/bitcoind "$UNPATCHED_DIR"/bitcoin-cli "$UNPATCHED_DIR"/bitcoin-util
-    rm -rf "$TMP"
-    trap - EXIT
+# --- ecash drynet Bitcoin Core ---
+if [ ! -x "$DRYNET_DIR/bitcoind" ]; then
+    echo "Downloading ecash drynet bitcoin ($DRYNET_TARGET)..."
+    fetch_drivechain_zip "L1-ecash-bitcoin-$DRYNET_REVISION-$DRYNET_TARGET" "$DRYNET_DIR"
 else
-    echo "Stock bitcoin: cached"
+    echo "ecash drynet bitcoin: cached"
 fi
+
+# --- Stock Bitcoin Core, one per CI_BITCOIN_CORE_VERSIONS entry ---
+# The newest doubles as BITCOIND_UNPATCHED for the drivechain-patched
+# flavors; the rest let `just test-it --bitcoind stock-<version>` (and
+# `--bitcoind all`) mirror the CI matrix locally.
+for v in $ALL_BITCOIN_VERSIONS; do
+    STOCK_DIR="$DEPS_DIR/bitcoin-stock-$v"
+    if [ ! -x "$STOCK_DIR/bitcoind" ]; then
+        echo "Downloading stock Bitcoin Core $v ($STOCK_TARGET)..."
+        fetch_stock_tarball "$v" "$STOCK_DIR"
+    else
+        echo "Stock bitcoin $v: cached"
+    fi
+done
 
 # --- bitcoin-patched repo (signet miner script only) ---
 if [ ! -f "$SIGNET_REPO_DIR/contrib/signet/miner" ]; then
@@ -106,21 +157,37 @@ else
     echo "electrs: cached"
 fi
 
-# --- Write integrationtests.env ---
+# --- Write env files, one per --bitcoind flavor of `just test-it` ---
 # Deps paths are absolute (shared across worktrees); the enforcer binary stays
 # relative since `target/` is per-worktree and tests run with cwd at the worktree root.
-ENV_FILE="$REPO_ROOT/integrationtests.env"
-cat > "$ENV_FILE" <<EOF
+# The files differ in which builds the BITCOIND* vars point at and in
+# BITCOIND_HAS_DRIVECHAIN (see `BitcoindKind::accept_nonstd_txns` in
+# integration_tests/setup.rs for the standardness rationale). The stock
+# flavors use the same binary for BITCOIND and BITCOIND_UNPATCHED,
+# mirroring the stock CI matrix entries.
+write_env_file() {
+    local env_file="$1" bins_dir="$2" unpatched_dir="$3" has_drivechain="$4"
+    cat > "$env_file" <<EOF
 BIP300301_ENFORCER='target/debug/bip300301_enforcer'
-BITCOIND='$PATCHED_DIR/bitcoind'
-BITCOIND_UNPATCHED='$UNPATCHED_DIR/bitcoind'
-BITCOIN_CLI='$PATCHED_DIR/bitcoin-cli'
-BITCOIN_UTIL='$PATCHED_DIR/bitcoin-util'
+BITCOIND='$bins_dir/bitcoind'
+BITCOIND_HAS_DRIVECHAIN='$has_drivechain'
+BITCOIND_UNPATCHED='$unpatched_dir/bitcoind'
+BITCOIN_CLI='$bins_dir/bitcoin-cli'
+BITCOIN_UTIL='$bins_dir/bitcoin-util'
 ELECTRS='$ELECTRS_BIN'
 SIGNET_MINER='$SIGNET_REPO_DIR/contrib/signet/miner'
 EOF
+    echo "Wrote $env_file"
+}
 
 echo
-echo "Wrote $ENV_FILE"
+write_env_file "$REPO_ROOT/integrationtests.env" "$PATCHED_DIR" "$UNPATCHED_DIR" 1
+write_env_file "$REPO_ROOT/integrationtests.unpatched.env" "$UNPATCHED_DIR" "$UNPATCHED_DIR" 0
+write_env_file "$REPO_ROOT/integrationtests.$DRYNET_REVISION.env" "$DRYNET_DIR" "$UNPATCHED_DIR" 1
+for v in $ALL_BITCOIN_VERSIONS; do
+    STOCK_DIR="$DEPS_DIR/bitcoin-stock-$v"
+    write_env_file "$REPO_ROOT/integrationtests.stock-$v.env" "$STOCK_DIR" "$STOCK_DIR" 0
+done
+
 echo "Deps cache: $DEPS_DIR"
-echo "Run integration tests with: just test-it"
+echo "Run integration tests with: just test-it [--bitcoind bitcoin-patched|unpatched|stock-X.Y|drynetN|all]"


### PR DESCRIPTION
Also improve the `just test-it` recipe to take in the flavor of Bitcoin Core to run against. Can take in `all` to run against the entire matrix.