### PR TITLE
block_producer: build the M6 suffix from post-prefix state

### DIFF
--- a/lib/block_producer/coinbase.rs
+++ b/lib/block_producer/coinbase.rs
@@ -7,16 +7,20 @@ use crate::{
     block_producer::{BlockProducer, BundleProposals, error},
     messages::{CoinbaseBuilder, M4AckBundles},
     types::{AmountUnderflowError, Ctip, SidechainAck, SidechainNumber, SidechainProposal},
+    validator::PendingM6ids,
 };
 
 impl BlockProducer {
-    /// Bundle proposals we've stored, joined with the validator's view of each
-    /// one. Proposals for a sidechain that isn't active are dropped: per BIP300
-    /// M3, a bundle proposed for an inactive slot is just an ordinary script (a
-    /// no-op), so there is nothing to gain by proposing it. Those can sneak in by
-    /// activating a sidechain and then reorging it out of existence.
+    /// Bundle proposals we've stored, joined with `pending_m6ids`: the caller
+    /// picks which consensus state the join is against, since a block producer
+    /// must build against the state its own validator will see when it connects
+    /// what we produce. Proposals for a sidechain that isn't active are dropped:
+    /// per BIP300 M3, a bundle proposed for an inactive slot is just an ordinary
+    /// script (a no-op), so there is nothing to gain by proposing it. Those can
+    /// sneak in by activating a sidechain and then reorging it out of existence.
     pub(crate) async fn get_bundle_proposals(
         &self,
+        pending_m6ids: &HashMap<SidechainNumber, PendingM6ids>,
     ) -> Result<HashMap<SidechainNumber, BundleProposals>, error::GetBundleProposals> {
         let bundle_proposals = self.db().get_bundle_proposals().await?;
         let active_sidechain_numbers: HashSet<SidechainNumber> = self
@@ -33,10 +37,13 @@ impl BlockProducer {
                 if !active_sidechain_numbers.contains(&sidechain_id) {
                     return Ok(None);
                 }
-                let pending_m6ids = self.validator().get_pending_withdrawals(&sidechain_id)?;
+                let pending = pending_m6ids.get(&sidechain_id);
                 let res: Vec<_> = m6ids
                     .into_iter()
-                    .map(|(m6id, blinded_m6)| (m6id, blinded_m6, pending_m6ids.get(&m6id).copied()))
+                    .map(|(m6id, blinded_m6)| {
+                        let m6id_info = pending.and_then(|pending| pending.get(&m6id)).copied();
+                        (m6id, blinded_m6, m6id_info)
+                    })
                     .collect();
                 if res.is_empty() {
                     Ok(None)
@@ -213,7 +220,8 @@ impl BlockProducer {
             );
             coinbase_builder.bmm_accept(sidechain_number, bmm_hash)?;
         }
-        for (sidechain_id, m6ids) in self.get_bundle_proposals().await? {
+        let pending_m6ids = self.validator().get_all_pending_withdrawals()?;
+        for (sidechain_id, m6ids) in self.get_bundle_proposals(&pending_m6ids).await? {
             for (m6id, _blinded_m6, m6id_info) in m6ids {
                 if m6id_info.is_none() {
                     coinbase_builder.propose_bundle(sidechain_id, m6id)?;
@@ -228,17 +236,16 @@ impl BlockProducer {
             let upvotes = active_sidechains
                 .into_iter()
                 .map(|sidechain| {
-                    if self
-                        .validator()
-                        .get_pending_withdrawals(&sidechain.proposal.sidechain_number)?
-                        .is_empty()
+                    if pending_m6ids
+                        .get(&sidechain.proposal.sidechain_number)
+                        .is_none_or(|pending| pending.is_empty())
                     {
-                        Ok(M4AckBundles::ABSTAIN_ONE_BYTE)
+                        M4AckBundles::ABSTAIN_ONE_BYTE
                     } else {
-                        Ok(0)
+                        0
                     }
                 })
-                .collect::<Result<_, crate::validator::GetPendingWithdrawalsError>>()?;
+                .collect();
             coinbase_builder.ack_bundles(M4AckBundles::OneByte { upvotes })?;
         }
         let () = coinbase_builder.build()?;
@@ -263,13 +270,20 @@ impl BlockProducer {
     /// Generate the M6 suffix txs for a new block. These are fully determined by
     /// the approved bundle and the CTIP: treasury outputs are anyone-can-spend
     /// and consensus-gated, so an M6 is constructed, never signed.
+    ///
+    /// `ctips` and `pending_m6ids` MUST describe the same consensus state, and
+    /// that state must be the one the validator will be in when it connects the
+    /// suffix: a bundle that the rest of the block already pays out is no longer
+    /// pending, and paying it twice yields two M6s with the same m6id, the
+    /// second of which our own `connect_block` rejects.
     pub(crate) async fn generate_suffix_txs(
         &self,
         ctips: &HashMap<SidechainNumber, Ctip>,
+        pending_m6ids: &HashMap<SidechainNumber, PendingM6ids>,
     ) -> Result<Vec<Transaction>, error::GenerateSuffixTxs> {
         let thresholds = self.validator().network_params().thresholds;
         let mut res = Vec::new();
-        for (sidechain_id, m6ids) in self.get_bundle_proposals().await? {
+        for (sidechain_id, m6ids) in self.get_bundle_proposals(pending_m6ids).await? {
             let mut ctip = None;
             for (_m6id, blinded_m6, m6id_info) in m6ids {
                 let Some(m6id_info) = m6id_info else { continue };

--- a/lib/block_producer/error.rs
+++ b/lib/block_producer/error.rs
@@ -207,6 +207,8 @@ pub enum SelectBlockTxs {
     GetBlockTemplate(#[from] GetBlockTemplate),
     #[error(transparent)]
     GetCtips(#[from] crate::validator::GetCtipsError),
+    #[error(transparent)]
+    GetPendingWithdrawals(#[from] crate::validator::GetPendingWithdrawalsError),
     #[error("failed to decode transaction `{txid}` from the block template")]
     DecodeTemplateTransaction {
         txid: bitcoin::Txid,
@@ -231,6 +233,7 @@ impl ToStatus for SelectBlockTxs {
             Self::GenerateSuffixTxs(err) => err.builder(),
             Self::GetBlockTemplate(err) => err.builder(),
             Self::GetCtips(err) => err.builder(),
+            Self::GetPendingWithdrawals(err) => err.builder(),
             Self::DecodeTemplateTransaction { .. } => {
                 StatusBuilder::new(self).code(connectrpc::ErrorCode::Internal)
             }
@@ -504,6 +507,8 @@ pub(in crate::block_producer) enum InitialBlockTemplateInner {
     GenerateSuffixTxs(#[from] GenerateSuffixTxs),
     #[error("Failed to read the ACK-all-proposals setting")]
     GetAckAllProposals(#[source] rusqlite::Error),
+    #[error(transparent)]
+    GetPendingWithdrawals(#[from] crate::validator::GetPendingWithdrawalsError),
     #[error("the `coinbasetxn` GBT capability is required")]
     NoCoinbaseTxn,
 }
@@ -533,7 +538,7 @@ pub(in crate::block_producer) enum FinalizeBlockTemplateInner {
     #[error(transparent)]
     GenerateSuffixTxs(#[from] GenerateSuffixTxs),
     #[error(transparent)]
-    GetCtipsAfter(#[from] crate::validator::cusf_enforcer::GetCtipsAfterError),
+    GetSidechainStateAfter(#[from] crate::validator::cusf_enforcer::GetSidechainStateAfterError),
     #[error(transparent)]
     GetHeaderInfo(#[from] crate::validator::GetHeaderInfoError),
     #[error(transparent)]

--- a/lib/block_producer/mine.rs
+++ b/lib/block_producer/mine.rs
@@ -110,7 +110,8 @@ impl BlockProducer {
             CoinbaseTxnOrValue::Txn(_) => Vec::new(),
             CoinbaseTxnOrValue::ValueSats(_) => {
                 let ctips = self.validator().get_ctips()?;
-                self.generate_suffix_txs(&ctips).await?
+                let pending_m6ids = self.validator().get_all_pending_withdrawals()?;
+                self.generate_suffix_txs(&ctips, &pending_m6ids).await?
             }
         };
 

--- a/lib/block_producer/mod.rs
+++ b/lib/block_producer/mod.rs
@@ -14,8 +14,8 @@ use tracing::instrument;
 use crate::{
     errors::ErrorChain,
     messages::{CoinbaseBuilder, parse_m8_tx},
-    types::{BlindedM6, M6id, PendingM6idInfo, WithdrawalBundleEventKind},
-    validator::Validator,
+    types::{BlindedM6, M6id, PendingM6idInfo, SidechainNumber, WithdrawalBundleEventKind},
+    validator::{PendingM6ids, Validator},
 };
 
 mod coinbase;
@@ -295,6 +295,31 @@ impl CusfBlockProducer for BlockProducer {
     }
 }
 
+/// Upper bound on the pending bundles the finalized suffix can pay out.
+///
+/// The suffix reservation is computed from live state, but the finalized suffix
+/// is computed from the state after the coinbase and prefix txs are connected,
+/// where the coinbase M4 upvote can have lifted a bundle from
+/// `vote_count == withdrawal_bundle_inclusion_threshold` to `threshold + 1`.
+/// Reserving from live state would then miss that M6 entirely, and since the
+/// reserved weight is subtracted from the weight limit before mempool txs are
+/// selected, the assembled block could exceed the limit. The coinbase upvotes
+/// at most once per sidechain, so bumping every vote count by one bounds the
+/// suffix from above.
+fn pending_m6ids_upper_bound(
+    pending_m6ids: HashMap<SidechainNumber, PendingM6ids>,
+) -> HashMap<SidechainNumber, PendingM6ids> {
+    pending_m6ids
+        .into_iter()
+        .map(|(sidechain_id, mut pending)| {
+            for m6id_info in pending.values_mut() {
+                m6id_info.vote_count = m6id_info.vote_count.saturating_add(1);
+            }
+            (sidechain_id, pending)
+        })
+        .collect()
+}
+
 impl BlockProducer {
     async fn initial_block_template_inner<const COINBASE_TXN: bool>(
         &self,
@@ -372,7 +397,11 @@ impl BlockProducer {
                 };
                 (slot_number.into(), fake_ctip)
             }));
-            let fake_suffix_txs = self.generate_suffix_txs(&fake_ctips).await?;
+            let pending_m6ids =
+                pending_m6ids_upper_bound(self.validator().get_all_pending_withdrawals()?);
+            let fake_suffix_txs = self
+                .generate_suffix_txs(&fake_ctips, &pending_m6ids)
+                .await?;
             template
                 .suffix_txs
                 .extend(fake_suffix_txs.into_iter().map(|tx| {
@@ -473,14 +502,21 @@ impl BlockProducer {
                         .chain(template.prefix_txs.iter().map(|(tx, _)| tx.clone()))
                         .collect(),
                 };
-                let ctips = crate::validator::cusf_enforcer::get_ctips_after(
+                // The suffix must be built against the state the validator will
+                // be in once it has connected the coinbase and prefix txs,
+                // rather than against its current tip: a withdrawal bundle that
+                // a prefix tx already pays out is no longer pending, and must
+                // not be paid out a second time.
+                let state = crate::validator::cusf_enforcer::get_sidechain_state_after(
                     &self.inner.validator,
                     &block,
                 )?
                 .map_err(|reason| {
                     error::FinalizeBlockTemplateInner::InitialBlockTemplate { reason }
                 })?;
-                let suffix_txs = self.generate_suffix_txs(&ctips).await?;
+                let suffix_txs = self
+                    .generate_suffix_txs(&state.ctips, &state.pending_m6ids)
+                    .await?;
                 template
                     .suffix_txs
                     .extend(suffix_txs.into_iter().map(|tx| (tx, bitcoin::Amount::ZERO)));
@@ -488,5 +524,59 @@ impl BlockProducer {
             }
             BoolWit::False(_wit) => Ok(()),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use bitcoin::{Txid, hashes::Hash as _};
+
+    use super::pending_m6ids_upper_bound;
+    use crate::{
+        types::{M6id, NetworkParams, PendingM6idInfo, SidechainNumber},
+        validator::PendingM6ids,
+    };
+
+    /// A bundle that live state excludes, but that a single coinbase M4 upvote
+    /// would include, must still be reserved: the finalized suffix is built
+    /// from the post-coinbase state, and the mempool weight limit is reduced by
+    /// the reserved weight before txs are selected.
+    #[test]
+    fn pending_m6ids_upper_bound_covers_coinbase_upvote() {
+        let threshold = NetworkParams::for_network(bitcoin::Network::Regtest)
+            .thresholds
+            .withdrawal_bundle_inclusion_threshold;
+        let sidechain_id = SidechainNumber(0);
+        let m6id = M6id(Txid::from_byte_array([0x11; 32]));
+        let pending = PendingM6ids::from_iter([(
+            m6id,
+            PendingM6idInfo {
+                vote_count: threshold,
+                proposal_height: 0,
+            },
+        )]);
+        let upper_bound =
+            pending_m6ids_upper_bound(HashMap::from_iter([(sidechain_id, pending.clone())]));
+        assert!(pending[&m6id].vote_count <= threshold);
+        assert!(upper_bound[&sidechain_id][&m6id].vote_count > threshold);
+    }
+
+    /// Bumping must not overflow a bundle that has already accumulated the
+    /// maximum vote count.
+    #[test]
+    fn pending_m6ids_upper_bound_saturates() {
+        let sidechain_id = SidechainNumber(0);
+        let m6id = M6id(Txid::from_byte_array([0x22; 32]));
+        let pending = PendingM6ids::from_iter([(
+            m6id,
+            PendingM6idInfo {
+                vote_count: u16::MAX,
+                proposal_height: 0,
+            },
+        )]);
+        let upper_bound = pending_m6ids_upper_bound(HashMap::from_iter([(sidechain_id, pending)]));
+        assert_eq!(upper_bound[&sidechain_id][&m6id].vote_count, u16::MAX);
     }
 }

--- a/lib/validator/cusf_enforcer.rs
+++ b/lib/validator/cusf_enforcer.rs
@@ -26,7 +26,7 @@ use crate::{
     proto::mainchain::HeaderSyncProgress,
     types::{Ctip, Event, SidechainNumber},
     validator::{
-        Validator,
+        PendingM6ids, Validator,
         task::{self, BlockHandler, error::ValidateTransaction as ValidateTransactionError},
     },
 };
@@ -500,32 +500,50 @@ impl CusfEnforcer for Validator {
 }
 
 #[derive(Debug, Error)]
-pub(crate) enum GetCtipsAfterError {
+pub(crate) enum GetSidechainStateAfterError {
     #[error(transparent)]
     ConnectBlock(#[from] ConnectBlockError),
     #[error(transparent)]
     DbIter(#[from] db::error::Iter),
 }
 
-/// Get ctips after (speculatively) applying a block.
+/// Sidechain state after (speculatively) applying a block.
+pub(crate) struct SidechainStateAfter {
+    pub ctips: HashMap<SidechainNumber, Ctip>,
+    pub pending_m6ids: HashMap<SidechainNumber, PendingM6ids>,
+}
+
+/// Get sidechain state after (speculatively) applying a block.
 /// Returns the rejection reason if the block would be rejected.
-pub(crate) fn get_ctips_after(
+pub(crate) fn get_sidechain_state_after(
     validator: &Validator,
     block: &Block,
-) -> Result<Result<HashMap<SidechainNumber, Ctip>, String>, GetCtipsAfterError> {
-    match ConnectBlockDryRun(|rotxn: &RoTxn<'_>| -> Result<_, _> {
-        validator
+) -> Result<Result<SidechainStateAfter, String>, GetSidechainStateAfterError> {
+    match ConnectBlockDryRun(|rotxn: &RoTxn<'_>| -> Result<_, db::error::Iter> {
+        let ctips = validator
             .dbs
             .active_sidechains
             .ctip()
             .iter(rotxn)
             .map_err(db::error::Iter::Init)?
             .collect()
-            .map_err(db::error::Iter::Item)
+            .map_err(db::error::Iter::Item)?;
+        let pending_m6ids = validator
+            .dbs
+            .active_sidechains
+            .pending_m6ids()
+            .iter(rotxn)
+            .map_err(db::error::Iter::Init)?
+            .collect()
+            .map_err(db::error::Iter::Item)?;
+        Ok(SidechainStateAfter {
+            ctips,
+            pending_m6ids,
+        })
     })
     .connect_block(validator, block)?
     {
-        Ok(ctips) => Ok(Ok(ctips?)),
+        Ok(state) => Ok(Ok(state?)),
         Err(reason) => Ok(Err(format!("{:#}", ErrorChain::new(&reason)))),
     }
 }

--- a/lib/validator/mod.rs
+++ b/lib/validator/mod.rs
@@ -33,7 +33,8 @@ mod task;
 #[cfg(test)]
 mod test_utils;
 
-use self::dbs::{Dbs, PendingM6ids};
+use self::dbs::Dbs;
+pub(crate) use self::dbs::PendingM6ids;
 pub use self::sync_state_summary::{
     CtipSummary, PendingWithdrawalSummary, SidechainStateSummary, SyncStateSummary,
 };
@@ -356,6 +357,8 @@ pub enum GetPendingWithdrawalsError {
     #[error(transparent)]
     DbGet(#[from] db::error::Get),
     #[error(transparent)]
+    DbIter(#[from] db::error::Iter),
+    #[error(transparent)]
     ReadTxn(#[from] env::error::ReadTxn),
 }
 
@@ -363,6 +366,7 @@ impl ToStatus for GetPendingWithdrawalsError {
     fn builder(&self) -> StatusBuilder<'_> {
         match self {
             Self::DbGet(err) => StatusBuilder::new(err),
+            Self::DbIter(err) => StatusBuilder::new(err),
             Self::ReadTxn(err) => StatusBuilder::new(err),
         }
     }
@@ -780,6 +784,22 @@ impl Validator {
                     .map(Ok)
                     .transpose_into_fallible())
             })
+            .collect()?;
+        Ok(res)
+    }
+
+    /// Pending withdrawal bundles for every active sidechain.
+    pub fn get_all_pending_withdrawals(
+        &self,
+    ) -> Result<HashMap<SidechainNumber, PendingM6ids>, GetPendingWithdrawalsError> {
+        let rotxn = self.dbs.read_txn()?;
+        let res = self
+            .dbs
+            .active_sidechains
+            .pending_m6ids()
+            .iter(&rotxn)
+            .map_err(db::error::Iter::from)?
+            .map_err(db::error::Iter::from)
             .collect()?;
         Ok(res)
     }


### PR DESCRIPTION
`block_template_suffix_inner` built the M6 suffix against the CTIP state after
speculatively connecting the coinbase and prefix, while reading pending bundles from the
validator's current tip. If a prefix tx already paid out a bundle, that bundle still
looked pending and the suffix appended a second M6 with the same m6id, so `connect_block`
rejected the template this node had just served over getblocktemplate.

`get_sidechain_state_after` now returns ctips and `pending_m6ids` from one dry-run
snapshot, and the pending set is passed in by the caller rather than re-read per
sidechain. The suffix weight reservation uses an upper bound (each bundle's vote count
plus one, saturating), since the coinbase M4 can upvote a bundle over the inclusion
threshold during the dry run and that M6 must still be reserved.

Only changes the templates and blocks this node produces; no validation rules change.