### PR TITLE
wallet: use a BDK full scan with a stop gap for address discovery

### DIFF
--- a/integration_tests/test_wallet_large_gap_sync.rs
+++ b/integration_tests/test_wallet_large_gap_sync.rs
@@ -13,13 +13,28 @@
 //! enforcer's own wallet owns, so the coinbases are only discoverable by
 //! scanning the chain source. A checkpoint jump that skipped the scan would
 //! close the gap but silently lose the money.
+//!
+//! Part of the gap is paid to an address at a derivation index the wallet has
+//! never revealed, separated from the revealed ones by a run of unused
+//! indices. Addresses are not used in strictly increasing order in general --
+//! a recovered seed may come from a wallet that hands out addresses without
+//! requiring them to be used -- so a scan that searches for the first unused
+//! index and stops there silently drops everything funded after the gap. Only
+//! a scan that keeps going for a stop gap past the last used index finds it.
 
-use std::time::Duration;
+use std::{str::FromStr as _, time::Duration};
 
+use bdk_wallet::miniscript::{Descriptor, DescriptorPublicKey};
 use bip300301_enforcer_lib::{
     bins::CommandExt as _,
-    proto::mainchain::{CreateNewAddressRequest, GetBalanceRequest},
+    proto::{
+        mainchain::{
+            CreateNewAddressRequest, GetBalanceRequest, GetInfoRequest, ListUnspentOutputsRequest,
+        },
+        unwrap_string,
+    },
 };
+use bitcoin::secp256k1::Secp256k1;
 use futures::channel::mpsc;
 use tokio::time::sleep;
 
@@ -34,6 +49,22 @@ pub const TEST_NAME: &str = "wallet_large_gap_sync";
 /// Must exceed `MAX_BLOCK_BY_BLOCK_REPLAY`, or the wallet takes the
 /// block-by-block path and the assertions below fail (loudly, and correctly).
 const GAP_BLOCKS: u32 = 2_100;
+
+/// External keychain index of the address funded behind a derivation gap.
+///
+/// Must sit past BDK's default lookahead of 25: within the lookahead the
+/// indexer already holds the SPK, so block replay would match the coinbase
+/// without the scan having had to discover the index, and the test would pass
+/// for the wrong reason. Must also sit comfortably inside the full scan's stop
+/// gap, which is the reach this test pins down.
+const DERIVATION_GAP_INDEX: u32 = 50;
+
+/// How much of the gap is paid to [`DERIVATION_GAP_INDEX`]. Mined first, so
+/// these coinbases are far past maturity once the gap is closed.
+const GAP_INDEX_BLOCKS: u32 = 10;
+
+/// The rest of the gap, paid to the wallet's next unused (revealed) address.
+const SEQUENTIAL_GAP_BLOCKS: u32 = GAP_BLOCKS - GAP_INDEX_BLOCKS;
 
 /// Emitted by `sync_wallet_to_tip` when it takes the checkpoint path.
 const CHECKPOINT_LOG: &str = "checkpointing chain forward and running a full scan";
@@ -88,6 +119,29 @@ async fn wait_for_electrs_tip(post_setup: &PostSetup) -> anyhow::Result<()> {
     }
 }
 
+/// Derive an address from the wallet's own external descriptor without
+/// revealing it.
+///
+/// `CreateNewAddress` is `next_unused_address`, so it can only ever hand out a
+/// contiguous run of indices -- it returns the same address until that address
+/// is used. To fund an address sitting behind a derivation gap, the test has to
+/// derive it itself from the public descriptor the wallet reports.
+async fn peek_external_address(post_setup: &mut PostSetup, index: u32) -> anyhow::Result<String> {
+    let descriptors = post_setup
+        .wallet_service_client
+        .get_info(GetInfoRequest::default())
+        .await?
+        .into_owned()
+        .descriptors;
+    let external = descriptors.get("external").ok_or_else(|| {
+        anyhow::anyhow!("wallet reported no external descriptor, only: {descriptors:?}")
+    })?;
+    let address = Descriptor::<DescriptorPublicKey>::from_str(external)?
+        .derived_descriptor(&Secp256k1::verification_only(), index)?
+        .address(post_setup.network.into())?;
+    Ok(address.to_string())
+}
+
 pub async fn test_wallet_large_gap_sync(bin_paths: BinPaths) -> anyhow::Result<()> {
     let (res_tx, _res_rx) = mpsc::unbounded();
     let pre_setup = PreSetup::new(bin_paths.clone(), Network::Regtest)?;
@@ -113,14 +167,35 @@ pub async fn test_wallet_large_gap_sync(bin_paths: BinPaths) -> anyhow::Result<(
         .into_owned()
         .address;
 
+    // Also owned by the wallet, but never revealed by it, and separated from
+    // `gap_address` by a run of unused indices. Nothing short of a scan that
+    // keeps looking past the first unused index will ever ask about it.
+    let deep_gap_address = peek_external_address(&mut post_setup, DERIVATION_GAP_INDEX).await?;
+    anyhow::ensure!(
+        deep_gap_address != gap_address,
+        "index {DERIVATION_GAP_INDEX} derived the same address the wallet just revealed \
+         ({gap_address}), so there is no derivation gap to test"
+    );
+
     tracing::info!("killing enforcer, then mining {GAP_BLOCKS} blocks behind its back");
     post_setup.kill_enforcer().await?;
+    // Mined at the start of the gap, so these are well past coinbase maturity
+    // by the time the wallet comes back and counts them.
     post_setup
         .bitcoin_cli
         .command::<String, _, _, _, _>(
             [],
             "generatetoaddress",
-            [GAP_BLOCKS.to_string(), gap_address],
+            [GAP_INDEX_BLOCKS.to_string(), deep_gap_address.clone()],
+        )
+        .run_utf8()
+        .await?;
+    post_setup
+        .bitcoin_cli
+        .command::<String, _, _, _, _>(
+            [],
+            "generatetoaddress",
+            [SEQUENTIAL_GAP_BLOCKS.to_string(), gap_address],
         )
         .run_utf8()
         .await?;
@@ -166,6 +241,32 @@ pub async fn test_wallet_large_gap_sync(bin_paths: BinPaths) -> anyhow::Result<(
          {GAP_BLOCKS}-block gap; it should have checkpointed across it instead"
     );
     tracing::info!("crossed a {GAP_BLOCKS}-block gap with {replayed} individual block connects");
+
+    // Checked last, so that a wallet which never ran a scan at all is
+    // diagnosed by the assertions above rather than by this one. The balance
+    // check cannot tell a correct scan from one that stops at the first unused
+    // index -- `gap_address` is the wallet's own next unused address, so its
+    // coinbases are found either way. These are the ones that are only
+    // reachable by continuing past the gap.
+    let utxos = post_setup
+        .wallet_service_client
+        .list_unspent_outputs(ListUnspentOutputsRequest::default())
+        .await?
+        .into_owned();
+    let deep_gap_utxos = utxos
+        .outputs
+        .into_iter()
+        .filter(|output| output.is_confirmed)
+        .filter_map(|output| unwrap_string(output.address))
+        .filter(|address| *address == deep_gap_address)
+        .count();
+    anyhow::ensure!(
+        deep_gap_utxos == GAP_INDEX_BLOCKS as usize,
+        "the full scan must recover the {GAP_INDEX_BLOCKS} coinbases paid to external index \
+         {DERIVATION_GAP_INDEX} ({deep_gap_address}), which sits behind a run of unused \
+         indices, but the wallet holds {deep_gap_utxos} confirmed UTXOs there. A scan that \
+         stops at the first unused index never looks that far, and the money is silently lost"
+    );
 
     Ok(())
 }

--- a/lib/wallet/error.rs
+++ b/lib/wallet/error.rs
@@ -578,23 +578,12 @@ pub mod full_scan {
     };
 
     #[derive(Debug, Diagnostic, Error)]
-    #[diagnostic(code(check_address_transactions))]
-    #[error("failed to check for bitcoin address transactions")]
-    pub struct CheckAddressTransactions {
-        pub(in crate::wallet) address: bitcoin::Address,
-        pub(in crate::wallet) source: ChainSourceClient,
-    }
-
-    #[derive(Debug, Diagnostic, Error)]
     pub enum Error {
         #[error(transparent)]
         WalletNotUnlocked(#[from] NotUnlocked),
 
         #[error(transparent)]
         ChainSourceClient(#[from] ChainSourceClient),
-
-        #[error(transparent)]
-        CheckAddressTransactions(#[from] CheckAddressTransactions),
 
         #[error(transparent)]
         ListHeaders(#[from] crate::validator::ListHeadersError),

--- a/lib/wallet/sync.rs
+++ b/lib/wallet/sync.rs
@@ -4,7 +4,6 @@ use std::time::SystemTime;
 
 use async_lock::RwLockWriteGuard;
 use bdk_chain::bdk_core;
-use bdk_electrum::electrum_client::ElectrumApi;
 use bdk_esplora::EsploraAsyncExt as _;
 use futures::TryFutureExt;
 use tokio::time::Instant;
@@ -44,6 +43,12 @@ impl SyncWriteGuard<'_> {
 }
 
 const ESPLORA_PARALLEL_REQUESTS: usize = 25;
+
+/// Number of consecutive unused addresses that a full scan must observe before
+/// considering a keychain exhausted. Larger than the BIP44 gap limit of 20,
+/// since a recovered seed may have been used by a wallet that hands out
+/// addresses without requiring them to be used.
+const STOP_GAP: usize = 200;
 
 impl WalletInner {
     pub(in crate::wallet) async fn get_tip(&self) -> Result<bdk_core::BlockId, error::NotUnlocked> {
@@ -247,32 +252,6 @@ impl WalletInner {
         }))
     }
 
-    async fn address_has_txs(
-        &self,
-        chain_source_client: &ChainSourceClient,
-        address: &bitcoin::Address,
-    ) -> miette::Result<bool, error::full_scan::CheckAddressTransactions> {
-        let res = match chain_source_client {
-            ChainSourceClient::Electrum(electrum_client) => !electrum_client
-                .inner
-                .script_get_history(&address.script_pubkey())
-                .map_err(|err| error::full_scan::CheckAddressTransactions {
-                    address: address.clone(),
-                    source: err.into(),
-                })?
-                .is_empty(),
-            ChainSourceClient::Esplora(esplora_client) => !esplora_client
-                .get_address_txs(address, None)
-                .map_err(|err| error::full_scan::CheckAddressTransactions {
-                    address: address.clone(),
-                    source: err.into(),
-                })
-                .await?
-                .is_empty(),
-        };
-        Ok(res)
-    }
-
     async fn get_chain_checkpoint(
         &self,
         local_chain: &bdk_chain::local_chain::LocalChain,
@@ -325,7 +304,6 @@ impl WalletInner {
         Ok(checkpoint)
     }
 
-    // TODO: is this actually correct? Need help from the Rust grownups!
     #[expect(clippy::significant_drop_tightening, reason = "false positive")]
     pub(in crate::wallet) async fn full_scan(
         &self,
@@ -346,90 +324,48 @@ impl WalletInner {
             .read_wallet_upgradable()
             .await
             .map_err(error::FullScan::WalletNotUnlocked)?;
-        let mut reveal_map = std::collections::HashMap::new();
 
-        for (keychain, _) in wallet_read.spk_index().keychains() {
-            let mut last_used_index = 0;
-            let step = 1000;
-
-            // First find upper bound by incrementing by 1000 until we find unused
-            loop {
-                let address = wallet_read.peek_address(keychain, last_used_index);
-                let has_txs = self.address_has_txs(chain_source_client, &address).await?;
-
-                if !has_txs {
-                    break;
-                }
-                last_used_index += step;
-            }
-
-            // Now binary search between last_used_index - step and last_used_index
-            let mut high = last_used_index;
-            let mut low = last_used_index.saturating_sub(step);
-
-            while low < high {
-                let mid = low + (high - low) / 2;
-                let address = wallet_read.peek_address(keychain, mid);
-                let has_txs = self.address_has_txs(chain_source_client, &address).await?;
-
-                if !has_txs {
-                    high = mid;
-                } else {
-                    low = mid + 1;
-                }
-            }
-
-            tracing::info!(
-                "Found last used address at index {} for keychain {:?}: {} (next: {})",
-                low.saturating_sub(1),
-                keychain,
-                wallet_read.peek_address(keychain, low.saturating_sub(1)),
-                wallet_read.peek_address(keychain, low)
-            );
-
-            reveal_map.insert(keychain, low);
-        }
-
-        // Now upgrade to write lock and reveal all addresses
-        let mut wallet_write = RwLockUpgradableReadGuardSome::upgrade(wallet_read).await;
-
-        for (keychain, index) in reveal_map {
-            // Reveal the addresses, so that when we persist later the wallet
-            // will know which index we're at.
-            let _addresses =
-                wallet_write.with_mut(|wallet| wallet.reveal_addresses_to(keychain, index));
-        }
-
-        let local_chain = wallet_write.local_chain();
-        let checkpoint = self.get_chain_checkpoint(local_chain, None).await?;
-        let request = wallet_write
-            .start_sync_with_revealed_spks()
-            .chain_tip(checkpoint);
+        let checkpoint = {
+            let local_chain = wallet_read.local_chain();
+            self.get_chain_checkpoint(local_chain, None).await?
+        };
+        // Scan every keychain from index 0, stopping only once `STOP_GAP`
+        // consecutive unused addresses have been seen. Addresses are not
+        // necessarily used in index order, so searching for the first unused
+        // index, and revealing/syncing only up to it, misses addresses that are
+        // funded after a gap.
+        // Keeping already revealed SPKs, wallet txids and wallet UTXOs up to
+        // date remains the job of `sync`.
+        let request = wallet_read.start_full_scan().chain_tip(checkpoint);
 
         let update = match chain_source_client {
             ChainSourceClient::Electrum(electrum_client) => {
                 const BATCH_SIZE: usize = 100;
                 const FETCH_PREV_TXOUTS: bool = true;
                 electrum_client
-                    .sync(request, BATCH_SIZE, FETCH_PREV_TXOUTS)
+                    .full_scan(request, STOP_GAP, BATCH_SIZE, FETCH_PREV_TXOUTS)
                     .map_err(error::ChainSourceClient::Electrum)?
             }
 
             ChainSourceClient::Esplora(esplora_client) => {
                 esplora_client
-                    .sync(request, ESPLORA_PARALLEL_REQUESTS)
+                    .full_scan(request, STOP_GAP, ESPLORA_PARALLEL_REQUESTS)
                     .map_err(|err| error::ChainSourceClient::Esplora(*err))
                     .await?
             }
         };
 
         tracing::info!(
-            "wallet full scan complete in {:?}",
+            "wallet full scan complete in {:?}, last active indexes: {:?}",
             start.elapsed().unwrap_or_default(),
+            update.last_active_indices,
         );
 
         start = SystemTime::now();
 
+        // Applying the update reveals addresses up to the last active index of
+        // each keychain, so that the persist below records which index we're at.
+        let mut wallet_write = RwLockUpgradableReadGuardSome::upgrade(wallet_read).await;
         let mut bdk_db = self.bdk_db.lock().await;
 
         wallet_write


### PR DESCRIPTION
`WalletInner::full_scan` probed each keychain for the first index with no history and
scanned only up to it, which assumes addresses are used in strictly increasing order. If
index 0 was unused the probe stopped immediately and nothing was scanned; more generally
any address funded after a derivation gap was never scanned, so its coins were missing
from the balance, UTXO listings, and coin selection.

Use BDK's `start_full_scan` with a stop gap of 200 and apply the returned
`last_active_indices` when the update is persisted. `full_scan` is reached only from
`--wallet-full-scan` and the `blocks_behind > MAX_BLOCK_BY_BLOCK_REPLAY` catch-up, both
seed-recovery paths, where a recovered seed may come from a wallet that hands out
addresses without requiring them to be used.

Affects only this node's own wallet state.