### PR TITLE
integration tests: cache signet mining, remove sleeps

### DIFF
--- a/.github/workflows/check_lint_build_release.yaml
+++ b/.github/workflows/check_lint_build_release.yaml
@@ -297,6 +297,31 @@ jobs:
       - name: Build (debug)
         run: cargo build
 
+      # A signet chain can only be extended by real proof-of-work, and no
+      # coinbase is spendable until it is 100 blocks deep — so mining one per
+      # run cost more than the rest of the suite combined. The harness pins the
+      # signet challenge key, which makes the chain reproducible, so the test
+      # run mines one on first use into SIGNET_CHAIN_DIR and reuses it after.
+      # Here that means: restore it if we have it, and let the test run mine it
+      # if we don't.
+      #
+      # Keyed on the file holding the values that define the chain, so ordinary
+      # harness edits keep the cache and a real change invalidates it. The
+      # bitcoind build is in the key too, since this caches a datadir written
+      # by that binary: `zip` for the drivechain-patched flavors, `version` for
+      # stock (exactly one of the two is set per matrix entry). A restored
+      # chain that doesn't match the challenge is detected and re-mined rather
+      # than used, but nothing detects a datadir from a different flavor — so
+      # the key has to keep those apart.
+      - name: Restore pre-mined signet chain
+        id: cache-signet-chain
+        uses: actions/cache/restore@v6
+        with:
+          path: ${{ runner.temp }}/signet-chain
+          key:
+            signet-chain-${{ matrix.zip || matrix.version }}-${{
+            hashFiles('integration_tests/signet_chain_params.rs') }}
+
       # Verify gRPC server reflection with real schema-free clients
       # (grpcurl + buf curl). Reuses this job's bitcoind download and debug
       # build; gated to a single matrix entry since the result does not
@@ -356,6 +381,7 @@ jobs:
           export BITCOIN_UTIL='../bitcoin-bins/bitcoin-util'
           export ELECTRS='${{ runner.temp }}/electrs/target/release/electrs'
           export SIGNET_MINER='../bitcoin-patched/contrib/signet/miner'
+          export SIGNET_CHAIN_DIR='${{ runner.temp }}/signet-chain'
           # Each test leaks a TempDir holding per-component stdout/stderr (the
           # enforcer runs at --log-level=trace). Point TMPDIR at a known
           # directory so the "Upload integration test logs" step can collect
@@ -371,6 +397,31 @@ jobs:
             export BITCOIND_HAS_DRIVECHAIN=1
             cargo run --example integration_tests
           fi
+
+      # Did the run end up with a chain worth caching? A run that never needed
+      # one (the stock matrix skips the only signet test) leaves nothing to
+      # save, and `cache/save` would warn about the missing path.
+      #
+      # This is a shell test rather than `hashFiles` in the save step's `if`,
+      # because `hashFiles` only sees paths inside GITHUB_WORKSPACE — the chain
+      # lives in RUNNER_TEMP, so it silently returned '' and the save never ran.
+      - name: Check for a mined signet chain
+        id: mined-signet-chain
+        run: |
+          if [ -f "$RUNNER_TEMP/signet-chain/chain-info.txt" ]; then
+            echo 'present=true' >> "$GITHUB_OUTPUT"
+          fi
+
+      # Save whatever chain the run ended up with, so the next run restores it
+      # instead of re-mining.
+      - name: Save pre-mined signet chain
+        if: |
+          steps.cache-signet-chain.outputs.cache-hit != 'true' &&
+          steps.mined-signet-chain.outputs.present == 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: ${{ runner.temp }}/signet-chain
+          key: ${{ steps.cache-signet-chain.outputs.cache-primary-key }}
 
       - name: Upload integration test logs
         # Only on failure: the leaked TempDirs contain full trace-level

--- a/Justfile
+++ b/Justfile
@@ -64,5 +64,10 @@ fmt:
 # stock-X.Y (a specific stock release), drynetN, or all (every flavor in
 # the CI matrix, continuing past failures); remaining args go to the test
 # runner.
+# 
+# The signet tests need a chain with mature (spendable) coinbases, which costs
+# real proof-of-work to mine. The harness mines one on first use into
+# SIGNET_CHAIN_DIR and reuses it thereafter, so the first run here is a couple
+# of minutes slower than the rest.
 test-it *args='':
     '{{ justfile_directory() }}/scripts/run_integration_tests.sh' {{ args }}

--- a/integration_tests/block_verdict.rs
+++ b/integration_tests/block_verdict.rs
@@ -7,7 +7,7 @@ use bip300301_enforcer_lib::{
 use bitcoin::BlockHash;
 use tokio::time::sleep;
 
-use crate::setup::PostSetup;
+use crate::setup::{PostSetup, wait_until};
 
 /// Expected outcome of submitting a block to the enforcer.
 pub enum Expect {
@@ -21,7 +21,7 @@ pub enum Expect {
 /// The enforcer's validated chain tip `(hash, height)`. Surfaces the RPC error
 /// (e.g. `Unavailable` while the validator is not yet synced) so poll-loop
 /// callers can retry rather than abort.
-async fn enforcer_tip(post_setup: &mut PostSetup) -> anyhow::Result<(BlockHash, u32)> {
+async fn enforcer_tip(post_setup: &PostSetup) -> anyhow::Result<(BlockHash, u32)> {
     let info = post_setup
         .validator_service_client
         .get_chain_tip(GetChainTipRequest::default())
@@ -37,6 +37,24 @@ async fn enforcer_tip(post_setup: &mut PostSetup) -> anyhow::Result<(BlockHash, 
         .ok_or_else(|| anyhow::anyhow!("get_chain_tip: missing block_hash"))?
         .decode::<BlockHeaderInfo, BlockHash>("block_hash")?;
     Ok((hash, info.height))
+}
+
+/// Wait until the enforcer has validated the chain up to `height`.
+///
+/// Mining RPCs return once *bitcoind* has the blocks; the enforcer connects
+/// them asynchronously and is routinely well behind at that point. Anything
+/// that then asserts on the enforcer's verdict for a freshly mined block has to
+/// clear that backlog first, or [`assert_enforcer_verdict`]'s timeout is spent
+/// on the catch-up rather than on the verdict it is meant to be measuring.
+pub async fn wait_for_enforcer_height(post_setup: &PostSetup, height: u32) -> anyhow::Result<()> {
+    wait_until(
+        &format!("the enforcer to validate the chain up to height {height}"),
+        || async {
+            let (_tip_hash, tip_height) = enforcer_tip(post_setup).await?;
+            Ok(tip_height >= height)
+        },
+    )
+    .await
 }
 
 /// `Some(height)` if `block_hash` is on bitcoind's active chain (`getblock`

--- a/integration_tests/integration_test.rs
+++ b/integration_tests/integration_test.rs
@@ -24,6 +24,7 @@ use crate::{
     mine::{mine, mine_check_block_events, mine_generateblocks_check, mine_signet_check},
     setup::{
         Directories, DummySidechain, MiningMode, Mode, Network, PostSetup, PreSetup, Sidechain,
+        wait_for_pending_proposal, wait_for_tx_in_mempool,
     },
     test_peer_bmm_request, test_unconfirmed_transactions,
     util::{AsyncTrial, BinPaths, FileDumpConfig, TestFailureCollector, TestFileRegistry},
@@ -173,8 +174,13 @@ where
         .block_producer_service_client
         .create_sidechain_proposal(create_sidechain_proposal_request)
         .await?;
-    // Wait before mining
-    sleep(std::time::Duration::from_secs(1)).await;
+    // The proposal must be persisted before we mine, or the coinbase won't
+    // carry the M1.
+    let () = wait_for_pending_proposal(
+        &post_setup.block_producer_service_client,
+        S::SIDECHAIN_NUMBER,
+    )
+    .await?;
     tracing::debug!("Mining 1 block");
     let () = mine::<S>(post_setup, 1, Some(true)).await?;
     let Some(_) = create_sidechain_proposal_resp.message().await? else {
@@ -263,6 +269,23 @@ pub async fn wait_for_wallet_sync(post_setup: &mut PostSetup) -> anyhow::Result<
     }
 }
 
+/// How much to move into the enforcer wallet on signet when funding it from an
+/// already-mined chain. Far more than the deposits and withdrawals in these
+/// tests need, so no test has to reason about the exact figure.
+const SIGNET_FUNDING_AMOUNT: bitcoin::Amount = bitcoin::Amount::from_sat(5_000_000_000);
+
+/// Bitcoin Core's own spendable (mature, confirmed) wallet balance.
+async fn spendable_core_balance(post_setup: &PostSetup) -> anyhow::Result<bitcoin::Amount> {
+    let balance_btc: f64 = post_setup
+        .bitcoin_cli
+        .command::<String, _, String, _, _>([], "getbalance", [])
+        .run_utf8()
+        .await?
+        .trim()
+        .parse()?;
+    Ok(bitcoin::Amount::from_btc(balance_btc)?)
+}
+
 pub async fn fund_enforcer<S>(post_setup: &mut PostSetup) -> anyhow::Result<()>
 where
     S: Sidechain,
@@ -290,7 +313,50 @@ where
                 .await?;
         }
         Network::Signet => {
-            mine_signet_check::<_, Infallible, S>(post_setup, BLOCKS, |_| Ok(())).await?;
+            // Signet blocks cost real proof-of-work, so mining 100 of them
+            // just to mature a coinbase is by far the most expensive thing in
+            // the suite. When the chain was restored from the cache,
+            // bitcoind's own wallet already holds mature coinbases -- so just
+            // send from it and confirm that in a single block.
+            let spendable = spendable_core_balance(post_setup).await?;
+            if spendable >= SIGNET_FUNDING_AMOUNT {
+                tracing::debug!(
+                    %spendable,
+                    "Funding enforcer from the pre-mined chain's mature coinbases",
+                );
+                let address = post_setup
+                    .wallet_service_client
+                    .create_new_address(CreateNewAddressRequest::default())
+                    .await?
+                    .into_owned()
+                    .address;
+                // `-named` with an explicit `fee_rate`: this chain has no fee
+                // history, so Core's estimator has nothing to work from and
+                // `sendtoaddress` would fail rather than pick a rate.
+                let funding_txid: bitcoin::Txid = post_setup
+                    .bitcoin_cli
+                    .command::<_, _, _, _, _>(
+                        ["-named"],
+                        "sendtoaddress",
+                        [
+                            format!("address={address}"),
+                            format!("amount={}", SIGNET_FUNDING_AMOUNT.to_btc()),
+                            "fee_rate=2".to_owned(),
+                        ],
+                    )
+                    .run_utf8()
+                    .await?
+                    .trim()
+                    .parse()?;
+                let () = wait_for_tx_in_mempool(&post_setup.bitcoin_cli, &funding_txid).await?;
+                mine_signet_check::<_, Infallible, S>(post_setup, 1, |_| Ok(())).await?;
+            } else {
+                tracing::debug!(
+                    %spendable,
+                    "No pre-mined signet chain, mining {BLOCKS} blocks to coinbase maturity",
+                );
+                mine_signet_check::<_, Infallible, S>(post_setup, BLOCKS, |_| Ok(())).await?;
+            }
         }
     };
     tracing::debug!("Waiting for wallet sync...");
@@ -331,8 +397,7 @@ where
         .ok_or_else(|| proto::Error::missing_field::<CreateDepositTransactionResponse>("txid"))?
         .decode::<CreateDepositTransactionResponse, _>("txid")?;
     tracing::debug!("Deposit TXID: {deposit_txid}");
-    // Wait for deposit tx to enter mempool
-    sleep(std::time::Duration::from_secs(1)).await;
+    let () = wait_for_tx_in_mempool(&post_setup.bitcoin_cli, &deposit_txid).await?;
     tracing::debug!("Mining 1 sidechain block");
     let () = mine_check_block_events::<_, S>(post_setup, 1, None, |_, block_info| match block_info
         .events

--- a/integration_tests/lib.rs
+++ b/integration_tests/lib.rs
@@ -2,6 +2,7 @@ pub mod block_verdict;
 pub mod integration_test;
 pub mod mine;
 pub mod setup;
+pub mod signet_chain_params;
 mod test_activation_height;
 mod test_blinded_m6_roundtrip;
 mod test_consecutive_deposits;

--- a/integration_tests/setup.rs
+++ b/integration_tests/setup.rs
@@ -30,7 +30,6 @@ use bitcoin::{Address, BlockHash, Txid};
 use connectrpc::{
     ConnectError,
     client::{ClientConfig, HttpClient},
-    error::ErrorCode,
 };
 use futures::{channel::mpsc, future};
 use reserve_port::ReservedPort;
@@ -41,7 +40,10 @@ use tokio::{
     time::{Duration, sleep, timeout},
 };
 
-use crate::util::{AbortOnDrop, BinPaths, Bitcoind, Electrs, Enforcer, VarError};
+use crate::{
+    signet_chain_params::{SIGNET_CACHED_CHAIN_BLOCKS, SIGNET_CHALLENGE_SECRET_KEY},
+    util::{AbortOnDrop, BinPaths, Bitcoind, Electrs, Enforcer, VarError},
+};
 
 #[derive(strum::Display, Clone, Copy, Debug)]
 pub enum Network {
@@ -68,7 +70,10 @@ pub struct SignetSetup {
 
 impl SignetSetup {
     fn new() -> anyhow::Result<Self> {
-        let secret_key = bitcoin::PrivateKey::generate(bitcoin::NetworkKind::Test);
+        let secret_key = bitcoin::PrivateKey::from_slice(
+            &SIGNET_CHALLENGE_SECRET_KEY,
+            bitcoin::NetworkKind::Test,
+        )?;
         let cpk = bitcoin::CompressedPublicKey::from_private_key(
             &bitcoin::secp256k1::Secp256k1::new(),
             &secret_key,
@@ -407,18 +412,375 @@ pub async fn wait_for_validator_synced(
                         .into_option()
                         .ok_or_else(|| anyhow!("no block header info in chain tip"));
                 }
-                // Validator is not synced yet
-                Err(err) if err.code == ErrorCode::Unavailable => {
-                    tracing::trace!("Validator is not synced yet, waiting...");
+                // Not ready yet. `Unavailable` means the validator is still
+                // syncing; a transport error means the gRPC server isn't
+                // actually serving yet, even though the port accepted a TCP
+                // connection. With the whole suite starting processes at once
+                // both are routine, so retry either until the timeout rather
+                // than failing a test on a startup hiccup.
+                Err(err) => {
+                    tracing::trace!("Validator not ready yet ({err}), waiting...");
                     sleep(CHECK_INTERVAL).await;
                 }
-                Err(err) => return Err(anyhow!("Error getting enforcer tip: {err}")),
             }
         }
     };
     timeout(TIMEOUT, task)
         .await
         .map_err(|_| anyhow!("Timeout waiting for validator to sync after {TIMEOUT:?}"))?
+}
+
+/// Default budget for the `wait_for_*` helpers below. Generous, because the
+/// whole suite runs in parallel and the machine is saturated; these are
+/// deadlines that catch a genuinely stuck test, not expected wait times.
+pub const WAIT_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Interval between polls for conditions checked in-process or over an already
+/// open connection (gRPC, a file read). Short, because these are cheap and the
+/// conditions are normally already true on the first check.
+const WAIT_POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+/// Interval between polls for conditions checked by shelling out to
+/// `bitcoin-cli`. Each check forks a process and opens a fresh RPC connection,
+/// so polling these as fast as the in-process checks would put more load on an
+/// already-saturated machine than it saves in latency.
+pub const WAIT_POLL_INTERVAL_SUBPROCESS: Duration = Duration::from_millis(250);
+
+/// Poll `check` until it reports the condition has been reached, erroring out
+/// with `what` in the message if it hasn't happened within `WAIT_TIMEOUT`.
+///
+/// Prefer this over sleeping a fixed duration: it returns as soon as the state
+/// is actually observable (normally on the first poll) instead of paying a
+/// worst-case guess every run, and it fails loudly rather than silently
+/// continuing against state that was never reached.
+///
+/// A failing `check` counts as "not yet", not as a test failure: processes are
+/// still coming up while the suite runs in parallel, so an RPC can legitimately
+/// be refused or time out on the first attempts. Whatever it failed with last
+/// is reported if the deadline runs out.
+pub async fn wait_until<Check, Fut>(what: &str, check: Check) -> anyhow::Result<()>
+where
+    Check: FnMut() -> Fut,
+    Fut: Future<Output = anyhow::Result<bool>>,
+{
+    wait_until_every(what, WAIT_POLL_INTERVAL, check).await
+}
+
+/// [`wait_until`], with an explicit poll interval. Use
+/// [`WAIT_POLL_INTERVAL_SUBPROCESS`] for checks that shell out.
+pub async fn wait_until_every<Check, Fut>(
+    what: &str,
+    poll_interval: Duration,
+    mut check: Check,
+) -> anyhow::Result<()>
+where
+    Check: FnMut() -> Fut,
+    Fut: Future<Output = anyhow::Result<bool>>,
+{
+    let deadline = tokio::time::Instant::now() + WAIT_TIMEOUT;
+    let mut last_err: Option<anyhow::Error> = None;
+    loop {
+        // Bound each individual check by whatever budget is left, so a single
+        // hung RPC can't outlive the deadline.
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        match timeout(remaining, check()).await {
+            Ok(Ok(true)) => return Ok(()),
+            Ok(Ok(false)) => tracing::trace!("still waiting for {what}..."),
+            Ok(Err(err)) => {
+                tracing::trace!("still waiting for {what} (check failed: {err:#})");
+                last_err = Some(err);
+            }
+            Err(_elapsed) => break,
+        }
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        sleep(poll_interval.min(remaining)).await;
+    }
+    Err(match last_err {
+        Some(err) => err.context(format!(
+            "Timed out after {WAIT_TIMEOUT:?} waiting for {what}; last check failed"
+        )),
+        None => anyhow!("Timeout waiting for {what} after {WAIT_TIMEOUT:?}"),
+    })
+}
+
+/// Wait until `txid` is in `bitcoin_cli`'s node's mempool.
+///
+/// The wallet broadcasts asynchronously, so a tx is not necessarily in the
+/// node's mempool by the time the RPC that created it returns.
+pub async fn wait_for_tx_in_mempool(
+    bitcoin_cli: &bins::BitcoinCli,
+    txid: &bitcoin::Txid,
+) -> anyhow::Result<()> {
+    let txid = txid.to_string();
+    wait_until_every(
+        &format!("tx `{txid}` to enter the mempool"),
+        WAIT_POLL_INTERVAL_SUBPROCESS,
+        || async {
+            Ok(bitcoin_cli
+                .command::<String, _, _, _, _>([], "getmempoolentry", [txid.clone()])
+                .run_utf8()
+                .await
+                .is_ok())
+        },
+    )
+    .await
+}
+
+/// Wait until a sidechain proposal for `sidechain_number` has been persisted by
+/// the block producer, so that the next block it builds carries the M1.
+///
+/// `CreateSidechainProposal` persists before it returns, but the unary response
+/// to a server-streaming call resolves on headers, so poll the state the next
+/// block template actually reads rather than assuming the write landed.
+pub async fn wait_for_pending_proposal(
+    client: &BlockProducerServiceClient<Transport>,
+    sidechain_number: SidechainNumber,
+) -> anyhow::Result<()> {
+    use proto::mainchain::GetBlockProducerStateRequest;
+    let slot = u32::from(sidechain_number.0);
+    wait_until(
+        &format!("sidechain proposal for slot {slot} to be persisted"),
+        || async {
+            let state = client
+                .get_block_producer_state(GetBlockProducerStateRequest::default())
+                .await?
+                .into_owned();
+            Ok(state.pending_proposals.into_iter().any(|proposal| {
+                proto::unwrap_u32(proposal.sidechain_number).is_some_and(|number| number == slot)
+            }))
+        },
+    )
+    .await
+}
+
+/// Per-run state that bitcoind rewrites on startup, or that would leak one
+/// run's runtime details into the next. Excluded when snapshotting a datadir
+/// for reuse.
+const DATADIR_VOLATILE_NAMES: &[&str] = &[
+    ".cookie",
+    ".lock",
+    "anchors.dat",
+    "banlist.json",
+    "bitcoind.pid",
+    "debug.log",
+    "fee_estimates.dat",
+    "mempool.dat",
+    "peers.dat",
+    "stderr.txt",
+    "stdout.txt",
+];
+
+/// Recursively copy `src` into `dst`, skipping [`DATADIR_VOLATILE_NAMES`].
+fn copy_datadir(src: &std::path::Path, dst: &std::path::Path) -> anyhow::Result<()> {
+    std::fs::create_dir_all(dst)?;
+    for entry in std::fs::read_dir(src)? {
+        let entry = entry?;
+        let name = entry.file_name();
+        if DATADIR_VOLATILE_NAMES.contains(&name.to_string_lossy().as_ref()) {
+            continue;
+        }
+        let (src_path, dst_path) = (entry.path(), dst.join(&name));
+        if entry.file_type()?.is_dir() {
+            copy_datadir(&src_path, &dst_path)?;
+        } else {
+            std::fs::copy(&src_path, &dst_path)?;
+        }
+    }
+    Ok(())
+}
+
+/// Written into the cached chain directory, recording what the chain actually
+/// is. A chain mined for a different signet challenge is not merely stale --
+/// bitcoind would reject every block in it -- so it is checked before use
+/// rather than trusting whatever a cache (local or CI) restored.
+const SIGNET_CHAIN_MARKER_FILE: &str = "chain-info.txt";
+
+fn signet_chain_marker(signet_setup: &SignetSetup) -> String {
+    format!(
+        "challenge={}\nblocks={SIGNET_CACHED_CHAIN_BLOCKS}\n",
+        hex::encode(signet_setup.signet_challenge.as_bytes()),
+    )
+}
+
+/// Whether `dir` holds a chain usable by *this* build: present, and built for
+/// the current challenge and block count.
+fn usable_cached_signet_chain(dir: &std::path::Path, signet_setup: &SignetSetup) -> bool {
+    if !dir.join("signet").is_dir() {
+        return false;
+    }
+    let marker = std::fs::read_to_string(dir.join(SIGNET_CHAIN_MARKER_FILE)).unwrap_or_default();
+    if marker != signet_chain_marker(signet_setup) {
+        tracing::warn!(
+            "Cached signet chain at `{}` was built for a different challenge or \
+             block count; re-mining it.",
+            dir.display()
+        );
+        return false;
+    }
+    true
+}
+
+/// Resolved once per process: several tests can reach [`Setup::setup`] at the
+/// same time, and they must not mine into the same directory concurrently.
+/// The first caller mines; the rest await its result.
+static CACHED_SIGNET_CHAIN: LazyLock<tokio::sync::OnceCell<Option<PathBuf>>> =
+    LazyLock::new(tokio::sync::OnceCell::new);
+
+/// Path to the pre-mined signet chain, mining it first if it isn't there yet.
+///
+/// Mining signet blocks costs real proof-of-work, and a fresh chain needs 100+
+/// blocks before any coinbase is spendable -- which cost more than the rest of
+/// the test suite put together. Since [`SIGNET_CHALLENGE_SECRET_KEY`] is fixed,
+/// that chain is identical every run, so it is mined once and reused: by later
+/// runs on the same machine, and on CI by caching `SIGNET_CHAIN_DIR`.
+///
+/// Returns `None` when `SIGNET_CHAIN_DIR` is unset, i.e. when there is nowhere
+/// to keep a chain. Signet tests then mine to coinbase maturity themselves:
+/// much slower, but self-contained and correct.
+async fn cached_signet_chain(
+    bin_paths: &BinPaths,
+    signet_setup: &SignetSetup,
+) -> anyhow::Result<Option<PathBuf>> {
+    CACHED_SIGNET_CHAIN
+        .get_or_try_init(|| async {
+            let Some(dir) = std::env::var_os("SIGNET_CHAIN_DIR").map(PathBuf::from) else {
+                tracing::debug!("SIGNET_CHAIN_DIR is unset, not caching a signet chain");
+                return Ok(None);
+            };
+            if !usable_cached_signet_chain(&dir, signet_setup) {
+                let () = mine_cached_signet_chain(bin_paths, &dir, signet_setup).await?;
+            }
+            Ok(Some(dir))
+        })
+        .await
+        .cloned()
+}
+
+/// Mine the cached signet chain into `out_dir`, replacing anything already
+/// there.
+///
+/// Runs bitcoind and the signet miner on a throwaway datadir, mines
+/// [`SIGNET_CACHED_CHAIN_BLOCKS`] blocks to an address the node wallet owns,
+/// shuts bitcoind down cleanly, then snapshots the datadir.
+async fn mine_cached_signet_chain(
+    bin_paths: &BinPaths,
+    out_dir: &std::path::Path,
+    signet_setup: &SignetSetup,
+) -> anyhow::Result<()> {
+    tracing::info!(
+        "Mining {SIGNET_CACHED_CHAIN_BLOCKS}-block signet chain into `{}`. \
+         This is a one-off: later runs reuse it.",
+        out_dir.display()
+    );
+    let reserved_ports = ReservedPorts::new()?;
+    let dirs = Directories::new()?;
+    let (res_tx, _res_rx) = mpsc::unbounded::<anyhow::Result<()>>();
+
+    let mut bitcoind = new_bitcoind(
+        bin_paths,
+        BitcoindKind::Patched,
+        dirs.bitcoin_dir.clone(),
+        &reserved_ports,
+        Network::Signet,
+        Some(signet_setup),
+    )?;
+    // Match what the tests run with, so the snapshot doesn't force a reindex.
+    bitcoind.txindex = true;
+    let bitcoind_task = bitcoind.spawn_command_with_args::<String, String, _, _, _>([], [], {
+        move |err| {
+            let _err: Result<(), _> = res_tx.unbounded_send(Err(err));
+        }
+    });
+    let mut bitcoin_cli = bitcoind.new_bitcoin_cli(bin_paths.bitcoin_cli()?.clone());
+    wait_for_bitcoind_ready(&bitcoin_cli).await?;
+
+    let _create_wallet_output = bitcoin_cli
+        .command::<String, _, _, _, _>([], "createwallet", ["integration-test"])
+        .run_utf8()
+        .await?;
+    bitcoin_cli.rpc_wallet = Some("integration-test".to_owned());
+    let () = signet_setup.init_bitcoind_wallet(&bitcoin_cli).await?;
+
+    // Pay the coinbases to an address the wallet actually owns, so the whole
+    // point of this chain -- mature, *spendable* coins ready on startup -- is
+    // met. Note this is deliberately not `signet_challenge_addr`: that is
+    // derived from the challenge script code, so it satisfies the signet block
+    // signature but is not an output the wallet can spend from.
+    let mining_address = bitcoin_cli
+        .command::<String, _, String, _, _>([], "getnewaddress", [])
+        .run_utf8()
+        .await?
+        .trim()
+        .parse::<bitcoin::Address<_>>()?
+        .require_network(bitcoin::Network::Signet)?;
+    tracing::info!(%mining_address, "Mining cached chain's coinbases to the node wallet");
+    let signet_miner = bins::SignetMiner {
+        path: bin_paths.signet_miner()?.clone(),
+        bitcoin_cli: bitcoin_cli.clone(),
+        bitcoin_util: bin_paths.bitcoin_util()?.clone(),
+        block_interval: None,
+        coinbase_recipient: Some(mining_address.clone()),
+        debug: false,
+        // Signet's floor difficulty. Still real work -- roughly 0.6s of
+        // grinding per block -- which is exactly why this is cached.
+        nbits: None,
+        // Mine against Bitcoin Core's own templates: these are plain funding
+        // blocks, with no BIP300 messages that would need the enforcer.
+        getblocktemplate_command: None,
+        coinbasetxn: false,
+    };
+    for height in 1..=SIGNET_CACHED_CHAIN_BLOCKS {
+        let _mine_output = signet_miner
+            .command("generate", vec!["--address", &mining_address.to_string()])
+            .run_utf8()
+            .await?;
+        if height % 25 == 0 || height == SIGNET_CACHED_CHAIN_BLOCKS {
+            tracing::info!("Mined {height}/{SIGNET_CACHED_CHAIN_BLOCKS} signet blocks");
+        }
+    }
+    let blocks: u32 = bitcoin_cli
+        .command::<String, _, String, _, _>([], "getblockcount", [])
+        .run_utf8()
+        .await?
+        .trim()
+        .parse()?;
+    anyhow::ensure!(
+        blocks == SIGNET_CACHED_CHAIN_BLOCKS,
+        "expected to mine {SIGNET_CACHED_CHAIN_BLOCKS} blocks, chain is at height {blocks}"
+    );
+
+    // Shut bitcoind down cleanly so the snapshot has a consistent chainstate
+    // and a flushed wallet, rather than one that needs recovery on load.
+    // bitcoind closes its RPC port early in shutdown and keeps flushing after,
+    // so wait for the process itself to exit -- not for the port to free up.
+    tracing::info!("Stopping bitcoind before snapshotting");
+    let _stop_output = bitcoin_cli
+        .command::<String, _, String, _, _>([], "stop", [])
+        .run_utf8()
+        .await?;
+    timeout(Duration::from_secs(120), bitcoind_task.into_inner())
+        .await
+        .map_err(|_elapsed| anyhow!("Timed out waiting for bitcoind to shut down"))??;
+
+    if out_dir.exists() {
+        std::fs::remove_dir_all(out_dir)?;
+    }
+    copy_datadir(&dirs.bitcoin_dir, out_dir)?;
+    std::fs::write(
+        out_dir.join(SIGNET_CHAIN_MARKER_FILE),
+        signet_chain_marker(signet_setup),
+    )?;
+    tracing::info!(
+        "Wrote cached signet chain ({SIGNET_CACHED_CHAIN_BLOCKS} blocks) to `{}`",
+        out_dir.display()
+    );
+    Ok(())
 }
 
 /// Running tasks, aborted on drop
@@ -603,6 +965,22 @@ impl PostSetup {
         // regtest and signet regardless of either, and the one mode that does
         // need a mempool (`GetBlockTemplate`) enables it by construction.
 
+        // Start signet from the pre-mined chain when one is cached, so the
+        // test doesn't have to re-do its proof-of-work. It ships bitcoind's
+        // wallet too, already holding mature coinbases.
+        let cached_signet_chain = match signet_setup.as_ref() {
+            Some(signet_setup) => cached_signet_chain(bin_paths, signet_setup).await?,
+            None => None,
+        };
+        if let Some(cached_chain) = &cached_signet_chain {
+            tracing::debug!(
+                "Restoring cached signet chain from `{}`",
+                cached_chain.display()
+            );
+            copy_datadir(cached_chain, &dirs.bitcoin_dir)?;
+        }
+        let restored_signet_chain = cached_signet_chain.is_some();
+
         tracing::debug!("Starting bitcoin node");
         let mut bitcoind = new_bitcoind(
             bin_paths,
@@ -624,16 +1002,36 @@ impl PostSetup {
         let mut bitcoin_cli = bitcoind.new_bitcoin_cli(bin_paths.bitcoin_cli()?.clone());
         wait_for_bitcoind_ready(&bitcoin_cli).await?;
 
-        // Create a wallet and initialize it
-        tracing::debug!("Creating wallet");
-        let _create_wallet_output = bitcoin_cli
-            .command::<String, _, _, _, _>([], "createwallet", ["integration-test"])
-            .run_utf8()
-            .await?;
-        bitcoin_cli.rpc_wallet = Some("integration-test".to_owned());
+        // Create a wallet and initialize it. A restored chain already ships
+        // one, holding the mature coinbases it was mined to.
+        const WALLET_NAME: &str = "integration-test";
+        if restored_signet_chain {
+            tracing::debug!("Loading wallet from the restored chain");
+            let loaded_wallets: Vec<String> = serde_json::from_str(
+                &bitcoin_cli
+                    .command::<String, _, String, _, _>([], "listwallets", [])
+                    .run_utf8()
+                    .await?,
+            )?;
+            if !loaded_wallets.iter().any(|wallet| wallet == WALLET_NAME) {
+                let _load_wallet_output = bitcoin_cli
+                    .command::<String, _, _, _, _>([], "loadwallet", [WALLET_NAME])
+                    .run_utf8()
+                    .await?;
+            }
+        } else {
+            tracing::debug!("Creating wallet");
+            let _create_wallet_output = bitcoin_cli
+                .command::<String, _, _, _, _>([], "createwallet", [WALLET_NAME])
+                .run_utf8()
+                .await?;
+        }
+        bitcoin_cli.rpc_wallet = Some(WALLET_NAME.to_owned());
         let mining_address = match signet_setup.as_ref() {
             Some(signet_setup) => {
-                let () = signet_setup.init_bitcoind_wallet(&bitcoin_cli).await?;
+                if !restored_signet_chain {
+                    let () = signet_setup.init_bitcoind_wallet(&bitcoin_cli).await?;
+                }
                 signet_setup.signet_challenge_addr.clone()
             }
             None => {
@@ -678,9 +1076,24 @@ impl PostSetup {
         } else {
             None
         };
-        // Mine 1 block
+        // Mine 1 block, so the chain is non-empty. A restored chain already
+        // has blocks -- and mining a signet one costs real proof-of-work, so
+        // don't.
         tracing::debug!(%mining_address, "Mining 1 block");
-        if let Some(signet_miner) = signet_miner.as_ref() {
+        if restored_signet_chain {
+            let blocks: u32 = bitcoin_cli
+                .command::<String, _, String, _, _>([], "getblockcount", [])
+                .run_utf8()
+                .await?
+                .trim()
+                .parse()?;
+            anyhow::ensure!(
+                blocks >= SIGNET_CACHED_CHAIN_BLOCKS,
+                "restored signet chain is only {blocks} blocks, expected at least \
+                 {SIGNET_CACHED_CHAIN_BLOCKS}"
+            );
+            tracing::debug!("Restored signet chain at height {blocks}");
+        } else if let Some(signet_miner) = signet_miner.as_ref() {
             let mine_output = signet_miner
                 .command("generate", vec!["--address", &mining_address.to_string()])
                 .run_utf8()
@@ -723,8 +1136,14 @@ impl PostSetup {
                 let _err: Result<(), _> = res_tx.unbounded_send(Err(err));
             }
         });
-        // wait for electrs to start
-        sleep(std::time::Duration::from_secs(1)).await;
+        // Wait for electrs to start serving. The enforcer's wallet talks to
+        // both the Electrum RPC and HTTP ports, so wait for each to accept
+        // connections rather than guessing at a fixed startup delay.
+        for port in [electrs.electrum_rpc_port, electrs.electrum_http_port] {
+            wait_for_port("127.0.0.1", port, Duration::from_secs(60))
+                .await
+                .map_err(|err| anyhow!("Failed waiting for electrs port {port}: {err}"))?;
+        }
         // Start BIP300301 Enforcer
         tracing::debug!("Starting bip300301_enforcer");
         let enforcer = Enforcer {
@@ -763,10 +1182,24 @@ impl PostSetup {
         wait_for_port(
             "127.0.0.1",
             enforcer.serve_grpc_port,
-            Duration::from_secs(10),
+            Duration::from_secs(60),
         )
         .await
         .map_err(|e| anyhow!("Failed waiting for enforcer gRPC port: {e}"))?;
+
+        // The JSON-RPC (`getblocktemplate`) server comes up after the gRPC one,
+        // and only in the mode that serves block templates. Both the `gbt_client`
+        // below and the signet miner's GBT script talk to it, so wait for it
+        // too rather than racing the first template request against startup.
+        if enforcer.enable_block_template_server {
+            wait_for_port(
+                "127.0.0.1",
+                enforcer.serve_rpc_port,
+                Duration::from_secs(60),
+            )
+            .await
+            .map_err(|e| anyhow!("Failed waiting for enforcer JSON-RPC port: {e}"))?;
+        }
 
         let gbt_client = jsonrpsee::http_client::HttpClient::builder()
             .build(format!("http://127.0.0.1:{}", enforcer.serve_rpc_port))

--- a/integration_tests/signet_chain_params.rs
+++ b/integration_tests/signet_chain_params.rs
@@ -1,0 +1,30 @@
+//! Everything that determines what the cached signet chain *is*.
+//!
+//! Kept in its own file, separate from the rest of the harness, so that CI can
+//! key its cache of the pre-mined chain on this file's hash: the cache then
+//! survives ordinary edits to `setup.rs`, and is invalidated exactly when the
+//! chain these values describe would actually differ.
+//!
+//! Changing anything here means every cached chain (local and CI) is stale.
+//! Locally, the harness notices and re-mines; see `cached_signet_chain_dir`.
+
+/// Fixed secret key backing the signet challenge used by the integration
+/// tests.
+///
+/// TEST ONLY -- this is a hardcoded, publicly known key for a throwaway local
+/// signet. It must never be used to hold real funds on any network.
+///
+/// It is fixed rather than random so that the whole signet chain (challenge,
+/// network magic, genesis block) is reproducible across runs, which is what
+/// lets a pre-mined chain be cached and reused instead of re-mined -- mining
+/// signet blocks costs real proof-of-work, and mining the 100 blocks needed
+/// for coinbase maturity dominated the entire test suite's runtime.
+pub const SIGNET_CHALLENGE_SECRET_KEY: [u8; 32] = [
+    0x1b, 0x30, 0x03, 0x01, 0x1b, 0x30, 0x03, 0x01, 0x1b, 0x30, 0x03, 0x01, 0x1b, 0x30, 0x03, 0x01,
+    0x1b, 0x30, 0x03, 0x01, 0x1b, 0x30, 0x03, 0x01, 0x1b, 0x30, 0x03, 0x01, 0x1b, 0x30, 0x03, 0x01,
+];
+
+/// Number of blocks in the cached signet chain. Must exceed
+/// `COINBASE_MATURITY` (100) so that the earliest coinbases are spendable the
+/// moment a test starts, which is the entire point of caching it.
+pub const SIGNET_CACHED_CHAIN_BLOCKS: u32 = 110;

--- a/integration_tests/test_activation_height.rs
+++ b/integration_tests/test_activation_height.rs
@@ -19,11 +19,10 @@ use bip300301_enforcer_lib::{
         },
     },
 };
-use tokio::time::sleep;
 
 use crate::{
     mine::mine,
-    setup::{DummySidechain, PostSetup, Sidechain as _},
+    setup::{DummySidechain, PostSetup, Sidechain as _, wait_for_pending_proposal},
 };
 
 async fn block_count(post_setup: &PostSetup) -> anyhow::Result<u32> {
@@ -95,7 +94,13 @@ pub async fn test_activation_height(mut post_setup: PostSetup) -> anyhow::Result
         .block_producer_service_client
         .create_sidechain_proposal(create_sidechain_proposal_request)
         .await?;
-    sleep(std::time::Duration::from_secs(1)).await;
+    // The proposal must be persisted before we mine, or the coinbases below
+    // the activation height won't carry the M1 this test needs them to.
+    let () = wait_for_pending_proposal(
+        &post_setup.block_producer_service_client,
+        DummySidechain::SIDECHAIN_NUMBER,
+    )
+    .await?;
 
     // Mine up to (but not including) the activation height. Every one of
     // these coinbases carries the M1; the validator must ignore all of them.

--- a/integration_tests/test_consecutive_deposits.rs
+++ b/integration_tests/test_consecutive_deposits.rs
@@ -5,6 +5,7 @@ use bip300301_enforcer_lib::{
         mainchain::{
             CreateDepositTransactionRequest, CreateDepositTransactionResponse,
             CreateNewAddressRequest, ListUnspentOutputsRequest, SendTransactionRequest,
+            SendTransactionResponse,
         },
     },
 };
@@ -15,7 +16,7 @@ use crate::{
     integration_test::{
         activate_sidechain, fund_enforcer, propose_sidechain, wait_for_wallet_sync,
     },
-    setup::{DummySidechain, PostSetup, Sidechain as _},
+    setup::{DummySidechain, PostSetup, Sidechain as _, wait_for_tx_in_mempool},
 };
 
 const DEPOSIT_AMOUNT: bitcoin::Amount = bitcoin::Amount::from_sat(21_000_000);
@@ -91,21 +92,34 @@ async fn consolidate_to_single_utxo(post_setup: &mut PostSetup) -> anyhow::Resul
             .await?
             .into_owned()
             .address;
-        let _drain = post_setup
+        let drain_txid = post_setup
             .wallet_service_client
             .send_transaction(SendTransactionRequest {
                 drain_wallet_to: Some(drain_address),
                 ..Default::default()
             })
-            .await?;
-        sleep(std::time::Duration::from_secs(1)).await;
+            .await?
+            .into_owned()
+            .txid
+            .ok_or_else(|| proto::Error::missing_field::<SendTransactionResponse>("txid"))?
+            .decode::<SendTransactionResponse, _>("txid")?;
+        // The drain must be in the mempool before we mine, or it won't confirm.
+        let () = wait_for_tx_in_mempool(&post_setup.bitcoin_cli, &drain_txid).await?;
         let () = mine_to_core(post_setup, 1).await?;
-        // Poll for the enforcer wallet to ingest the confirmed drain.
-        for _ in 0..10 {
-            sleep(std::time::Duration::from_secs(2)).await;
+        // Poll for the enforcer wallet to ingest the confirmed drain. A timeout
+        // here is not fatal: a single drain can't always sweep the whole
+        // wallet, so fall through and let the outer loop try another one.
+        const INGEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(20);
+        const INGEST_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(100);
+        let deadline = std::time::Instant::now() + INGEST_TIMEOUT;
+        loop {
             if unspent_output_count(post_setup).await? == 1 {
                 return Ok(());
             }
+            if std::time::Instant::now() >= deadline {
+                break;
+            }
+            sleep(INGEST_POLL_INTERVAL).await;
         }
     }
     anyhow::bail!(
@@ -133,8 +147,7 @@ pub async fn test_consecutive_deposits(mut post_setup: PostSetup) -> anyhow::Res
     // First deposit: always succeeds, spending the sole UTXO.
     let deposit_txid_1 = create_deposit(&mut post_setup, "sidechain address 1").await?;
     tracing::info!(%deposit_txid_1, "Created first deposit");
-    // Wait for the deposit tx to enter the mempool.
-    sleep(std::time::Duration::from_secs(1)).await;
+    let () = wait_for_tx_in_mempool(&post_setup.bitcoin_cli, &deposit_txid_1).await?;
 
     // Second deposit, without a block in between. This must succeed: it should
     // be funded from the first deposit's change output, not by reselecting the
@@ -149,7 +162,7 @@ pub async fn test_consecutive_deposits(mut post_setup: PostSetup) -> anyhow::Res
             )
         })?;
     tracing::info!(%deposit_txid_2, "Created second deposit");
-    sleep(std::time::Duration::from_secs(1)).await;
+    let () = wait_for_tx_in_mempool(&post_setup.bitcoin_cli, &deposit_txid_2).await?;
 
     anyhow::ensure!(
         deposit_txid_1 != deposit_txid_2,

--- a/integration_tests/test_invalid_block.rs
+++ b/integration_tests/test_invalid_block.rs
@@ -19,7 +19,7 @@ use serde::Deserialize;
 use tokio::time::sleep;
 
 use crate::{
-    block_verdict::{Expect, assert_enforcer_verdict},
+    block_verdict::{Expect, assert_enforcer_verdict, wait_for_enforcer_height},
     integration_test::{activate_sidechain, fund_enforcer, propose_sidechain},
     setup::{DummySidechain, PostSetup, Sidechain},
 };
@@ -224,6 +224,19 @@ async fn submit_m5_missing_address_block(post_setup: &PostSetup) -> anyhow::Resu
         )
         .run_utf8()
         .await?;
+
+    // Let the enforcer catch up on those blocks before the bad one goes in.
+    // Mining that many at once leaves it far enough behind that the verdict
+    // timeout below would otherwise expire while it is still connecting the
+    // funding blocks, never having seen the block under test.
+    let funded_height: u32 = post_setup
+        .bitcoin_cli
+        .command::<String, _, String, _, _>([], "getblockcount", [])
+        .run_utf8()
+        .await?
+        .trim()
+        .parse()?;
+    let () = wait_for_enforcer_height(post_setup, funded_height).await?;
 
     let utxos: Vec<Utxo> = {
         let json = post_setup

--- a/integration_tests/test_peer_bmm_request.rs
+++ b/integration_tests/test_peer_bmm_request.rs
@@ -13,13 +13,16 @@ use bip300301_enforcer_lib::{
 };
 use buffa::MessageField;
 use futures::{StreamExt as _, channel::mpsc};
-use tokio::time::sleep;
 use tracing::Instrument as _;
 
 use crate::{
     integration_test::{activate_sidechain, fund_enforcer, propose_sidechain},
     mine,
-    setup::{BitcoindKind, DummySidechain, Mode, Network, SetupOpts, Sidechain},
+    setup::{
+        BitcoindKind, DummySidechain, Mode, Network, SetupOpts, Sidechain,
+        WAIT_POLL_INTERVAL_SUBPROCESS, wait_for_port_free, wait_for_tx_in_mempool, wait_until,
+        wait_until_every,
+    },
     util::{self, BinPaths, FileDumpConfig, TestFileRegistry},
 };
 
@@ -183,15 +186,17 @@ async fn test_peer_bmm_request_task(mut post_setup: PostSetup) -> anyhow::Result
         anyhow::bail!("Failed to create a tx to fund sender wallet")
     };
     let () = crate::mine::mine::<DummySidechain>(&mut post_setup.miner, 1, None).await?;
-    // Wait for sender to receive block
-    sleep(std::time::Duration::from_secs(1)).await;
-    let sender_balance = post_setup
-        .sender
-        .wallet_service_client
-        .get_balance(GetBalanceRequest::default())
-        .await?
-        .into_owned();
-    anyhow::ensure!(sender_balance.confirmed_sats > 0);
+    // Wait for the sender to receive the block over p2p and credit the funds.
+    let () = wait_until("sender wallet to see the funding tx confirmed", || async {
+        let balance = post_setup
+            .sender
+            .wallet_service_client
+            .get_balance(GetBalanceRequest::default())
+            .await?
+            .into_owned();
+        Ok(balance.confirmed_sats > 0)
+    })
+    .await?;
     tracing::info!("Funded enforcer successfully (sender)");
 
     let BlockHeaderInfo {
@@ -248,29 +253,32 @@ async fn test_peer_bmm_request_task(mut post_setup: PostSetup) -> anyhow::Result
         .run_utf8()
         .await?;
     tracing::debug!(%sender_mempool_entry);
-    // Wait for mempool inclusion / p2p broadcast.
-    // This can take >5s sometimes, for unknown reasons.
-    sleep(std::time::Duration::from_secs(10)).await;
-    let mempool_entry = post_setup
-        .miner
-        .bitcoin_cli
-        .command::<String, _, _, _, _>([], "getmempoolentry", [bmm_request_txid])
-        .run_utf8()
-        .await?;
-    tracing::debug!(%mempool_entry);
+    // Wait for the BMM request to reach the miner node's mempool over p2p.
+    let () = wait_for_tx_in_mempool(
+        &post_setup.miner.bitcoin_cli,
+        &bmm_request_txid.parse::<bitcoin::Txid>()?,
+    )
+    .await?;
     // Check that the tx entered the sender node's mempool via RPC broadcast,
-    // rather than via p2p relay from the miner node
-    let sender_enforcer_stdout = std::fs::read_to_string(
-        post_setup
-            .sender
-            .directories
-            .enforcer_dir
-            .join("stdout.txt"),
-    )?;
-    anyhow::ensure!(
-        sender_enforcer_stdout.contains("Broadcast BMM request transaction via RPC to own node"),
-        "Expected sender enforcer to broadcast the BMM request tx via RPC to its own node"
-    );
+    // rather than via p2p relay from the miner node. The enforcer logs this
+    // asynchronously, so poll rather than reading the log once.
+    const RPC_BROADCAST_LOG_LINE: &str = "Broadcast BMM request transaction via RPC to own node";
+    let sender_enforcer_stdout_path = post_setup
+        .sender
+        .directories
+        .enforcer_dir
+        .join("stdout.txt");
+    // The enforcer log is megabytes of trace output, so re-reading it in full
+    // is not a cheap check -- poll it at the slower interval.
+    let () = wait_until_every(
+        "sender enforcer to log the BMM request RPC broadcast to its own node",
+        WAIT_POLL_INTERVAL_SUBPROCESS,
+        || async {
+            let stdout = std::fs::read_to_string(&sender_enforcer_stdout_path)?;
+            Ok(stdout.contains(RPC_BROADCAST_LOG_LINE))
+        },
+    )
+    .await?;
     // Mine a block and check that the BMM request worked
     let () = mine::mine_check_block_events::<_, DummySidechain>(
         &mut post_setup.miner,
@@ -293,10 +301,23 @@ async fn test_peer_bmm_request_task(mut post_setup: PostSetup) -> anyhow::Result
         post_setup.miner.directories.base_dir.path().display(),
         post_setup.sender.directories.base_dir.path().display()
     );
+    // The child processes hold their data dirs open, so wait for them to
+    // actually exit before removing the dirs out from under them. Aborting the
+    // task only schedules cancellation; a freed port is proof it finished.
+    let teardown_ports: Vec<u16> = [&post_setup.miner, &post_setup.sender]
+        .into_iter()
+        .flat_map(|setup| {
+            [
+                setup.reserved_ports.bitcoind_rpc.port(),
+                setup.reserved_ports.enforcer_serve_grpc.port(),
+            ]
+        })
+        .collect();
     drop(post_setup.miner.tasks);
     drop(post_setup.sender.tasks);
-    // Wait for tasks to die
-    sleep(std::time::Duration::from_secs(1)).await;
+    for port in teardown_ports {
+        wait_for_port_free("127.0.0.1", port, std::time::Duration::from_secs(30)).await?;
+    }
     post_setup.miner.directories.base_dir.cleanup()?;
     post_setup.sender.directories.base_dir.cleanup()?;
     Ok(())

--- a/integration_tests/test_wallet_reorg_multi_block.rs
+++ b/integration_tests/test_wallet_reorg_multi_block.rs
@@ -7,7 +7,7 @@
 //! enforcer's validated tip stuck behind bitcoind's tip, a terminal state
 //! nothing else can sync past.
 
-use std::{str::FromStr as _, time::Duration};
+use std::str::FromStr as _;
 
 use bip300301_enforcer_lib::{
     bins::CommandExt as _,
@@ -24,7 +24,7 @@ use serde::Deserialize;
 
 use crate::{
     integration_test::{fund_enforcer, wait_for_wallet_sync},
-    setup::{DummySidechain, Mode, Network, PostSetup, PreSetup, SetupOpts, Sidechain},
+    setup::{DummySidechain, Mode, Network, PostSetup, PreSetup, SetupOpts, Sidechain, wait_until},
     util::BinPaths,
 };
 
@@ -431,6 +431,17 @@ async fn rejected_block_scenario(
         .run_utf8()
         .await?;
 
+    // The last block the enforcer can accept: everything from the poisoned
+    // block onwards builds on a chain it rejects, so this is where its own
+    // validated tip must come to rest once it has caught up.
+    let last_valid_height: u32 = post_setup
+        .bitcoin_cli
+        .command::<String, _, String, _, _>([], "getblockcount", [])
+        .run_utf8()
+        .await?
+        .trim()
+        .parse()?;
+
     // Force-mine a block containing the now-stale bid directly, bypassing
     // ordinary mempool/fee-based template selection entirely (which would
     // never pick a bid this stale on its own) -- exactly what an operator
@@ -482,31 +493,37 @@ async fn rejected_block_scenario(
         .restart_enforcer(bin_paths, Vec::<String>::new(), res_tx.clone())
         .await?;
 
-    // Give the batch sync a moment to actually run, then confirm the
-    // process is still alive and responsive -- pre-fix, it crashed almost
-    // immediately on restart and this call would fail with a connection
-    // error.
-    tokio::time::sleep(Duration::from_secs(2)).await;
-    let tip_info = post_setup
-        .validator_service_client
-        .get_chain_tip(GetChainTipRequest::default())
-        .await?
-        .into_owned();
+    // Wait for the batch sync to actually land on the last block the enforcer
+    // accepts. Polling `GetChainTip` doubles as the liveness check this
+    // scenario exists for -- pre-fix the enforcer crashed almost immediately
+    // on restart, so these calls would fail with a connection error rather
+    // than ever reaching the expected height.
+    let () = wait_until(
+        &format!("enforcer's validated tip to settle at height {last_valid_height}"),
+        || async {
+            let synced_height = post_setup
+                .validator_service_client
+                .get_chain_tip(GetChainTipRequest::default())
+                .await?
+                .into_owned()
+                .block_header_info
+                .into_option()
+                .ok_or_else(|| anyhow::anyhow!("GetChainTipResponse missing block_header_info"))?
+                .height;
+            anyhow::ensure!(
+                synced_height <= last_valid_height,
+                "expected the enforcer's own validated tip ({synced_height}) to stop at the last \
+                 block it accepts ({last_valid_height}), strictly before bitcoind's tip \
+                 ({tip_after_height}), since everything from the rejected block onward builds on \
+                 a chain it doesn't accept"
+            );
+            Ok(synced_height == last_valid_height)
+        },
+    )
+    .await?;
     tracing::info!(
-        ?tip_info,
-        "enforcer survived the restart and answered GetChainTip"
-    );
-
-    let synced_height = tip_info
-        .block_header_info
-        .into_option()
-        .ok_or_else(|| anyhow::anyhow!("GetChainTipResponse missing block_header_info"))?
-        .height;
-    anyhow::ensure!(
-        synced_height < tip_after_height,
-        "expected the enforcer's own validated tip ({synced_height}) to stop strictly before \
-         bitcoind's tip ({tip_after_height}), since everything from the rejected block onward \
-         builds on a chain it doesn't accept"
+        last_valid_height,
+        "enforcer survived the restart and caught up to its last accepted block"
     );
 
     Ok(())

--- a/scripts/setup_integration_tests.sh
+++ b/scripts/setup_integration_tests.sh
@@ -56,6 +56,9 @@ DRYNET_DIR="$DEPS_DIR/bitcoin-ecash-$DRYNET_REVISION"
 UNPATCHED_DIR="$DEPS_DIR/bitcoin-stock-$BITCOIN_VERSION"
 SIGNET_REPO_DIR="$DEPS_DIR/bitcoin-patched-repo"
 ELECTRS_DIR="$DEPS_DIR/electrs-$ELECTRS_VERSION"
+# Pre-mined signet chain, reused across runs. Not built here (it needs the
+# integration-test binary); `just test-it` mines it on first use.
+SIGNET_CHAIN_DIR="$DEPS_DIR/signet-chain"
 
 # `releases.drivechain.info` only publishes patched bitcoin for
 # x86_64-{linux,darwin,windows}. arm64 falls back to the x86_64 darwin
@@ -176,6 +179,7 @@ BITCOIN_CLI='$bins_dir/bitcoin-cli'
 BITCOIN_UTIL='$bins_dir/bitcoin-util'
 ELECTRS='$ELECTRS_BIN'
 SIGNET_MINER='$SIGNET_REPO_DIR/contrib/signet/miner'
+SIGNET_CHAIN_DIR='$SIGNET_CHAIN_DIR'
 EOF
     echo "Wrote $env_file"
 }


### PR DESCRIPTION
Signet mining was dominating runtime for the integration tests. Change the setup to use a deterministic private key, such that the chainstate can be cached. The first run does the expensive CPU mining we previously did every run, and then the next runs just reuse that chain data.

Also remove a few 'stupid' sleeps around the integration test codebase in favor of checking for states and events.

A cached run is reduced by around 2/3 on my machine. 