### PR TITLE
Dump all command line args to logs, w/ secrets redacted

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -470,7 +470,6 @@ dependencies = [
  "bitcoin",
  "bitcoin-jsonrpsee",
  "buffa",
- "clap",
  "connectrpc",
  "connectrpc-health",
  "connectrpc-reflection",

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -12,7 +12,6 @@ buffa = { workspace = true }
 bip300301_enforcer_lib = { path = "../lib", default-features = false }
 bitcoin = { workspace = true }
 bitcoin-jsonrpsee = { workspace = true }
-clap = { workspace = true, features = ["std"] }
 cusf-enforcer-mempool = { workspace = true }
 educe = { workspace = true }
 either = { workspace = true }

--- a/app/main.rs
+++ b/app/main.rs
@@ -30,7 +30,6 @@ use bip300301_enforcer_lib::{
 };
 use bitcoin::ScriptBuf;
 use bitcoin_jsonrpsee::{MainClient, jsonrpsee::http_client::transport};
-use clap::Parser;
 use connectrpc::Router;
 use connectrpc_health::{HealthExt, HealthService, StaticChecker};
 use connectrpc_reflection::Reflector;
@@ -1068,7 +1067,7 @@ async fn main() -> Result<()> {
         default_hook(info); // Panics are bad. re-throw!
     }));
 
-    let cli = cli::Config::parse();
+    let (cli, arg_matches) = cli::Config::parse_with_matches();
     // Assign the tracing guard to a variable so that it is dropped when the end of main is reached.
     let _tracing_guard = logging::set_tracing_subscriber(
         cli.log_formatter(),
@@ -1082,6 +1081,7 @@ async fn main() -> Result<()> {
         build = if cfg!(debug_assertions) { "debug" } else { "release" },
         "Starting up bip300301_enforcer",
     );
+    cli::log_effective_config(&arg_matches);
 
     // Validate the verification reference early, before creating node connections etc.
     let verify_reference = cli

--- a/integration_tests/integration_test.rs
+++ b/integration_tests/integration_test.rs
@@ -925,6 +925,18 @@ pub fn tests(
         crate::test_blinded_m6_roundtrip::test_blinded_m6_zero_input_roundtrip,
     ));
 
+    async_trials.push(new_trial_with_setup(
+        crate::test_no_secrets_in_logs::TEST_NAME.to_string(),
+        TestSetupComponents {
+            bin_paths: bin_paths.clone(),
+            network: Network::Regtest,
+            mode: Mode::Mempool,
+            file_registry: file_registry.clone(),
+            failure_collector: failure_collector.clone(),
+        },
+        crate::test_no_secrets_in_logs::test_no_secrets_in_logs,
+    ));
+
     // Needs direct `bin_paths` (to respawn the enforcer mid-test), so it uses
     // a bespoke trial rather than `new_trial_with_setup`.
     async_trials.push({

--- a/integration_tests/lib.rs
+++ b/integration_tests/lib.rs
@@ -9,6 +9,7 @@ mod test_file_based_block_parser;
 mod test_generate_to_address;
 mod test_inactive_drivechain_output;
 mod test_invalid_block;
+mod test_no_secrets_in_logs;
 mod test_peer_bmm_request;
 mod test_seed_migration;
 mod test_sidechain_ack_policy;

--- a/integration_tests/setup.rs
+++ b/integration_tests/setup.rs
@@ -862,8 +862,10 @@ impl PostSetup {
             node_rpc_pass: self
                 .bitcoin_cli
                 .rpc_pass
-                .clone()
-                .ok_or_else(|| anyhow!("bitcoin_cli has no rpc_pass"))?,
+                .as_ref()
+                .ok_or_else(|| anyhow!("bitcoin_cli has no rpc_pass"))?
+                .expose()
+                .to_owned(),
             node_rpc_port: self.bitcoin_cli.rpc_port,
             node_zmq_sequence_port: self.reserved_ports.bitcoind_zmq_sequence.port(),
             serve_grpc_port: self.reserved_ports.enforcer_serve_grpc.port(),
@@ -933,8 +935,10 @@ impl PostSetup {
                     .ok_or_else(|| anyhow!("bitcoin_cli has no rpc_user"))?,
                 self.bitcoin_cli
                     .rpc_pass
-                    .clone()
-                    .ok_or_else(|| anyhow!("bitcoin_cli has no rpc_pass"))?,
+                    .as_ref()
+                    .ok_or_else(|| anyhow!("bitcoin_cli has no rpc_pass"))?
+                    .expose()
+                    .to_owned(),
             ),
             daemon_dir: self.directories.bitcoin_dir.join("path"),
             daemon_rpc_port: self.bitcoin_cli.rpc_port,

--- a/integration_tests/test_no_secrets_in_logs.rs
+++ b/integration_tests/test_no_secrets_in_logs.rs
@@ -1,0 +1,149 @@
+//! Nothing the enforcer was configured with as a secret may appear in
+//! anything it writes.
+//!
+//! The unit tests in `lib/cli.rs` cover how the startup configuration dump
+//! renders a `SecretString`. This covers everything a *running* enforcer
+//! emits around that -- RPC client output, error messages, span fields -- with
+//! the harness's `trace` log level turned on, which is where a leak is most
+//! likely to show up.
+
+use std::path::PathBuf;
+
+use bip300301_enforcer_lib::cli::SecretString;
+
+use crate::{
+    integration_test::fund_enforcer,
+    setup::{DummySidechain, PostSetup},
+};
+
+pub const TEST_NAME: &str = "no_secrets_in_logs";
+
+/// Standard base64, to reconstruct the HTTP Basic credentials the enforcer
+/// sends to Bitcoin Core. A leak through an `Authorization` header would never
+/// show the password in plaintext, so searching for the plaintext alone would
+/// miss it.
+fn base64_encode(input: &[u8]) -> String {
+    const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut out = String::new();
+    for chunk in input.chunks(3) {
+        let bytes = [
+            chunk[0],
+            chunk.get(1).copied().unwrap_or(0),
+            chunk.get(2).copied().unwrap_or(0),
+        ];
+        let n = (u32::from(bytes[0]) << 16) | (u32::from(bytes[1]) << 8) | u32::from(bytes[2]);
+        out.push(char::from(ALPHABET[((n >> 18) & 63) as usize]));
+        out.push(char::from(ALPHABET[((n >> 12) & 63) as usize]));
+        out.push(if chunk.len() > 1 {
+            char::from(ALPHABET[((n >> 6) & 63) as usize])
+        } else {
+            '='
+        });
+        out.push(if chunk.len() > 2 {
+            char::from(ALPHABET[(n & 63) as usize])
+        } else {
+            '='
+        });
+    }
+    out
+}
+
+/// Everything the enforcer writes: both captured streams and every rolling log
+/// file. Missing files are skipped -- `stderr.txt` is empty on a healthy run.
+fn enforcer_output(post_setup: &PostSetup) -> anyhow::Result<Vec<(PathBuf, String)>> {
+    let dir = &post_setup.directories.enforcer_dir;
+    let mut paths = vec![dir.join("stdout.txt"), dir.join("stderr.txt")];
+    let log_dir = dir.join("logs");
+    if log_dir.is_dir() {
+        for entry in std::fs::read_dir(&log_dir)? {
+            let path = entry?.path();
+            if path.is_file() {
+                paths.push(path);
+            }
+        }
+    }
+
+    let mut out = Vec::new();
+    for path in paths {
+        match std::fs::read_to_string(&path) {
+            Ok(contents) => out.push((path, contents)),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+            Err(err) => return Err(anyhow::anyhow!("reading {}: {err}", path.display())),
+        }
+    }
+    anyhow::ensure!(!out.is_empty(), "the enforcer wrote no output to scan");
+    Ok(out)
+}
+
+/// Fail with the offending line rather than just a count, so a regression says
+/// where the secret escaped.
+fn assert_absent(files: &[(PathBuf, String)], needle: &str, what: &str) -> anyhow::Result<()> {
+    for (path, contents) in files {
+        if let Some(line) = contents.lines().find(|line| line.contains(needle)) {
+            // The line itself is not printed in full: it contains the secret.
+            let position = line.find(needle).unwrap_or(0);
+            anyhow::bail!(
+                "{what} leaked into {} at character {position} of a {} line starting `{}`",
+                path.display(),
+                line.len(),
+                line.chars().take(60).collect::<String>(),
+            );
+        }
+    }
+    Ok(())
+}
+
+pub async fn test_no_secrets_in_logs(mut post_setup: PostSetup) -> anyhow::Result<()> {
+    // Drive real work through the enforcer first, so the logs cover node RPC
+    // traffic and wallet activity rather than just startup.
+    fund_enforcer::<DummySidechain>(&mut post_setup).await?;
+
+    // Take the secret from the harness rather than hardcoding it, so this
+    // keeps testing the real value if the harness ever changes it.
+    let rpc_user = post_setup
+        .bitcoin_cli
+        .rpc_user
+        .clone()
+        .ok_or_else(|| anyhow::anyhow!("harness has no rpc user"))?;
+    let rpc_pass: SecretString = post_setup
+        .bitcoin_cli
+        .rpc_pass
+        .clone()
+        .ok_or_else(|| anyhow::anyhow!("harness has no rpc password to check for"))?;
+
+    let files = enforcer_output(&post_setup)?;
+    let total_bytes: usize = files.iter().map(|(_, contents)| contents.len()).sum();
+    tracing::info!(
+        "scanning {} enforcer output file(s), {total_bytes} bytes",
+        files.len()
+    );
+
+    // Non-vacuity: prove the scan is reading the content that *would* hold a
+    // leak. The dump reports the RPC user verbatim right next to the password,
+    // so finding it means a leaked password would have been found too.
+    let dumped_user = format!("--node-rpc-user=\"{rpc_user}\"");
+    anyhow::ensure!(
+        files
+            .iter()
+            .any(|(_, contents)| contents.contains(&dumped_user)),
+        "expected the startup config dump to report {dumped_user}; without it this test \
+         proves nothing, since it would be scanning logs that never mention the credentials"
+    );
+    anyhow::ensure!(
+        files
+            .iter()
+            .any(|(_, contents)| contents.contains("--node-rpc-pass=[redacted]")),
+        "the startup config dump must report the password as redacted"
+    );
+
+    // Self-check the encoder, so a broken one cannot make the search below
+    // silently vacuous.
+    assert_eq!(base64_encode(b"hello"), "aGVsbG8=");
+    let basic_auth = base64_encode(format!("{rpc_user}:{}", rpc_pass.expose()).as_bytes());
+
+    assert_absent(&files, rpc_pass.expose(), "the node RPC password")?;
+    assert_absent(&files, &basic_auth, "the node RPC basic-auth credentials")?;
+
+    tracing::info!("no secrets found in enforcer output");
+    Ok(())
+}

--- a/integration_tests/util.rs
+++ b/integration_tests/util.rs
@@ -673,7 +673,9 @@ impl Bitcoind {
             path,
             network: self.network,
             rpc_user: Some(self.rpc_user.clone()),
-            rpc_pass: Some(self.rpc_pass.clone()),
+            rpc_pass: Some(bip300301_enforcer_lib::cli::SecretString::new(
+                self.rpc_pass.clone(),
+            )),
             rpc_cookie_path: None,
             rpc_port: self.rpc_port,
             rpc_host: self.rpc_host.clone(),

--- a/lib/bins.rs
+++ b/lib/bins.rs
@@ -68,7 +68,8 @@ pub struct BitcoinCli {
     pub path: PathBuf,
     pub network: bitcoin::Network,
     pub rpc_user: Option<String>,
-    pub rpc_pass: Option<String>,
+    /// Redacted by `Debug`, so a logged `BitcoinCli` cannot leak it.
+    pub rpc_pass: Option<crate::cli::SecretString>,
     pub rpc_cookie_path: Option<String>,
     pub rpc_port: u16,
     pub rpc_host: String,
@@ -92,7 +93,7 @@ impl BitcoinCli {
         }
 
         if let Some(rpc_pass) = &self.rpc_pass {
-            res.push(format!("-rpcpassword={rpc_pass}"));
+            res.push(format!("-rpcpassword={}", rpc_pass.expose()));
         }
 
         if let Some(rpc_wallet) = &self.rpc_wallet {

--- a/lib/cli.rs
+++ b/lib/cli.rs
@@ -292,8 +292,11 @@ pub struct NodeRpcConfig {
     pub user: Option<String>,
     /// RPC password for Bitcoin Core. Implies also setting user. Cannot
     /// be set together with cookie path.
+    // Doc comments on these fields become `--help` text, so this note is a
+    // plain comment: the `SecretString` type is what redacts this value
+    // everywhere, including the startup configuration dump.
     #[arg(long = "node-rpc-pass")]
-    pub pass: Option<String>,
+    pub pass: Option<SecretString>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, ValueEnum)]
@@ -503,7 +506,197 @@ pub struct Config {
     pub bitcoin_core_skip_version_check: bool,
 }
 
+/// Written in place of a sensitive value.
+const REDACTED: &str = "[redacted]";
+
+/// Written in place of an argument that was neither given nor defaulted.
+const UNSET: &str = "<unset>";
+
+/// A configuration value that must never be written to a log.
+///
+/// The annotation lives on the field, as its type. Two things follow from
+/// that, neither of which depends on anyone maintaining a list of names:
+///
+/// - `Debug` and `Display` print `[redacted]`, so a secret cannot escape
+///   through a stray `{:?}` on a whole config struct.
+/// - [`log_effective_config`] asks clap what type each argument parses into,
+///   so typing a field `SecretString` is what makes it redacted in the dump.
+///
+/// Read the value back with [`SecretString::expose`], which is deliberately
+/// noisy at the call site.
+#[derive(Clone, PartialEq, Eq)]
+pub struct SecretString(String);
+
+impl SecretString {
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    /// Read the underlying secret. Every call is a place a secret could
+    /// escape, so keep them few and obvious.
+    pub fn expose(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Debug for SecretString {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(REDACTED)
+    }
+}
+
+impl std::fmt::Display for SecretString {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(REDACTED)
+    }
+}
+
+/// Parses a [`SecretString`]. Exists so that clap builds a value parser whose
+/// output type is `SecretString`, which is how secret arguments are recognized
+/// without matching on their names.
+#[derive(Clone, Copy, Debug)]
+pub struct SecretStringParser;
+
+impl clap::builder::TypedValueParser for SecretStringParser {
+    type Value = SecretString;
+
+    fn parse_ref(
+        &self,
+        cmd: &clap::Command,
+        _arg: Option<&clap::Arg>,
+        value: &std::ffi::OsStr,
+    ) -> Result<Self::Value, clap::Error> {
+        match value.to_str() {
+            Some(value) => Ok(SecretString::new(value)),
+            // Deliberately does not quote the value back, the way clap's own
+            // InvalidUtf8 message would.
+            None => Err(clap::Error::raw(
+                clap::error::ErrorKind::InvalidUtf8,
+                "secret value is not valid UTF-8\n",
+            )
+            .with_cmd(cmd)),
+        }
+    }
+}
+
+impl clap::builder::ValueParserFactory for SecretString {
+    type Parser = SecretStringParser;
+
+    fn value_parser() -> Self::Parser {
+        SecretStringParser
+    }
+}
+
+/// Whether `arg`'s value is secret, determined by asking clap what type the
+/// argument parses into rather than by matching on its name.
+fn is_secret_arg(arg: &clap::Arg) -> bool {
+    use clap::builder::{ValueParser, ValueParserFactory as _};
+
+    let secret = ValueParser::from(SecretString::value_parser());
+    arg.get_value_parser().type_id() == secret.type_id()
+}
+
+/// Strip the password from a value that parses as a URL, e.g.
+/// `https://user:hunter2@example.com/api`. Returns `None` when there is
+/// nothing to strip, so callers can keep the original value.
+fn redact_embedded_credentials(value: &str) -> Option<String> {
+    let mut url = url::Url::parse(value).ok()?;
+    url.password()?;
+    // `set_password` only fails for URLs that cannot have credentials at all,
+    // which cannot be the case for one that already has a password.
+    url.set_password(Some("redacted")).ok()?;
+    Some(url.to_string())
+}
+
+/// Log the effective value of every argument, one line each, with secrets
+/// masked. This mirrors the configuration dump Bitcoin Core writes at startup:
+/// it makes a log self-describing, so a bug report says exactly what the node
+/// was run with, defaults included.
+pub fn log_effective_config(matches: &clap::ArgMatches) {
+    for line in effective_config_lines(matches) {
+        tracing::info!("Command-line arg: {line}");
+    }
+}
+
+/// Render `name=value (source)` for every argument, sorted by flag name.
+///
+/// Works off the raw [`clap::ArgMatches`] rather than a [`Config`] so that
+/// every argument is covered by construction: a new argument shows up here
+/// without anyone remembering to add it. Kept separate from the logging so
+/// that tests can assert on exactly what would be written.
+fn effective_config_lines(matches: &clap::ArgMatches) -> Vec<String> {
+    use clap::{CommandFactory as _, parser::ValueSource};
+
+    let command = Config::command();
+    // Sorted by the flag the operator actually types, not by clap's internal
+    // id, which is the struct field name and orders the dump arbitrarily.
+    let mut arguments: Vec<_> = command
+        .get_arguments()
+        .filter(|arg| !matches!(arg.get_id().as_str(), "help" | "version"))
+        .map(|arg| {
+            let id = arg.get_id().as_str();
+            let name = arg
+                .get_long()
+                .map_or_else(|| id.to_owned(), |long| format!("--{long}"));
+            (name, id, is_secret_arg(arg))
+        })
+        .collect();
+    arguments.sort_unstable();
+
+    let mut lines = Vec::with_capacity(arguments.len());
+    for (name, id, secret) in arguments {
+        let source = match matches.value_source(id) {
+            Some(ValueSource::CommandLine) => "command line",
+            Some(ValueSource::EnvVariable) => "env",
+            Some(ValueSource::DefaultValue) => "default",
+            _ => "unset",
+        };
+        let values: Vec<String> = match matches.try_get_raw(id) {
+            Ok(Some(values)) => values
+                .map(|value| value.to_string_lossy().into_owned())
+                .collect(),
+            // An argument that was never given and has no default.
+            Ok(None) | Err(_) => Vec::new(),
+        };
+        let rendered = if values.is_empty() {
+            UNSET.to_owned()
+        } else if secret {
+            REDACTED.to_owned()
+        } else {
+            let values: Vec<String> = values
+                .iter()
+                .map(|value| {
+                    let value = redact_embedded_credentials(value).unwrap_or_else(|| value.clone());
+                    format!("{value:?}")
+                })
+                .collect();
+            // Bracket repeated arguments so a multi-valued one is not mistaken
+            // for a single value that happens to contain a comma.
+            match values.as_slice() {
+                [single] => single.clone(),
+                many => format!("[{}]", many.join(", ")),
+            }
+        };
+        lines.push(format!("{name}={rendered} ({source})"));
+    }
+    lines
+}
+
 impl Config {
+    /// Parse the command line, keeping the raw [`clap::ArgMatches`] alongside
+    /// the parsed config so that [`log_effective_config`] can report where each
+    /// value came from once a tracing subscriber has been installed.
+    pub fn parse_with_matches() -> (Self, clap::ArgMatches) {
+        use clap::{CommandFactory as _, FromArgMatches as _};
+
+        let matches = Self::command().get_matches();
+        match Self::from_arg_matches(&matches) {
+            Ok(config) => (config, matches),
+            // The same exit path `Parser::parse` takes on a bad command line.
+            Err(err) => err.exit(),
+        }
+    }
+
     /// Returns the git hash that was set during build time
     pub fn git_hash(&self) -> &'static str {
         env!("GIT_HASH")
@@ -564,5 +757,144 @@ impl Config {
         builder
             .build(self.log_dir())
             .map_err(RollingLoggerError::Init)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::{CommandFactory as _, parser::ValueSource};
+
+    use super::{
+        Config, REDACTED, SecretString, UNSET, is_secret_arg, redact_embedded_credentials,
+    };
+
+    /// The annotation itself: typing a field `SecretString` is what makes the
+    /// dump redact it, and typing it anything else is what makes the dump
+    /// print it.
+    #[test]
+    fn secret_args_are_recognized_by_their_type() {
+        let command = Config::command();
+        let arg = |id: &str| {
+            command
+                .get_arguments()
+                .find(|arg| arg.get_id() == id)
+                .unwrap_or_else(|| panic!("no argument `{id}`"))
+        };
+        assert!(
+            is_secret_arg(arg("pass")),
+            "--node-rpc-pass is typed SecretString, so it must be recognized as secret",
+        );
+        assert!(
+            !is_secret_arg(arg("user")),
+            "--node-rpc-user is a plain String and must not be redacted",
+        );
+        // A path is not a secret; over-redacting one costs debuggability.
+        assert!(!is_secret_arg(arg("mnemonic_path")));
+        assert!(!is_secret_arg(arg("data_dir")));
+    }
+
+    /// A secret must not render its value through any of the usual escapes.
+    #[test]
+    fn secret_string_never_renders_its_value() {
+        let secret = SecretString::new("hunter2");
+        assert_eq!(format!("{secret:?}"), REDACTED);
+        assert_eq!(format!("{secret}"), REDACTED);
+        // Including when nested inside a derived `Debug`.
+        assert!(!format!("{:?}", Some(secret.clone())).contains("hunter2"));
+        assert_eq!(secret.expose(), "hunter2", "but it is still readable");
+    }
+
+    /// End to end over what actually gets written: the secret is masked, the
+    /// non-secrets around it are not, and the plaintext appears nowhere.
+    #[test]
+    fn the_dump_masks_secrets_and_nothing_else() {
+        let matches = Config::command().get_matches_from([
+            "bip300301_enforcer",
+            "--node-rpc-user=alice",
+            "--node-rpc-pass=hunter2",
+            "--wallet-esplora-url=https://bob:s3kr1t@esplora.example/api",
+        ]);
+        let lines = super::effective_config_lines(&matches);
+
+        assert!(
+            lines.contains(&format!("--node-rpc-pass={REDACTED} (command line)")),
+            "expected a redacted password line, got: {lines:#?}"
+        );
+        assert!(lines.contains(&"--node-rpc-user=\"alice\" (command line)".to_owned()));
+        assert!(
+            lines.contains(
+                &"--wallet-esplora-url=\"https://bob:redacted@esplora.example/api\" \
+                  (command line)"
+                    .to_owned()
+            ),
+            "URL credentials must be stripped, got: {lines:#?}"
+        );
+
+        let dump = lines.join("\n");
+        assert!(!dump.contains("hunter2"), "the password leaked: {dump}");
+        assert!(!dump.contains("s3kr1t"), "URL credentials leaked: {dump}");
+    }
+
+    /// Defaults and unset arguments are distinguishable in the dump, which is
+    /// the point of reporting the value source.
+    #[test]
+    fn value_sources_distinguish_default_from_unset() {
+        let matches = Config::command().get_matches_from(["bip300301_enforcer"]);
+
+        assert_eq!(
+            matches.value_source("sync_source"),
+            Some(ValueSource::DefaultValue),
+            "an argument with a default reports one",
+        );
+        assert_eq!(
+            matches.value_source("pass"),
+            None,
+            "an unset optional argument reports no source",
+        );
+        assert!(
+            matches.try_get_raw("pass").unwrap().is_none(),
+            "an unset optional argument has no raw value, and renders as {UNSET}",
+        );
+        assert_eq!(REDACTED, "[redacted]");
+    }
+
+    /// Booleans reach the dump as raw values too, rather than vanishing.
+    #[test]
+    fn boolean_flags_have_raw_values() {
+        let matches = Config::command().get_matches_from(["bip300301_enforcer", "--enable-wallet"]);
+        let raw: Vec<_> = matches
+            .try_get_raw("enable_wallet")
+            .unwrap()
+            .unwrap()
+            .map(|value| value.to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(raw, ["true"]);
+    }
+
+    /// `value_source` panics on an unknown id, so confirm the dump only ever
+    /// asks about ids that really exist, for every argument, in one pass.
+    #[test]
+    fn dumping_the_config_does_not_panic() {
+        let matches = Config::command().get_matches_from([
+            "bip300301_enforcer",
+            "--node-rpc-pass=hunter2",
+            "--node-rpc-user=alice",
+            "--enable-wallet",
+        ]);
+        super::log_effective_config(&matches);
+    }
+
+    #[test]
+    fn url_credentials_are_stripped() {
+        assert_eq!(
+            redact_embedded_credentials("https://alice:hunter2@esplora.example/api").as_deref(),
+            Some("https://alice:redacted@esplora.example/api"),
+        );
+        // Nothing to strip: caller keeps the value as-is.
+        assert_eq!(
+            redact_embedded_credentials("https://esplora.example/api"),
+            None,
+        );
+        assert_eq!(redact_embedded_credentials("/not/a/url"), None);
     }
 }

--- a/lib/rpc_client.rs
+++ b/lib/rpc_client.rs
@@ -35,7 +35,12 @@ pub fn create_client(conf: &NodeRpcConfig) -> Result<HttpClient, Error> {
     }
 
     let mut conf_user = conf.user.clone().unwrap_or_default();
-    let mut conf_pass = conf.pass.clone().unwrap_or_default();
+    // The secret is exposed here, at the boundary where it is handed to the
+    // RPC client, and nowhere else.
+    let mut conf_pass = conf
+        .pass
+        .as_ref()
+        .map_or_else(String::new, |pass| pass.expose().to_owned());
 
     if conf.cookie_path.is_some() {
         let cookie_path = conf.cookie_path.clone().unwrap();


### PR DESCRIPTION
Inspired by the startup logs in Bitcoin Core, dump all args to the logs. Makes it easier to debug accurately, knowing the configuration we're pick 72ccfa1017 # Classify OP_DRIVECHAIN outputs in Solver() working with.