### PR TITLE
wallet: be smarter about large catch-up syncs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -519,6 +519,7 @@ dependencies = [
  "jsonrpsee",
  "libtest-mimic",
  "parking_lot",
+ "reqwest 0.13.4",
  "reserve-port",
  "rusqlite",
  "serde",

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -25,6 +25,7 @@ jsonrpsee = { workspace = true }
 thiserror = { workspace = true }
 libtest-mimic = { workspace = true }
 parking_lot = { workspace = true }
+reqwest = { workspace = true }
 reserve-port = { workspace = true }
 rusqlite = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/integration_tests/integration_test.rs
+++ b/integration_tests/integration_test.rs
@@ -925,6 +925,26 @@ pub fn tests(
         crate::test_blinded_m6_roundtrip::test_blinded_m6_zero_input_roundtrip,
     ));
 
+    // Needs direct `bin_paths` (to respawn the enforcer mid-test), so it uses
+    // a bespoke trial rather than `new_trial_with_setup`.
+    async_trials.push({
+        let name = crate::test_wallet_large_gap_sync::TEST_NAME;
+        AsyncTrial::new(
+            name,
+            Box::pin({
+                let bin_paths = bin_paths.clone();
+                async move {
+                    let test_future =
+                        crate::test_wallet_large_gap_sync::test_wallet_large_gap_sync(bin_paths)
+                            .instrument(tracing::info_span!("test", name = %name));
+                    catch_unwind(test_future).await
+                }
+            }),
+            file_registry.clone(),
+            failure_collector.clone(),
+        )
+    });
+
     // Needs direct `bin_paths` (to respawn the enforcer/electrs mid-test),
     // so it uses a bespoke trial rather than `new_trial_with_setup`.
     async_trials.push({

--- a/integration_tests/lib.rs
+++ b/integration_tests/lib.rs
@@ -13,6 +13,7 @@ mod test_peer_bmm_request;
 mod test_seed_migration;
 mod test_sidechain_ack_policy;
 mod test_unconfirmed_transactions;
+mod test_wallet_large_gap_sync;
 mod test_wallet_less_block_template;
 mod test_wallet_reorg_multi_block;
 pub mod util;

--- a/integration_tests/test_wallet_large_gap_sync.rs
+++ b/integration_tests/test_wallet_large_gap_sync.rs
@@ -1,0 +1,193 @@
+//! Regression test for the wallet crossing a gap far larger than it can
+//! afford to replay one block at a time.
+//!
+//! Connecting missing blocks individually costs two node RPCs and a wallet
+//! persist per block, and each persist gets slower as the local chain grows,
+//! so a wallet that is hundreds of thousands of blocks behind never finishes.
+//! Past `MAX_BLOCK_BY_BLOCK_REPLAY` in `lib/wallet/cusf_block_producer.rs`,
+//! `sync_wallet_to_tip` must instead advance the local chain with a single
+//! checkpoint update and recover its transactions with a full scan against
+//! the chain source.
+//!
+//! The gap is mined while the enforcer is down, and paid to an address the
+//! enforcer's own wallet owns, so the coinbases are only discoverable by
+//! scanning the chain source. A checkpoint jump that skipped the scan would
+//! close the gap but silently lose the money.
+
+use std::time::Duration;
+
+use bip300301_enforcer_lib::{
+    bins::CommandExt as _,
+    proto::mainchain::{CreateNewAddressRequest, GetBalanceRequest},
+};
+use futures::channel::mpsc;
+use tokio::time::sleep;
+
+use crate::{
+    integration_test::{fund_enforcer, wait_for_wallet_sync},
+    setup::{DummySidechain, Mode, Network, PostSetup, PreSetup, SetupOpts},
+    util::BinPaths,
+};
+
+pub const TEST_NAME: &str = "wallet_large_gap_sync";
+
+/// Must exceed `MAX_BLOCK_BY_BLOCK_REPLAY`, or the wallet takes the
+/// block-by-block path and the assertions below fail (loudly, and correctly).
+const GAP_BLOCKS: u32 = 2_100;
+
+/// Emitted by `sync_wallet_to_tip` when it takes the checkpoint path.
+const CHECKPOINT_LOG: &str = "checkpointing chain forward and running a full scan";
+
+/// Emitted once per block by the block-by-block path.
+const REPLAY_LOG: &str = "unable to connect block to bdk_chain";
+
+/// Block until electrs has indexed up to bitcoind's tip.
+///
+/// The wallet full-scans exactly once, during startup sync, and the test
+/// harness runs the enforcer with `--wallet-skip-periodic-sync`, so there is
+/// no later retry to paper over a chain source that was still catching up.
+async fn wait_for_electrs_tip(post_setup: &PostSetup) -> anyhow::Result<()> {
+    const POLL_INTERVAL: Duration = Duration::from_millis(500);
+    const TIMEOUT: Duration = Duration::from_secs(180);
+
+    let target_height: u32 = post_setup
+        .bitcoin_cli
+        .command::<String, _, String, _, _>([], "getblockcount", [])
+        .run_utf8()
+        .await?
+        .trim()
+        .parse()?;
+    let url = format!(
+        "http://127.0.0.1:{}/blocks/tip/height",
+        post_setup.reserved_ports.electrs_electrum_http.port()
+    );
+    tracing::debug!("waiting for electrs to index up to block {target_height}");
+
+    let client = reqwest::Client::new();
+    let deadline = std::time::Instant::now() + TIMEOUT;
+    loop {
+        // electrs returns 5xx while it is still opening its index, so a
+        // failed request here is expected rather than fatal.
+        let indexed_height: Option<u32> = match client.get(&url).send().await {
+            Ok(response) => response
+                .text()
+                .await
+                .ok()
+                .and_then(|body| body.trim().parse().ok()),
+            Err(_) => None,
+        };
+        if indexed_height.is_some_and(|height| height >= target_height) {
+            return Ok(());
+        }
+        anyhow::ensure!(
+            std::time::Instant::now() < deadline,
+            "electrs did not index up to block {target_height} within {TIMEOUT:?} \
+             (stuck at {indexed_height:?})"
+        );
+        sleep(POLL_INTERVAL).await;
+    }
+}
+
+/// Concatenate the enforcer's rolling log files.
+///
+/// The enforcer's `stdout.txt` only holds the run the harness spawned most
+/// recently, whereas the rolling log in the data dir spans the restart, which
+/// is the run this test needs to make assertions about.
+fn read_enforcer_log(post_setup: &PostSetup) -> anyhow::Result<String> {
+    let log_dir = post_setup.directories.enforcer_dir.join("logs");
+    let mut combined = String::new();
+    for entry in std::fs::read_dir(&log_dir)? {
+        let path = entry?.path();
+        if path.is_file() {
+            combined.push_str(&std::fs::read_to_string(&path)?);
+        }
+    }
+    anyhow::ensure!(
+        !combined.is_empty(),
+        "no enforcer log content found in {}",
+        log_dir.display()
+    );
+    Ok(combined)
+}
+
+pub async fn test_wallet_large_gap_sync(bin_paths: BinPaths) -> anyhow::Result<()> {
+    let (res_tx, _res_rx) = mpsc::unbounded();
+    let pre_setup = PreSetup::new(bin_paths.clone(), Network::Regtest)?;
+    let setup_opts: SetupOpts = Default::default();
+    let mut post_setup = pre_setup
+        .setup(Mode::Mempool, setup_opts, res_tx.clone())
+        .await?;
+
+    fund_enforcer::<DummySidechain>(&mut post_setup).await?;
+    let balance_before = post_setup
+        .wallet_service_client
+        .get_balance(GetBalanceRequest::default())
+        .await?
+        .into_owned();
+    tracing::info!(?balance_before, "wallet balance before the gap");
+
+    // Owned by the enforcer's wallet, so the gap's coinbases are money the
+    // full scan is obliged to find.
+    let gap_address = post_setup
+        .wallet_service_client
+        .create_new_address(CreateNewAddressRequest::default())
+        .await?
+        .into_owned()
+        .address;
+
+    tracing::info!("killing enforcer, then mining {GAP_BLOCKS} blocks behind its back");
+    post_setup.kill_enforcer().await?;
+    post_setup
+        .bitcoin_cli
+        .command::<String, _, _, _, _>(
+            [],
+            "generatetoaddress",
+            [GAP_BLOCKS.to_string(), gap_address],
+        )
+        .run_utf8()
+        .await?;
+    wait_for_electrs_tip(&post_setup).await?;
+
+    tracing::info!("restarting enforcer -- it must checkpoint across the gap, not replay it");
+    post_setup
+        .restart_enforcer(&bin_paths, Vec::<String>::new(), res_tx.clone())
+        .await?;
+    wait_for_wallet_sync(&mut post_setup).await?;
+
+    let balance_after = post_setup
+        .wallet_service_client
+        .get_balance(GetBalanceRequest::default())
+        .await?
+        .into_owned();
+    tracing::info!(?balance_after, "wallet balance after crossing the gap");
+    anyhow::ensure!(
+        balance_after.confirmed_sats > balance_before.confirmed_sats,
+        "the full scan must recover the coinbases paid to the wallet during the gap, \
+         but confirmed_sats did not grow: {balance_after:?} (was {balance_before:?})"
+    );
+
+    let enforcer_log = read_enforcer_log(&post_setup)?;
+    anyhow::ensure!(
+        enforcer_log.contains(CHECKPOINT_LOG),
+        "expected the wallet to close a {GAP_BLOCKS}-block gap with a checkpoint and full \
+         scan, but {CHECKPOINT_LOG:?} never appeared in the enforcer log. Has \
+         MAX_BLOCK_BY_BLOCK_REPLAY been raised above {GAP_BLOCKS}?"
+    );
+    anyhow::ensure!(
+        !enforcer_log.contains("no chain source is configured"),
+        "the harness configures a chain source, so the wallet must not have taken the \
+         block-by-block fallback"
+    );
+    // The point of the fix: the gap is crossed in one update, not one block at
+    // a time. A handful of these can legitimately show up for the small tail
+    // the replay loop still handles, but nothing on the order of the gap.
+    let replayed = enforcer_log.matches(REPLAY_LOG).count();
+    anyhow::ensure!(
+        replayed < GAP_BLOCKS as usize / 10,
+        "the wallet replayed {replayed} blocks individually while crossing a \
+         {GAP_BLOCKS}-block gap; it should have checkpointed across it instead"
+    );
+    tracing::info!("crossed a {GAP_BLOCKS}-block gap with {replayed} individual block connects");
+
+    Ok(())
+}

--- a/lib/wallet/cusf_block_producer.rs
+++ b/lib/wallet/cusf_block_producer.rs
@@ -71,6 +71,43 @@ async fn sync_wallet_to_tip(
     } else {
         wallet_tip
     };
+    // Replaying the gap block-by-block below costs two node RPCs and a wallet
+    // persist per block, and each persist gets slower as the local chain grows.
+    // That is fine for the handful of blocks a running node falls behind by, but
+    // a gap of hundreds of thousands of blocks takes hours. Past this many
+    // blocks, advance the local chain with a single checkpoint update built from
+    // validator headers and recover any wallet transactions in the skipped range
+    // with a full scan against the chain source.
+    const MAX_BLOCK_BY_BLOCK_REPLAY: u32 = 2_000;
+    let blocks_behind = new_tip_height.saturating_sub(wallet_tip.height);
+    let wallet_tip = if blocks_behind <= MAX_BLOCK_BY_BLOCK_REPLAY {
+        wallet_tip
+    } else if wallet.inner.has_chain_source() {
+        tracing::info!(
+            wallet_tip_height = wallet_tip.height,
+            %new_tip_height,
+            %blocks_behind,
+            "wallet is too far behind to replay block-by-block, \
+             checkpointing chain forward and running a full scan instead"
+        );
+        // `full_scan` checkpoints the local chain to the validator tip from
+        // validator headers, then scans the chain source for transactions
+        // against that checkpoint, so it both closes the gap and recovers the
+        // wallet transactions the skipped blocks would have contributed.
+        let _tip: BlockHash = wallet.inner.full_scan().await?;
+        wallet.inner.get_tip().await?
+    } else {
+        tracing::warn!(
+            wallet_tip_height = wallet_tip.height,
+            %new_tip_height,
+            %blocks_behind,
+            "wallet is far behind and no chain source is configured, \
+             falling back to block-by-block replay. This is very slow. \
+             Set --wallet-sync-source to electrum or esplora to catch up \
+             with a checkpoint and full scan instead"
+        );
+        wallet_tip
+    };
     // If the wallet tip is higher than the block height we need to connect the missing blocks.
     // We have logic for that below. We therefore use max() here to ensure that the loop
     // will run at least once (thereby triggering the logic for missing blocks).

--- a/lib/wallet/error.rs
+++ b/lib/wallet/error.rs
@@ -796,8 +796,8 @@ where
 pub(in crate::wallet) enum SyncWalletToTipInner {
     #[error("failed to connect missing block to wallet")]
     ConnectMissingBlock(#[from] ConnectMissingBlock),
-    #[error("failed to fast-forward wallet chain to tip")]
-    FastForward(#[from] FullScan),
+    #[error("failed to catch wallet chain up to tip")]
+    ChainCatchUp(#[from] FullScan),
     #[error("unable to fetch block from mainchain")]
     #[diagnostic(code(fetch_block_error))]
     GetBlock(#[source] BitcoinCoreRPC),

--- a/lib/wallet/sync.rs
+++ b/lib/wallet/sync.rs
@@ -120,6 +120,13 @@ impl WalletInner {
         }
     }
 
+    /// Whether a chain source (Electrum/Esplora) is configured. Without one,
+    /// the wallet can only learn about its transactions from blocks connected
+    /// one at a time, so [`Self::full_scan`] is not available.
+    pub(in crate::wallet) fn has_chain_source(&self) -> bool {
+        self.chain_source_client.is_some()
+    }
+
     /// Fast-forward the wallet's local chain up to `up_to_height` (or the
     /// validator tip) by applying one checkpoint update built from validator
     /// headers, instead of connecting every missing block individually.
@@ -295,16 +302,26 @@ impl WalletInner {
                 .unwrap_or("nil".to_string()),
         );
 
+        // Extend the wallet's existing checkpoint rather than building a fresh
+        // chain that starts at its tip. A sync inserts a `BlockId` for every
+        // transaction it finds, and `CheckPoint::insert` panics ("will break
+        // before genesis block") if an insert lands below the lowest checkpoint
+        // it was handed. A chain rebuilt from the tip has no history below it,
+        // so the wallet's own older transactions are exactly what blows it up.
+        let tip = local_chain.tip();
+        let tip_height = tip.height();
         let block_ids = headers
             .into_iter()
+            // Anything at or below the tip is already covered by the checkpoint
+            // being extended, and `extend` requires strictly ascending heights.
+            .filter(|(height, _)| *height > tip_height)
             .map(|(height, hash)| bdk_chain::BlockId { height, hash });
 
-        let checkpoint =
-            bdk_chain::CheckPoint::from_block_ids(block_ids).map_err(|last_successful_header| {
-                error::FullScan::CreateCheckPointFromHeaders {
-                    last_successful_header,
-                }
-            })?;
+        let checkpoint = tip.extend(block_ids).map_err(|last_successful_header| {
+            error::FullScan::CreateCheckPointFromHeaders {
+                last_successful_header: Some(last_successful_header),
+            }
+        })?;
         Ok(checkpoint)
     }
 


### PR DESCRIPTION
When we're far behind, do checkpoint + full remote sync instead of feeding block by block. Shaves hours off a resync on mainnet