### PR TITLE
wallet: warn when an absolute fee exceeds the destination total

### DIFF
--- a/lib/server/wallet/grpc.rs
+++ b/lib/server/wallet/grpc.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, str::FromStr};
 
 use bdk_wallet::bip39::Mnemonic;
-use bitcoin::{Address, Amount, hashes::Hash as _};
+use bitcoin::{Address, Amount, amount::CheckedSum as _, hashes::Hash as _};
 use buffa::MessageField;
 use connectrpc::{ConnectError, RequestContext, Response, ServiceRequest, ServiceResult};
 
@@ -470,6 +470,23 @@ impl WalletService for crate::wallet::Wallet {
             .into_option()
             .map(|fee_rate| fee_rate.try_into())
             .transpose()?;
+
+        // An absolute fee larger than the total being sent is a caller error. Only
+        // checkable when the destinations account for the whole spend: a send with
+        // no destinations has no destination value, and a drain spends the entire
+        // wallet balance rather than the requested amounts.
+        // Advisory only: an absolute fee can legitimately exceed a small payment
+        // during a fee spike, and the caller opted into the absolute fee policy.
+        if let Some(crate::types::FeePolicy::Absolute(fee)) = &fee_policy
+            && !destinations_validated.is_empty()
+            && drain_wallet_to.is_none()
+            && let Some(total) = destinations_validated.values().copied().checked_sum()
+            && *fee > total
+        {
+            tracing::warn!(
+                "absolute fee is greater than the total destination amount: {fee} > {total}"
+            );
+        }
 
         let op_return_message = op_return_message
             .into_option()


### PR DESCRIPTION
The `SendTransaction` handler validated addresses, dust and the
`drain_wallet_to`/`required_utxos` combination, but not the fee, so an absolute fee far
larger than the amount being sent was built, signed and broadcast, with the difference
going to the miner.

Log a warning when an absolute fee exceeds the total being sent. The check is advisory
rather than a rejection: an absolute fee legitimately exceeds a small payment when
spending many small inputs during a fee spike, and the caller had to opt into the
absolute-fee policy to reach this path. It applies only when the destinations account for
the whole spend, i.e. there is at least one destination and no drain.