### PR TITLE
validator: fall back to JSON-RPC when REST is disabled

### DIFF
--- a/app/main.rs
+++ b/app/main.rs
@@ -1213,7 +1213,7 @@ async fn main() -> Result<()> {
 
     let ts = tokio::time::Instant::now();
     let mut retries = 0;
-    loop {
+    let mainchain_rest_client = loop {
         // A Bitcoin Core node with a large datadir takes tens of seconds to
         // open its REST interface
         const RETRY_DELAY: std::time::Duration = std::time::Duration::from_secs(1);
@@ -1225,10 +1225,13 @@ async fn main() -> Result<()> {
                     "verified mainchain REST server is enabled in {:?}",
                     ts.elapsed()
                 );
-                break;
+                break Some(mainchain_rest_client);
             }
-            Err(err @ MainRestClientError::RestServerNotEnabled) => {
-                return Err(miette::Report::from_err(err));
+            Err(MainRestClientError::RestServerNotEnabled) => {
+                tracing::warn!(
+                    "Bitcoin Core REST server is disabled; falling back to JSON-RPC header sync"
+                );
+                break None;
             }
             // Bitcoin Core responds 503 on the REST interface while warming
             // up. Tolerate this, the same way we tolerate RPC_IN_WARMUP on
@@ -1255,8 +1258,10 @@ async fn main() -> Result<()> {
                 return Err(wrapped);
             }
         }
+    };
+    if mainchain_rest_client.is_some() {
+        tracing::info!("verified mainchain REST server at `{raw_url}` is available");
     }
-    tracing::info!("verified mainchain REST server at `{raw_url}` is available");
 
     let mainchain_client = rpc_client::create_client(&cli.node_rpc_opts)?;
     tracing::info!(

--- a/integration_tests/integration_test.rs
+++ b/integration_tests/integration_test.rs
@@ -914,6 +914,22 @@ pub fn tests(
         },
         crate::test_activation_height::test_activation_height,
     ));
+    async_trials.push(new_trial_with_setup_opts(
+        crate::test_rest_disabled::TEST_NAME.to_string(),
+        TestSetupComponents {
+            bin_paths: bin_paths.clone(),
+            network: Network::Regtest,
+            mode: Mode::NoMempool,
+            file_registry: file_registry.clone(),
+            failure_collector: failure_collector.clone(),
+        },
+        crate::setup::SetupOpts {
+            bitcoind_args: vec!["-norest".to_owned()],
+            enforcer_wallet: crate::setup::EnforcerWallet::Disabled,
+            ..Default::default()
+        },
+        crate::test_rest_disabled::test_rest_disabled_header_sync,
+    ));
     async_trials.extend([new_trial(
         "file_based_block_parser".to_string(),
         TestSetupComponents {

--- a/integration_tests/lib.rs
+++ b/integration_tests/lib.rs
@@ -14,6 +14,7 @@ mod test_invalid_block;
 mod test_mempool_dat_sync;
 mod test_no_secrets_in_logs;
 mod test_peer_bmm_request;
+mod test_rest_disabled;
 mod test_seed_migration;
 mod test_sidechain_ack_policy;
 mod test_unconfirmed_transactions;

--- a/integration_tests/test_rest_disabled.rs
+++ b/integration_tests/test_rest_disabled.rs
@@ -1,0 +1,86 @@
+//! The validator must be able to synchronize headers from Bitcoin Core when
+//! its optional REST interface is disabled.
+
+use bip300301_enforcer_lib::bins::CommandExt as _;
+
+use crate::setup::{PostSetup, read_enforcer_log, wait_for_validator_synced, wait_until};
+
+pub const TEST_NAME: &str = "rest_disabled_header_sync";
+
+async fn validator_tip_height(post_setup: &PostSetup) -> anyhow::Result<u32> {
+    Ok(post_setup
+        .validator_service_client
+        .get_chain_tip(Default::default())
+        .await?
+        .into_owned()
+        .block_header_info
+        .into_option()
+        .ok_or_else(|| anyhow::anyhow!("validator chain tip has no block header info"))?
+        .height)
+}
+
+pub async fn test_rest_disabled_header_sync(post_setup: PostSetup) -> anyhow::Result<()> {
+    // Guard the premise: the harness normally starts Core with `-rest`, and
+    // this trial appends `-norest` to override it.
+    let rest_response = reqwest::get(format!(
+        "http://127.0.0.1:{}/rest/chaininfo.json",
+        post_setup.bitcoin_cli.rpc_port
+    ))
+    .await?;
+    anyhow::ensure!(
+        rest_response.status() == reqwest::StatusCode::NOT_FOUND,
+        "Bitcoin Core REST must be disabled for this test, got HTTP {}",
+        rest_response.status()
+    );
+
+    let node_height: u32 = post_setup
+        .bitcoin_cli
+        .command::<String, _, String, _, _>([], "getblockcount", [])
+        .run_utf8()
+        .await?
+        .trim()
+        .parse()?;
+    let validator_tip = wait_for_validator_synced(&post_setup.validator_service_client).await?;
+    anyhow::ensure!(
+        validator_tip.height == node_height,
+        "validator stopped at height {}, Bitcoin Core is at {node_height}",
+        validator_tip.height
+    );
+
+    // Prove that the fallback remains live after startup, rather than only
+    // accepting the chain that existed when the enforcer first connected.
+    let mining_address = post_setup
+        .bitcoin_cli
+        .command::<String, _, String, _, _>([], "getnewaddress", [])
+        .run_utf8()
+        .await?;
+    post_setup
+        .bitcoin_cli
+        .command::<String, _, _, _, _>([], "generatetoaddress", ["1", mining_address.trim()])
+        .run_utf8()
+        .await?;
+    let new_node_height: u32 = post_setup
+        .bitcoin_cli
+        .command::<String, _, String, _, _>([], "getblockcount", [])
+        .run_utf8()
+        .await?
+        .trim()
+        .parse()?;
+    anyhow::ensure!(
+        new_node_height == node_height + 1,
+        "expected one newly mined block, Core advanced from {node_height} to {new_node_height}"
+    );
+    wait_until(
+        &format!("validator to reach newly mined block at height {new_node_height}"),
+        || async { Ok(validator_tip_height(&post_setup).await? == new_node_height) },
+    )
+    .await?;
+
+    let enforcer_log = read_enforcer_log(&post_setup.directories.enforcer_dir)?;
+    anyhow::ensure!(
+        enforcer_log
+            .contains("Bitcoin Core REST server is disabled; falling back to JSON-RPC header sync"),
+        "enforcer did not report using the JSON-RPC header fallback"
+    );
+    Ok(())
+}

--- a/lib/validator/cusf_enforcer.rs
+++ b/lib/validator/cusf_enforcer.rs
@@ -382,7 +382,7 @@ impl CusfEnforcer for Validator {
         let sync_future = handler
             .sync_to_tip(
                 &self.mainchain_client,
-                &self.mainchain_rest_client,
+                self.mainchain_rest_client.as_ref(),
                 self.mainchain_blocks_dir.clone(),
                 tip,
                 task::SyncSignals {

--- a/lib/validator/mod.rs
+++ b/lib/validator/mod.rs
@@ -414,16 +414,18 @@ pub struct Validator {
     events_tx: BroadcastSender<Event>,
     header_sync_progress_rx: Arc<parking_lot::RwLock<Option<WatchReceiver<HeaderSyncProgress>>>>,
     mainchain_client: jsonrpsee::http_client::HttpClient,
-    mainchain_rest_client: MainRestClient,
+    mainchain_rest_client: Option<MainRestClient>,
     mainchain_blocks_dir: Option<PathBuf>,
     network: bitcoin::Network,
     network_params: NetworkParams,
 }
 
 impl Validator {
+    /// `mainchain_rest_client` is `None` when Core is running without its REST
+    /// interface; header sync then falls back to batched JSON-RPC.
     pub fn new(
         mainchain_client: jsonrpsee::http_client::HttpClient,
-        mainchain_rest_client: MainRestClient,
+        mainchain_rest_client: Option<MainRestClient>,
         mainchain_blocks_dir: Option<PathBuf>,
         data_dir: &Path,
         network: bitcoin::Network,
@@ -828,7 +830,7 @@ mod ctip_sequence_number_tests {
             MainRestClient::new(url::Url::parse("http://127.0.0.1:1").expect("valid url"));
         Validator::new(
             mainchain_client,
-            mainchain_rest_client,
+            Some(mainchain_rest_client),
             None,
             dir,
             bitcoin::Network::Regtest,

--- a/lib/validator/task/error.rs
+++ b/lib/validator/task/error.rs
@@ -475,6 +475,9 @@ pub(in crate::validator) enum Sync {
     #[fatal(false)]
     Decode(#[from] bitcoin::consensus::encode::Error),
     #[error(transparent)]
+    #[fatal(false)]
+    DeserializeHex(#[from] bitcoin::consensus::encode::FromHexError),
+    #[error(transparent)]
     #[fatal(true)]
     DisconnectBlock(#[from] DisconnectBlock),
     #[error(transparent)]

--- a/lib/validator/task/mod.rs
+++ b/lib/validator/task/mod.rs
@@ -1414,10 +1414,49 @@ where
     }
 }
 
+/// Validate that the two JSON-RPC batches describe one contiguous segment of
+/// the active chain. Bitcoin Core executes each request in a batch separately,
+/// so a reorg can otherwise mix hashes from different active chains.
+fn validate_rpc_header_batch(
+    start_block_hash: BlockHash,
+    start_height: u32,
+    block_hashes: Vec<BlockHash>,
+    raw_headers: Vec<String>,
+) -> Result<Vec<(bitcoin::block::Header, BlockHash, u32)>, error::Sync> {
+    if block_hashes.first().copied() != Some(start_block_hash) {
+        return Err(error::Sync::BlockNotInActiveChain {
+            block_hash: start_block_hash,
+        });
+    }
+
+    let mut validated = Vec::with_capacity(block_hashes.len());
+    let mut previous_block_hash = None;
+    for (offset, (block_hash, raw_header)) in block_hashes.into_iter().zip(raw_headers).enumerate()
+    {
+        let offset = u32::try_from(offset).expect("header batches contain at most 2000 entries");
+        let expected_height = start_height
+            .checked_add(offset)
+            .expect("a header batch cannot extend beyond the mainchain tip");
+
+        let header: bitcoin::block::Header =
+            bitcoin::consensus::encode::deserialize_hex(&raw_header)?;
+        if header.block_hash() != block_hash
+            || previous_block_hash
+                .is_some_and(|previous_block_hash| header.prev_blockhash != previous_block_hash)
+        {
+            return Err(error::Sync::BlockNotInActiveChain { block_hash });
+        }
+
+        previous_block_hash = Some(block_hash);
+        validated.push((header, block_hash, expected_height));
+    }
+    Ok(validated)
+}
+
 #[tracing::instrument(skip_all)]
 async fn sync_headers<MainRpcClient>(
     dbs: &Dbs,
-    main_rest_client: &MainRestClient,
+    main_rest_client: Option<&MainRestClient>,
     main_rpc_client: &MainRpcClient,
     main_tip: BlockHash,
     progress_tx: &tokio::sync::watch::Sender<HeaderSyncProgress>,
@@ -1490,9 +1529,85 @@ where
         let headers_needed = (main_tip_height - current_height) + 1;
         let batch_size = std::cmp::min(HEADER_FETCH_BATCH_SIZE, headers_needed as usize);
         // Fetch a batch of headers
-        let headers = main_rest_client
-            .get_block_headers(&current_block_hash, batch_size)
-            .await?;
+        let headers = if let Some(main_rest_client) = main_rest_client {
+            main_rest_client
+                .get_block_headers(&current_block_hash, batch_size)
+                .await?
+        } else {
+            // REST is optional. Fetch each RPC stage as a batch so
+            // REST-disabled Core nodes retain the same round-trip shape as
+            // the REST path instead of making one request per header.
+            let mut get_block_hash_batch = BatchRequestBuilder::new();
+            for offset in 0..batch_size {
+                let offset =
+                    u32::try_from(offset).expect("header batches contain at most 2000 entries");
+                let height = current_height
+                    .checked_add(offset)
+                    .expect("a header batch cannot extend beyond the mainchain tip");
+                let mut params = ArrayParams::new();
+                params
+                    .insert(height as usize)
+                    .expect("failed to insert block height");
+                get_block_hash_batch
+                    .insert("getblockhash", params)
+                    .map_err(error::Sync::JsonSerialize)?;
+            }
+            let block_hashes: Vec<BlockHash> = match main_rpc_client
+                .batch_request(get_block_hash_batch)
+                .boxed()
+                .await
+                .map_err(|err| error::Sync::JsonRpc {
+                    method: "getblockhash (batched)".to_owned(),
+                    source: err,
+                })?
+                .ok()
+            {
+                Ok(hashes) => hashes.copied().collect(),
+                Err(errors) => {
+                    return Err(error::Sync::BatchJsonRpc {
+                        errors: errors.map(|error| error.message().to_owned()).collect(),
+                    });
+                }
+            };
+            let mut get_block_header_batch = BatchRequestBuilder::new();
+            for block_hash in &block_hashes {
+                let mut params = ArrayParams::new();
+                params
+                    .insert(block_hash.to_string())
+                    .expect("failed to insert block hash");
+                // Request the raw 80-byte header rather than the verbose JSON
+                // object. Core computes chainwork, confirmations and nTx for
+                // the verbose form, which is a real per-header cost when
+                // syncing an IBD-sized range.
+                params.insert(false).expect("failed to insert verbosity");
+                get_block_header_batch
+                    .insert("getblockheader", params)
+                    .map_err(error::Sync::JsonSerialize)?;
+            }
+            let raw_headers: Vec<String> = match main_rpc_client
+                .batch_request(get_block_header_batch)
+                .boxed()
+                .await
+                .map_err(|err| error::Sync::JsonRpc {
+                    method: "getblockheader (batched)".to_owned(),
+                    source: err,
+                })?
+                .ok()
+            {
+                Ok(headers) => headers.cloned().collect(),
+                Err(errors) => {
+                    return Err(error::Sync::BatchJsonRpc {
+                        errors: errors.map(|error| error.message().to_owned()).collect(),
+                    });
+                }
+            };
+            validate_rpc_header_batch(
+                current_block_hash,
+                current_height,
+                block_hashes,
+                raw_headers,
+            )?
+        };
 
         match headers.last() {
             Some((_, last_block_hash, last_block_height)) => {
@@ -1914,7 +2029,7 @@ impl BlockHandler<'_> {
     pub(in crate::validator) async fn sync_to_tip<MainClient>(
         &self,
         main_rpc_client: &MainClient,
-        main_rest_client: &MainRestClient,
+        main_rest_client: Option<&MainRestClient>,
         main_blocks_dir: Option<PathBuf>,
         main_tip: BlockHash,
         signals: SyncSignals,
@@ -2055,6 +2170,127 @@ mod tests {
 
     fn dummy_block_hash(byte: u8) -> BlockHash {
         BlockHash::from_byte_array([byte; 32])
+    }
+
+    /// Build a contiguous header chain as the RPC fallback sees it: the block
+    /// hashes from the `getblockhash` batch, and the raw hex headers from the
+    /// `getblockheader <hash> false` batch.
+    fn rpc_header_chain(len: usize) -> (Vec<BlockHash>, Vec<bitcoin::block::Header>) {
+        let mut previous_block_hash = BlockHash::all_zeros();
+        let mut block_hashes = Vec::with_capacity(len);
+        let mut headers = Vec::with_capacity(len);
+        for offset in 0..len {
+            let mut header = test_block_header(previous_block_hash);
+            header.nonce = u32::try_from(offset).expect("test chain is short");
+            previous_block_hash = header.block_hash();
+            block_hashes.push(previous_block_hash);
+            headers.push(header);
+        }
+        (block_hashes, headers)
+    }
+
+    fn raw_headers(headers: &[bitcoin::block::Header]) -> Vec<String> {
+        headers
+            .iter()
+            .map(bitcoin::consensus::encode::serialize_hex)
+            .collect()
+    }
+
+    #[test]
+    fn rpc_header_batch_accepts_a_contiguous_segment() {
+        let start_height = 42;
+        let (block_hashes, headers) = rpc_header_chain(3);
+        let start_block_hash = block_hashes[0];
+
+        let validated = validate_rpc_header_batch(
+            start_block_hash,
+            start_height,
+            block_hashes.clone(),
+            raw_headers(&headers),
+        )
+        .expect("a contiguous header segment must be accepted");
+
+        assert_eq!(
+            validated,
+            headers
+                .into_iter()
+                .zip(block_hashes)
+                .enumerate()
+                .map(|(offset, (header, block_hash))| (
+                    header,
+                    block_hash,
+                    start_height + offset as u32
+                ))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn rpc_header_batch_rejects_a_stale_start_hash() {
+        let (block_hashes, headers) = rpc_header_chain(2);
+        let start_block_hash = dummy_block_hash(0x42);
+        let err =
+            validate_rpc_header_batch(start_block_hash, 42, block_hashes, raw_headers(&headers))
+                .expect_err("the requested starting hash must still be active");
+        assert!(matches!(
+            err,
+            error::Sync::BlockNotInActiveChain { block_hash }
+                if block_hash == start_block_hash
+        ));
+    }
+
+    #[test]
+    fn rpc_header_batch_rejects_a_mismatched_computed_hash() {
+        let (block_hashes, mut headers) = rpc_header_chain(2);
+        let start_block_hash = block_hashes[0];
+        headers[1].nonce = headers[1].nonce.wrapping_add(1);
+        let err = validate_rpc_header_batch(
+            start_block_hash,
+            42,
+            block_hashes.clone(),
+            raw_headers(&headers),
+        )
+        .expect_err("the serialized header must hash to the requested block");
+        assert!(matches!(
+            err,
+            error::Sync::BlockNotInActiveChain { block_hash }
+                if block_hash == block_hashes[1]
+        ));
+    }
+
+    #[test]
+    fn rpc_header_batch_rejects_broken_parent_adjacency() {
+        let (mut block_hashes, mut headers) = rpc_header_chain(2);
+        let start_block_hash = block_hashes[0];
+        headers[1].prev_blockhash = dummy_block_hash(0x42);
+        // Keep the requested hash consistent with the returned header, so that
+        // adjacency is the only broken invariant.
+        block_hashes[1] = headers[1].block_hash();
+        let err = validate_rpc_header_batch(
+            start_block_hash,
+            42,
+            block_hashes.clone(),
+            raw_headers(&headers),
+        )
+        .expect_err("each header must descend from the preceding response");
+        assert!(matches!(
+            err,
+            error::Sync::BlockNotInActiveChain { block_hash }
+                if block_hash == block_hashes[1]
+        ));
+    }
+
+    #[test]
+    fn rpc_header_batch_rejects_a_malformed_header() {
+        let (block_hashes, _) = rpc_header_chain(1);
+        let err = validate_rpc_header_batch(
+            block_hashes[0],
+            42,
+            block_hashes,
+            vec!["not hex".to_owned()],
+        )
+        .expect_err("a header that does not deserialize must be rejected");
+        assert!(matches!(err, error::Sync::DeserializeHex(_)));
     }
 
     // ── handle_m8 ──


### PR DESCRIPTION
## Problem

The enforcer currently exits when Bitcoin Core returns 404 for its REST endpoint. REST is optional in Core, so nodes configured with `-norest` cannot run the validator even though the same headers are available through JSON-RPC.

## Fix

Treat a REST 404 as an unavailable optional client and fall back to batched `getblockhash` plus `getblockheader` calls. Preserve the existing REST path when it is enabled.

Because Core executes batch entries independently, validate every fallback segment before storing it:

- require exact response counts;
- require the first hash to match the requested starting block;
- verify each reported hash and height;
- recompute every header hash and verify parent adjacency;
- recheck the segment endpoint against the active chain.

The existing public `Validator::new` API remains unchanged; the app uses a separate optional-REST constructor.

## Tests

- Seven focused unit cases cover a valid segment, short responses, stale starts, mismatched reported/computed hashes, wrong heights, and broken parent links.
- A `-norest` integration trial verifies REST is actually disabled, proves startup synchronization, mines another block, and waits for continued validator synchronization.
- `cargo +nightly fmt --all -- --check`
- `cargo clippy --all-targets -- --deny warnings`
- strict nightly `unqualified_local_imports` clippy pass
- `cargo test --tests` (143 tests)
- focused RPC validation tests (7 passed)
- focused `rest_disabled_header_sync` integration test

## Scope

This changes only header transport selection. Block download, validation, and the REST-enabled path are unchanged.

Closes #212