### PR TITLE
block_producer: emit M4 unless an M2 can activate a new slot

### DIFF
--- a/integration_tests/integration_test.rs
+++ b/integration_tests/integration_test.rs
@@ -13,6 +13,7 @@ use bip300301_enforcer_lib::{
             ListSidechainDepositTransactionsRequest, block_info, withdrawal_bundle_event,
         },
     },
+    types::SidechainNumber,
 };
 use bitcoin::Amount;
 use either::Either;
@@ -150,11 +151,17 @@ where
     )
 }
 
-pub async fn propose_sidechain<S>(post_setup: &mut PostSetup) -> anyhow::Result<()>
+/// Propose a sidechain for `sidechain_number`, and mine one block to carry
+/// the M1. `S` is only used to subscribe to block events while mining, so the
+/// proposed slot does not have to be `S::SIDECHAIN_NUMBER`.
+pub async fn propose_sidechain_for_slot<S>(
+    post_setup: &mut PostSetup,
+    sidechain_number: SidechainNumber,
+) -> anyhow::Result<()>
 where
     S: Sidechain,
 {
-    tracing::info!("Proposing sidechain");
+    tracing::info!("Proposing sidechain for slot {}", sidechain_number.0);
     let create_sidechain_proposal_request = {
         let v0 = proto::mainchain::sidechain_declaration::V0 {
             title: proto::wrap_string("sidechain"),
@@ -166,7 +173,7 @@ where
             sidechain_declaration: Some(v0.into()),
         };
         CreateSidechainProposalRequest {
-            sidechain_id: proto::wrap_u32(S::SIDECHAIN_NUMBER.0.into()),
+            sidechain_id: proto::wrap_u32(sidechain_number.0.into()),
             declaration: buffa::MessageField::some(declaration),
         }
     };
@@ -176,11 +183,8 @@ where
         .await?;
     // The proposal must be persisted before we mine, or the coinbase won't
     // carry the M1.
-    let () = wait_for_pending_proposal(
-        &post_setup.block_producer_service_client,
-        S::SIDECHAIN_NUMBER,
-    )
-    .await?;
+    let () = wait_for_pending_proposal(&post_setup.block_producer_service_client, sidechain_number)
+        .await?;
     tracing::debug!("Mining 1 block");
     let () = mine::<S>(post_setup, 1, Some(true)).await?;
     let Some(_) = create_sidechain_proposal_resp.message().await? else {
@@ -188,15 +192,32 @@ where
     };
     tracing::debug!("Proposed sidechain");
     tracing::debug!("Checking sidechain proposals");
-    let sidechain_proposals_resp = post_setup
+    let matching_proposals = post_setup
         .validator_service_client
         .get_sidechain_proposals(GetSidechainProposalsRequest::default())
         .await?
-        .into_owned();
-    if sidechain_proposals_resp.sidechain_proposals.len() != 1 {
-        anyhow::bail!("Expected 1 sidechain proposal")
+        .into_owned()
+        .sidechain_proposals
+        .into_iter()
+        .filter(|proposal| {
+            proto::unwrap_u32(proposal.sidechain_number.clone())
+                == Some(u32::from(sidechain_number.0))
+        })
+        .count();
+    if matching_proposals != 1 {
+        anyhow::bail!(
+            "Expected 1 sidechain proposal for slot {}, got {matching_proposals}",
+            sidechain_number.0
+        )
     }
     Ok(())
+}
+
+pub async fn propose_sidechain<S>(post_setup: &mut PostSetup) -> anyhow::Result<()>
+where
+    S: Sidechain,
+{
+    propose_sidechain_for_slot::<S>(post_setup, S::SIDECHAIN_NUMBER).await
 }
 
 pub async fn activate_sidechain<S>(post_setup: &mut PostSetup) -> anyhow::Result<()>

--- a/integration_tests/test_sidechain_ack_policy.rs
+++ b/integration_tests/test_sidechain_ack_policy.rs
@@ -4,18 +4,28 @@
 //! policy, so the M2 acks in the coinbases mined here come from the policy
 //! alone, and the `ack_all_proposals` argument to `mine` is ignored.
 
-use bip300301_enforcer_lib::proto::{
-    self,
-    mainchain::{
-        GetBlockProducerStateRequest, GetChainInfoRequest, GetSidechainProposalsRequest,
-        GetSidechainsRequest, SetAckAllProposalsRequest, SetSidechainAckRequest,
+use bip300301_enforcer_lib::{
+    bins::CommandExt as _,
+    messages::{CoinbaseMessage, M4AckBundles},
+    proto::{
+        self,
+        mainchain::{
+            BlockHeaderInfo, BroadcastWithdrawalBundleRequest, GetBlockProducerStateRequest,
+            GetChainInfoRequest, GetChainTipRequest, GetSidechainProposalsRequest,
+            GetSidechainsRequest, GetWithdrawalBundleProposalsRequest,
+            GetWithdrawalBundleProposalsResponse, SetAckAllProposalsRequest,
+            SetSidechainAckRequest,
+        },
     },
+    types::SidechainNumber,
 };
+use bitcoin::{Amount, BlockHash, Txid};
 
 use crate::{
-    integration_test::propose_sidechain,
+    integration_test::{propose_sidechain, propose_sidechain_for_slot},
     mine::mine,
     setup::{DummySidechain, PostSetup, Sidechain as _},
+    test_blinded_m6_roundtrip::{make_blinded_m6, serialize_zero_input_legacy},
 };
 
 async fn sidechains_active(post_setup: &mut PostSetup) -> anyhow::Result<usize> {
@@ -25,6 +35,73 @@ async fn sidechains_active(post_setup: &mut PostSetup) -> anyhow::Result<usize> 
         .await?
         .into_owned();
     Ok(resp.sidechains.len())
+}
+
+/// All parseable BIP300 coinbase messages in the chain tip's coinbase.
+async fn tip_coinbase_messages(post_setup: &mut PostSetup) -> anyhow::Result<Vec<CoinbaseMessage>> {
+    let tip_hash: BlockHash = post_setup
+        .validator_service_client
+        .get_chain_tip(GetChainTipRequest::default())
+        .await?
+        .into_owned()
+        .block_header_info
+        .into_option()
+        .ok_or_else(|| anyhow::anyhow!("GetChainTip returned no block_header_info"))?
+        .block_hash
+        .into_option()
+        .ok_or_else(|| anyhow::anyhow!("GetChainTip returned no block_hash"))?
+        .decode::<BlockHeaderInfo, _>("block_hash")?;
+    let block_hex = post_setup
+        .bitcoin_cli
+        .command::<String, _, _, _, _>([], "getblock", [tip_hash.to_string(), "0".to_string()])
+        .run_utf8()
+        .await?;
+    let block: bitcoin::Block = bitcoin::consensus::deserialize(&hex::decode(block_hex.trim())?)?;
+    let coinbase = block
+        .txdata
+        .first()
+        .ok_or_else(|| anyhow::anyhow!("block {tip_hash} has no coinbase"))?;
+    let messages = coinbase
+        .output
+        .iter()
+        .filter_map(|txout| {
+            CoinbaseMessage::parse(&txout.script_pubkey)
+                .ok()
+                .map(|(_rest, message)| message)
+        })
+        .collect();
+    Ok(messages)
+}
+
+/// The vote count of the only pending withdrawal bundle for
+/// [`DummySidechain`]'s slot, according to the validator.
+async fn bundle_vote_count(post_setup: &mut PostSetup, m6id: Txid) -> anyhow::Result<u32> {
+    let proposals = post_setup
+        .validator_service_client
+        .get_withdrawal_bundle_proposals(GetWithdrawalBundleProposalsRequest {
+            sidechain_id: proto::wrap_u32(DummySidechain::SIDECHAIN_NUMBER.0.into()),
+        })
+        .await?
+        .into_owned()
+        .proposals;
+    let [bundle] = proposals.as_slice() else {
+        anyhow::bail!(
+            "expected exactly 1 pending withdrawal bundle, got {}",
+            proposals.len()
+        )
+    };
+    let bundle_m6id: Txid = bundle
+        .m6id
+        .clone()
+        .into_option()
+        .ok_or_else(|| anyhow::anyhow!("withdrawal bundle proposal missing m6id"))?
+        .decode::<GetWithdrawalBundleProposalsResponse, _>("m6id")?;
+    anyhow::ensure!(
+        bundle_m6id == m6id,
+        "pending withdrawal bundle m6id mismatch: {bundle_m6id} != {m6id}"
+    );
+    proto::unwrap_u32(bundle.vote_count.clone())
+        .ok_or_else(|| anyhow::anyhow!("withdrawal bundle proposal missing vote_count"))
 }
 
 pub async fn test_sidechain_ack_policy(mut post_setup: PostSetup) -> anyhow::Result<()> {
@@ -135,6 +212,93 @@ pub async fn test_sidechain_ack_policy(mut post_setup: PostSetup) -> anyhow::Res
     anyhow::ensure!(
         sidechains_active(&mut post_setup).await? == 1,
         "sidechain did not activate despite an explicit ACK"
+    );
+
+    // The case enabled by suppressing the M4 only for M2s that can activate a
+    // new slot, rather than for any M2: a withdrawal bundle gathers votes in
+    // a block whose coinbase also ACKs a proposal for another slot.
+
+    tracing::info!("Proposing a withdrawal bundle for the active sidechain");
+    let bundle_tx = make_blinded_m6(1_000, Amount::from_sat(50_000));
+    let bundle_m6id = bundle_tx.compute_txid();
+    let _resp = post_setup
+        .wallet_service_client
+        .broadcast_withdrawal_bundle(BroadcastWithdrawalBundleRequest {
+            sidechain_id: proto::wrap_u32(DummySidechain::SIDECHAIN_NUMBER.0.into()),
+            transaction: buffa::MessageField::some(buffa_types::google::protobuf::BytesValue {
+                value: serialize_zero_input_legacy(&bundle_tx),
+                ..Default::default()
+            }),
+        })
+        .await?;
+    // Mine the bundle's M3 into the chain. Per BIP300 M3, a newly proposed
+    // bundle starts with an ACK score of 1; ack-all is still off, so this
+    // block carries no M4 on top of that.
+    let () = mine::<DummySidechain>(&mut post_setup, 1, Some(false)).await?;
+    anyhow::ensure!(
+        bundle_vote_count(&mut post_setup, bundle_m6id).await? == 1,
+        "expected the bundle to sit at its initial M3 ACK score of 1"
+    );
+
+    // A proposal for a second slot: with ack-all on, the next block template
+    // wants to carry an M2 for it. A single ACK cannot activate the slot
+    // (activation requires strictly more ACKs than the threshold), so the M2
+    // must not suppress the M4 that votes on the bundle.
+    const OTHER_SLOT: SidechainNumber = SidechainNumber(1);
+    let () = propose_sidechain_for_slot::<DummySidechain>(&mut post_setup, OTHER_SLOT).await?;
+    anyhow::ensure!(
+        bundle_vote_count(&mut post_setup, bundle_m6id).await? == 1,
+        "bundle gathered a vote in a block without an M4"
+    );
+    let () = post_setup
+        .block_producer_service_client
+        .set_ack_all_proposals(SetAckAllProposalsRequest { ack_all: true })
+        .await
+        .map(|_| ())?;
+
+    tracing::info!("Mining with ack-all on: expecting an M2 and an M4 in one coinbase");
+    let () = mine::<DummySidechain>(&mut post_setup, 1, Some(true)).await?;
+
+    // The coinbase must ACK the other slot's proposal...
+    let coinbase_messages = tip_coinbase_messages(&mut post_setup).await?;
+    anyhow::ensure!(
+        coinbase_messages.iter().any(|message| matches!(
+            message,
+            CoinbaseMessage::M2AckSidechain(m2) if m2.sidechain_number == OTHER_SLOT
+        )),
+        "expected an M2 ACK for slot {OTHER_SLOT} in the coinbase"
+    );
+    // ...and still carry an M4 upvoting the bundle: one active sidechain,
+    // upvoting its first (and only) pending bundle.
+    anyhow::ensure!(
+        coinbase_messages.iter().any(|message| matches!(
+            message,
+            CoinbaseMessage::M4AckBundles(M4AckBundles::OneByte { upvotes })
+                if upvotes.as_slice() == [0u8].as_slice()
+        )),
+        "expected an M4 upvoting the bundle in the same coinbase"
+    );
+    // The validator must have counted the bundle's vote from that block...
+    anyhow::ensure!(
+        bundle_vote_count(&mut post_setup, bundle_m6id).await? == 2,
+        "bundle vote count did not increment in a block with an M2 ACK"
+    );
+    // ...as well as the M2 ACK itself.
+    let proposals = post_setup
+        .validator_service_client
+        .get_sidechain_proposals(GetSidechainProposalsRequest::default())
+        .await?
+        .into_owned()
+        .sidechain_proposals;
+    let [other_slot_proposal] = proposals.as_slice() else {
+        anyhow::bail!(
+            "expected exactly 1 sidechain proposal, got {}",
+            proposals.len()
+        )
+    };
+    anyhow::ensure!(
+        proto::unwrap_u32(other_slot_proposal.vote_count.clone()) == Some(1),
+        "the other slot's proposal was not ACKed: `{other_slot_proposal:?}`"
     );
 
     drop(post_setup);

--- a/lib/block_producer/coinbase.rs
+++ b/lib/block_producer/coinbase.rs
@@ -5,8 +5,11 @@ use fallible_iterator::{FallibleIterator as _, IteratorExt as _};
 
 use crate::{
     block_producer::{BlockProducer, BundleProposals, error},
-    messages::{CoinbaseBuilder, M4AckBundles},
-    types::{AmountUnderflowError, Ctip, SidechainAck, SidechainNumber, SidechainProposal},
+    messages::{CoinbaseBuilder, CoinbaseMessage, CoinbaseMessages, M4AckBundles},
+    types::{
+        AmountUnderflowError, Ctip, Sidechain, SidechainAck, SidechainNumber, SidechainProposal,
+        SidechainProposalId,
+    },
 };
 
 impl BlockProducer {
@@ -86,6 +89,63 @@ impl BlockProducer {
             );
             false
         }
+    }
+
+    /// An M4 carries exactly one vote per active sidechain, as seen *after* the
+    /// M2s in the same coinbase have been applied. An ACK that activates an unused slot grows the active
+    /// set by one, which would invalidate an M4 sized against the current one.
+    /// Returns `true` if any M2 in this coinbase might activate an unused slot,
+    /// in which case the M4 must be omitted.
+    ///
+    /// `next_height` is the height of the block under construction, from
+    /// which each proposal's age is computed, mirroring the validator's M2
+    /// handling at connect time.
+    fn m2s_may_activate_unused_slot(
+        &self,
+        coinbase_messages: &CoinbaseMessages,
+        active_sidechains: &[Sidechain],
+        next_height: u32,
+    ) -> Result<bool, crate::validator::GetSidechainsError> {
+        if coinbase_messages.m2_ack_slots().is_empty() {
+            return Ok(false);
+        }
+        let active_slots: HashSet<SidechainNumber> = active_sidechains
+            .iter()
+            .map(|sidechain| sidechain.proposal.sidechain_number)
+            .collect();
+
+        let mut unused_slot_acks = HashSet::new();
+        for (message, _vout) in coinbase_messages.iter() {
+            let CoinbaseMessage::M2AckSidechain(m2) = message else {
+                continue;
+            };
+            // Only ACKs for slots that are not already active can grow the
+            // active set
+            if active_slots.contains(&m2.sidechain_number) {
+                continue;
+            }
+            unused_slot_acks.insert(SidechainProposalId {
+                sidechain_number: m2.sidechain_number,
+                description_hash: m2.description_hash,
+            });
+        }
+        if unused_slot_acks.is_empty() {
+            return Ok(false);
+        }
+        let thresholds = self.validator().network_params().thresholds;
+        let res = self
+            .validator()
+            .get_sidechains()?
+            .into_iter()
+            .any(|(proposal_id, sidechain)| {
+                let proposal_age = next_height.saturating_sub(sidechain.status.proposal_height);
+                unused_slot_acks.contains(&proposal_id)
+                    && thresholds.activates_unused_slot(
+                        sidechain.status.vote_count.saturating_add(1),
+                        proposal_age,
+                    )
+            });
+        Ok(res)
     }
 
     /// Extend coinbase txouts for a new block with our drivechain messages:
@@ -220,13 +280,28 @@ impl BlockProducer {
                 }
             }
         }
+        // One read of the active set, shared by the activation check and the
+        // M4 below, so that the M4 is sized against the same active set the
+        // check ran against.
+        let active_sidechains = self.validator().get_active_sidechains()?;
+        // The height of the block under construction, for the proposal age
+        // window in the activation check below.
+        let next_height = self
+            .validator()
+            .get_header_info(&mainchain_tip)?
+            .height
+            .saturating_add(1);
         // Ack bundles
         // TODO: Exclusively ack bundles that are known to us
-        // TODO: ack bundles when M2 messages are present
-        if ack_all_proposals && coinbase_builder.messages().m2_ack_slots().is_empty() {
-            let active_sidechains = self.validator().get_active_sidechains()?;
+        if ack_all_proposals
+            && !self.m2s_may_activate_unused_slot(
+                coinbase_builder.messages(),
+                &active_sidechains,
+                next_height,
+            )?
+        {
             let upvotes = active_sidechains
-                .into_iter()
+                .iter()
                 .map(|sidechain| {
                     if self
                         .validator()

--- a/lib/block_producer/error.rs
+++ b/lib/block_producer/error.rs
@@ -69,6 +69,8 @@ pub enum GenerateCoinbaseTxouts {
     #[error("transparent")]
     GetBundleProposals(#[from] GetBundleProposals),
     #[error(transparent)]
+    GetHeaderInfo(#[from] crate::validator::GetHeaderInfoError),
+    #[error(transparent)]
     GetPendingWithdrawals(#[from] crate::validator::GetPendingWithdrawalsError),
     #[error(transparent)]
     GetSidechains(#[from] crate::validator::GetSidechainsError),
@@ -83,6 +85,7 @@ impl ToStatus for GenerateCoinbaseTxouts {
         match self {
             Self::CoinbaseMessages(err) => err.builder(),
             Self::GetBundleProposals(err) => err.builder(),
+            Self::GetHeaderInfo(err) => err.builder(),
             Self::GetPendingWithdrawals(err) => err.builder(),
             Self::GetSidechains(err) => err.builder(),
             Self::PushBytes(err) => StatusBuilder::new(err),

--- a/lib/types.rs
+++ b/lib/types.rs
@@ -83,6 +83,15 @@ impl Thresholds {
             _ => Self::SHORT,
         }
     }
+
+    /// BIP300 M2: whether a proposal with `vote_count` ACKs at
+    /// `proposal_age` blocks since its M1 activates into a currently unused
+    /// sidechain slot. The vote threshold must be strictly exceeded; the age
+    /// window is inclusive.
+    pub const fn activates_unused_slot(&self, vote_count: u16, proposal_age: u32) -> bool {
+        vote_count > self.unused_sidechain_slot_activation_threshold
+            && proposal_age <= self.unused_sidechain_slot_proposal_max_age as u32
+    }
 }
 
 /// Resolved network parameters: the BIP 300 [`Thresholds`] plus, for dry-run
@@ -1090,7 +1099,24 @@ mod tests {
 
     use miette::Diagnostic as _;
 
-    use crate::types::{BlindedM6, SidechainDeclaration, SidechainNumber, SidechainProposal};
+    use crate::types::{
+        BlindedM6, SidechainDeclaration, SidechainNumber, SidechainProposal, Thresholds,
+    };
+
+    #[test]
+    fn unused_slot_activation_boundary() {
+        // The validator activates on this predicate, and the block producer
+        // suppresses an M4 whenever an M2 in the same coinbase could satisfy
+        // it, so both boundaries matter: the vote threshold must be strictly
+        // exceeded, and the age window is inclusive.
+        let thresholds = Thresholds::SHORT;
+        let vote_threshold = thresholds.unused_sidechain_slot_activation_threshold;
+        let max_age = thresholds.unused_sidechain_slot_proposal_max_age as u32;
+        assert!(!thresholds.activates_unused_slot(vote_threshold, 1));
+        assert!(thresholds.activates_unused_slot(vote_threshold + 1, 1));
+        assert!(thresholds.activates_unused_slot(vote_threshold + 1, max_age));
+        assert!(!thresholds.activates_unused_slot(vote_threshold + 1, max_age + 1));
+    }
 
     fn proposal(description: Vec<u8>) -> SidechainProposal {
         SidechainProposal {

--- a/lib/validator/task/mod.rs
+++ b/lib/validator/task/mod.rs
@@ -260,10 +260,8 @@ impl BlockHandler<'_> {
                 && sidechain_proposal_age <= thresholds.used_sidechain_slot_proposal_max_age as u32
         } || {
             !sidechain_slot_is_used
-                && sidechain.status.vote_count
-                    > thresholds.unused_sidechain_slot_activation_threshold
-                && sidechain_proposal_age
-                    <= thresholds.unused_sidechain_slot_proposal_max_age as u32
+                && thresholds
+                    .activates_unused_slot(sidechain.status.vote_count, sidechain_proposal_age)
         };
 
         let effect = if new_sidechain_activated {


### PR DESCRIPTION
`extend_coinbase_txouts` skipped the M4 bundle-vote output whenever the coinbase
carried any M2 at all. With `ack_all_proposals` enabled the producer adds an M2 for
every votable proposal, so the M4 was dropped from every block while any proposal was
outstanding, and `handle_m4_votes` reads a missing M4 as an abstain — pending bundles
gained no votes and could age out.

Skip the M4 only when an M2 in this coinbase acks a proposal for a slot that is not
already active and is one ack away from activation, which is the only case that can
grow the active set the vote vector is sized against. The active sidechain set is read
once and shared by the guard and the vote sizing so both see one snapshot.

Only affects the coinbase this node produces; no validation rules change.