### PR TITLE
validator: ignore duplicate M1 proposals

### DIFF
--- a/lib/messages.rs
+++ b/lib/messages.rs
@@ -501,21 +501,14 @@ impl CoinbaseMessages {
                     sidechain_number: sidechain_proposal.sidechain_number,
                     description_hash: sidechain_proposal.description.sha256d_hash(),
                 };
-                match self
-                    .m1_sidechain_proposal_id_to_index
+                // BIP 300 does not invalidate a block for a repeated M1. Keep
+                // the first vout for builder queries and let the proposal
+                // handler ignore the repeat without resetting its vote count.
+                self.m1_sidechain_proposal_id_to_index
                     .entry(sidechain_proposal_id)
-                {
-                    hash_map::Entry::Occupied(entry) => Err(CoinbaseMessagesError::DuplicateM1 {
-                        index: *entry.get(),
-                        slot: sidechain_proposal_id.sidechain_number,
-                        sidechain_description_hash: sidechain_proposal_id.description_hash,
-                    }),
-                    hash_map::Entry::Vacant(entry) => {
-                        entry.insert(vout);
-                        self.messages.push((msg, vout));
-                        Ok(())
-                    }
-                }
+                    .or_insert(vout);
+                self.messages.push((msg, vout));
+                Ok(())
             }
             CoinbaseMessage::M2AckSidechain(m2) => {
                 match self.m2_ack_slot_to_index.entry(m2.sidechain_number) {

--- a/lib/validator/task/mod.rs
+++ b/lib/validator/task/mod.rs
@@ -2767,6 +2767,59 @@ mod tests {
         Ok(())
     }
 
+    /// Repeating an M1 in the same coinbase is not a block-invalid condition.
+    /// The first proposal is retained and the repeat must not reset its age or
+    /// create a second proposal event.
+    #[test]
+    fn connect_block_ignores_duplicate_m1_in_same_coinbase() -> Result<()> {
+        let (_dir, dbs) = create_test_dbs()?;
+        let mut rwtxn = dbs.write_txn().into_diagnostic()?;
+        let proposal = SidechainProposal {
+            sidechain_number: SidechainNumber(4),
+            description: SidechainDescription(b"duplicate-m1".to_vec()),
+        };
+        let proposal_id = proposal.compute_id();
+        let m1_script: ScriptBuf = M1ProposeSidechain {
+            sidechain_number: proposal.sidechain_number,
+            description: proposal.description.clone(),
+        }
+        .try_into()
+        .into_diagnostic()?;
+        let block = build_test_block(
+            BlockHash::all_zeros(),
+            TestBlockParts {
+                extra_coinbase_outputs: vec![
+                    TxOut {
+                        script_pubkey: m1_script.clone(),
+                        value: Amount::ZERO,
+                    },
+                    TxOut {
+                        script_pubkey: m1_script,
+                        value: Amount::ZERO,
+                    },
+                ],
+                ..Default::default()
+            },
+        );
+        dbs.block_hashes
+            .put_headers(&mut rwtxn, &[(block.header, 0)])
+            .into_diagnostic()?;
+
+        let event = test_handler(&dbs)
+            .connect_block(&mut rwtxn, &block)
+            .into_diagnostic()?;
+        let sidechain = dbs
+            .proposal_id_to_sidechain
+            .get(&rwtxn, &proposal_id)
+            .into_diagnostic()?;
+        assert_eq!(sidechain.status.vote_count, 0);
+        let Event::ConnectBlock { block_info, .. } = event else {
+            panic!("expected connect-block event");
+        };
+        assert_eq!(block_info.events.len(), 1);
+        Ok(())
+    }
+
     // ── handle_m2 ──
 
     /// Regression: activating a proposal into an already-used slot overwrites


### PR DESCRIPTION
## Problem

The LayerTwo-Labs BIP300 block-validation rules say an M1 must never make a block invalid and explicitly permit duplicate M1s in one coinbase. `CoinbaseMessages::push` currently returns `DuplicateM1` for an exact repeat, so the validator rejects that block before the proposal handler can apply its existing ignore-without-resetting behavior.

## Fix

Keep the first M1 vout for builder queries, retain repeated messages in coinbase order, and let `handle_m1_propose_sidechain` ignore the repeated proposal. This preserves the original proposal height and vote count and emits only one proposal event.

## Tests

- Added a block-level regression test with two identical M1 outputs.
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --workspace` (134 library tests plus app tests)
- nightly rustfmt check and `git diff --check`

## Scope

Coinbase M1 validation only; no wire-format or proposal-policy changes.
