### PR TITLE
wallet: reject withdrawal bundles without a CTIP

### DIFF
--- a/integration_tests/test_blinded_m6_roundtrip.rs
+++ b/integration_tests/test_blinded_m6_roundtrip.rs
@@ -13,7 +13,7 @@ use either::Either;
 use futures::channel::mpsc;
 
 use crate::{
-    integration_test::{activate_sidechain, propose_sidechain},
+    integration_test::{activate_sidechain, deposit, fund_enforcer, propose_sidechain},
     mine::mine_generateblocks_check,
     setup::{DummySidechain, PostSetup, Sidechain as _},
 };
@@ -104,7 +104,7 @@ async fn mine_block_and_collect_proposed_m6ids(
 
 pub async fn test_blinded_m6_zero_input_roundtrip(mut post_setup: PostSetup) -> anyhow::Result<()> {
     let (sidechain_res_tx, _sidechain_res_rx) = mpsc::unbounded();
-    let mut _sidechain = DummySidechain::setup((), &post_setup, sidechain_res_tx).await?;
+    let mut sidechain = DummySidechain::setup((), &post_setup, sidechain_res_tx).await?;
     propose_sidechain::<DummySidechain>(&mut post_setup).await?;
     activate_sidechain::<DummySidechain>(&mut post_setup).await?;
 
@@ -117,6 +117,50 @@ pub async fn test_blinded_m6_zero_input_roundtrip(mut post_setup: PostSetup) -> 
 
     // Serialize the way Bitcoin Core / a sidechain does (legacy, NOT segwit).
     let transaction_bytes = serialize_zero_input_legacy(&blinded_tx);
+
+    // An active slot does not necessarily have a treasury yet: nothing has been
+    // deposited at this point, so slot 0 has no CTIP and an M6 built from this
+    // bundle would have no treasury output to spend. Reject at ingestion rather
+    // than store a proposal that can never be acted on. These are the exact
+    // bytes the enforcer accepts once the treasury exists below, so the
+    // rejection can only come from the missing CTIP.
+    let no_ctip_result = post_setup
+        .wallet_service_client
+        .broadcast_withdrawal_bundle(BroadcastWithdrawalBundleRequest {
+            sidechain_id: bip300301_enforcer_lib::proto::wrap_u32(0),
+            transaction: buffa::MessageField::some(buffa_types::google::protobuf::BytesValue {
+                value: transaction_bytes.clone(),
+                ..Default::default()
+            }),
+        })
+        .await;
+    let status = no_ctip_result.err().ok_or_else(|| {
+        anyhow::anyhow!(
+            "BroadcastWithdrawalBundle accepted a bundle for an active sidechain without a CTIP"
+        )
+    })?;
+    anyhow::ensure!(
+        status.code == connectrpc::ErrorCode::FailedPrecondition,
+        "expected FailedPrecondition for a sidechain without a CTIP, got: {status}"
+    );
+    anyhow::ensure!(
+        status.to_string().contains("no treasury UTXO"),
+        "expected the rejection to identify the missing treasury UTXO, got: {status}"
+    );
+
+    // A withdrawal bundle is meaningful only after the active sidechain has a
+    // treasury UTXO. Establish one before exercising the positive storage and
+    // M3 round-trip below.
+    fund_enforcer::<DummySidechain>(&mut post_setup).await?;
+    let sidechain_address = sidechain.get_deposit_address().await?;
+    deposit(
+        &mut post_setup,
+        &mut sidechain,
+        &sidechain_address,
+        Amount::from_sat(1_000_000),
+        Amount::from_sat(10_000),
+    )
+    .await?;
 
     // Verify the fixture against Bitcoin Core itself: Core must parse these bytes
     // in legacy form (`iswitness=false`) and must agree with rust-bitcoin on the txid,

--- a/integration_tests/test_sidechain_ack_policy.rs
+++ b/integration_tests/test_sidechain_ack_policy.rs
@@ -20,9 +20,10 @@ use bip300301_enforcer_lib::{
     types::SidechainNumber,
 };
 use bitcoin::{Amount, BlockHash, Txid};
+use futures::channel::mpsc;
 
 use crate::{
-    integration_test::{propose_sidechain, propose_sidechain_for_slot},
+    integration_test::{deposit, fund_enforcer, propose_sidechain, propose_sidechain_for_slot},
     mine::mine,
     setup::{DummySidechain, PostSetup, Sidechain as _},
     test_blinded_m6_roundtrip::{make_blinded_m6, serialize_zero_input_legacy},
@@ -105,6 +106,9 @@ async fn bundle_vote_count(post_setup: &mut PostSetup, m6id: Txid) -> anyhow::Re
 }
 
 pub async fn test_sidechain_ack_policy(mut post_setup: PostSetup) -> anyhow::Result<()> {
+    let (sidechain_res_tx, _sidechain_res_rx) = mpsc::unbounded();
+    let mut sidechain = DummySidechain::setup((), &post_setup, sidechain_res_tx).await?;
+
     // Black box: learn the network's BIP300 constants over RPC, like any
     // client, rather than hardcoding the enforcer's regtest thresholds.
     let constants = post_setup
@@ -213,6 +217,19 @@ pub async fn test_sidechain_ack_policy(mut post_setup: PostSetup) -> anyhow::Res
         sidechains_active(&mut post_setup).await? == 1,
         "sidechain did not activate despite an explicit ACK"
     );
+
+    // Withdrawal-bundle policy is meaningful only after the active sidechain
+    // has a treasury UTXO. Establish one before testing its M3/M4 votes.
+    fund_enforcer::<DummySidechain>(&mut post_setup).await?;
+    let sidechain_address = sidechain.get_deposit_address().await?;
+    deposit(
+        &mut post_setup,
+        &mut sidechain,
+        &sidechain_address,
+        Amount::from_sat(1_000_000),
+        Amount::from_sat(10_000),
+    )
+    .await?;
 
     // The case enabled by suppressing the M4 only for M2s that can activate a
     // new slot, rather than for any M2: a withdrawal bundle gathers votes in

--- a/lib/server/wallet/grpc.rs
+++ b/lib/server/wallet/grpc.rs
@@ -110,6 +110,21 @@ impl WalletService for crate::wallet::Wallet {
             Ok(true) => (),
             Err(err) => return Err(internal_err(err)),
         }
+        // Likewise reject bundles for an active slot that has no CTIP: with no
+        // treasury UTXO there is nothing for an M6 to spend, so the bundle could
+        // never become a valid withdrawal. NB: as with the active-slot gate
+        // above, this cannot cover a CTIP that a reorg removes *after* a bundle
+        // is stored. In that state block building fails with `MissingCtip` once
+        // the bundle clears the inclusion threshold.
+        match self.validator().try_get_ctip(sidechain_id) {
+            Ok(None) => {
+                return Err(ConnectError::failed_precondition(format!(
+                    "cannot accept a withdrawal bundle for sidechain {sidechain_id}: no treasury UTXO"
+                )));
+            }
+            Ok(Some(_)) => (),
+            Err(err) => return Err(internal_err(err)),
+        }
         let transaction_bytes: Vec<u8> = transaction
             .into_option()
             .ok_or_else(|| missing_field::<BroadcastWithdrawalBundleRequest>("transaction"))?


### PR DESCRIPTION
## Problem

An active sidechain may not have a treasury UTXO yet. `BroadcastWithdrawalBundle` currently accepts and persists a blinded M6 in that state even though there is no CTIP from which a withdrawal transaction can be constructed.

## Fix

Check the validator CTIP immediately after the existing active-sidechain gate. If none exists, return `FailedPrecondition` with a specific missing-treasury message.

## Tests

- Add an integration regression that activates a sidechain without making a deposit and verifies the RPC is rejected.
- Update the existing positive blinded-M6 and sidechain-ACK-policy fixtures to establish a confirmed CTIP before proposing a bundle; retain their storage, M3, and M4 assertions.
- `cargo +nightly fmt --all -- --check`
- `cargo check --all-targets`
- `cargo clippy --all-targets -- --deny warnings`
- strict nightly `unqualified_local_imports` clippy pass
- `cargo test --tests` (136 tests)
- focused `blinded_m6_requires_ctip` integration test
- focused `blinded_m6_roundtrip` integration test
- focused `sidechain_ack_policy` integration test

## Scope

This changes only wallet RPC ingestion for active sidechains without a CTIP. Inactive-sidechain rejection and funded-sidechain paths remain covered.

Closes #97