### PR TITLE
Allow + produce shortened M4 vote arrays

### DIFF
--- a/integration_tests/custom_coinbase.rs
+++ b/integration_tests/custom_coinbase.rs
@@ -1,0 +1,152 @@
+//! Mining a block whose coinbase carries hand-built BIP300 messages.
+//!
+//! The block producer only ever emits coinbases it considers valid, so any test
+//! that needs a specific — possibly invalid — arrangement of coinbase messages
+//! has to assemble the block itself and hand it to `submitblock`.
+
+use bip300301_enforcer_lib::bins::CommandExt as _;
+use bitcoin::{
+    Amount, Block, BlockHash, CompactTarget, OutPoint, ScriptBuf, Sequence, Transaction, TxIn,
+    TxMerkleNode, TxOut, Witness,
+    block::Header,
+    consensus::encode::{deserialize_hex, serialize_hex},
+    hashes::Hash as _,
+    script::{Builder as ScriptBuilder, PushBytesBuf},
+    transaction::Version,
+};
+use serde::Deserialize;
+
+use crate::setup::PostSetup;
+
+/// A zero-value coinbase output carrying `script_pubkey`, the shape every
+/// BIP300 coinbase message takes.
+pub fn zero_value(script_pubkey: ScriptBuf) -> TxOut {
+    TxOut {
+        script_pubkey,
+        value: Amount::ZERO,
+    }
+}
+
+/// Block-template fields we read from bitcoind's `getblocktemplate`. Callers
+/// talk to bitcoind directly (not via the enforcer's GBT proxy) because the
+/// proxy is disabled in `Mode::NoMempool`.
+#[derive(Deserialize)]
+struct BlockTemplate {
+    previousblockhash: BlockHash,
+    version: i32,
+    #[serde(deserialize_with = "deserialize_bits")]
+    bits: CompactTarget,
+    height: u32,
+    coinbasevalue: u64,
+    mintime: u32,
+    curtime: u32,
+    #[serde(default)]
+    transactions: Vec<serde_json::Value>,
+}
+
+fn deserialize_bits<'de, D: serde::Deserializer<'de>>(de: D) -> Result<CompactTarget, D::Error> {
+    let hex = String::deserialize(de)?;
+    u32::from_str_radix(&hex, 16)
+        .map(CompactTarget::from_consensus)
+        .map_err(serde::de::Error::custom)
+}
+
+/// Mine a block on top of the current tip whose coinbase is the mining payout,
+/// the witness commitment, and then `extra_coinbase_outputs` in the order
+/// given. The coinbase carries no producer-generated messages, so the caller's
+/// outputs are the only BIP300 messages in the block, at known indices.
+///
+/// Returns the submitted block's hash; use
+/// [`crate::block_verdict::assert_enforcer_verdict`] to assert on what the
+/// enforcer made of it. `submitblock` accepting the block says nothing about
+/// the enforcer's verdict — bitcoind does not know the BIP300 rules.
+pub async fn submit_block_with_coinbase_outputs(
+    post_setup: &PostSetup,
+    extra_coinbase_outputs: Vec<TxOut>,
+) -> anyhow::Result<BlockHash> {
+    let template_json = post_setup
+        .bitcoin_cli
+        .command::<String, _, _, _, _>([], "getblocktemplate", [r#"{"rules":["segwit"]}"#])
+        .run_utf8()
+        .await?;
+    let template: BlockTemplate = serde_json::from_str(&template_json)?;
+    anyhow::ensure!(
+        template.transactions.is_empty(),
+        "test assumes empty mempool for witness-commitment shortcut; \
+         got {} extra tx(s) in template",
+        template.transactions.len()
+    );
+
+    const WITNESS_RESERVED_VALUE: [u8; 32] = [0; 32];
+    let coinbase_input = TxIn {
+        previous_output: OutPoint::null(),
+        script_sig: ScriptBuilder::new()
+            .push_int(template.height as i64)
+            .into_script(),
+        sequence: Sequence::MAX,
+        witness: Witness::from_slice(&[WITNESS_RESERVED_VALUE]),
+    };
+
+    // All-zero witness merkle root because the coinbase wtxid is 0x00..00 (BIP141).
+    let witness_commitment = Block::compute_witness_commitment(
+        &bitcoin::WitnessMerkleNode::all_zeros(),
+        &WITNESS_RESERVED_VALUE,
+    );
+    let witness_commit_script = {
+        const WITNESS_COMMITMENT_HEADER: [u8; 4] = [0xaa, 0x21, 0xa9, 0xed];
+        let mut payload = PushBytesBuf::from(WITNESS_COMMITMENT_HEADER);
+        payload.extend_from_slice(witness_commitment.as_byte_array())?;
+        ScriptBuf::new_op_return(payload)
+    };
+
+    let mut outputs = vec![
+        TxOut {
+            script_pubkey: post_setup.mining_address.script_pubkey(),
+            value: Amount::from_sat(template.coinbasevalue),
+        },
+        TxOut {
+            script_pubkey: witness_commit_script,
+            value: Amount::ZERO,
+        },
+    ];
+    outputs.extend(extra_coinbase_outputs);
+    let coinbase = Transaction {
+        version: Version::TWO,
+        lock_time: bitcoin::locktime::absolute::LockTime::ZERO,
+        input: vec![coinbase_input],
+        output: outputs,
+    };
+
+    let merkle_root = TxMerkleNode::from(coinbase.compute_txid().to_raw_hash());
+    let header = Header {
+        version: bitcoin::block::Version::from_consensus(template.version),
+        prev_blockhash: template.previousblockhash,
+        merkle_root,
+        time: std::cmp::max(template.curtime, template.mintime),
+        bits: template.bits,
+        nonce: 0,
+    };
+    let header_hex = post_setup
+        .bitcoin_util()?
+        .command::<String, _, _, _, _>([], "grind", [serialize_hex(&header)])
+        .run_utf8()
+        .await?;
+    let header: Header = deserialize_hex(header_hex.trim())?;
+
+    let block = Block {
+        header,
+        txdata: vec![coinbase],
+    };
+    let block_hash = block.block_hash();
+    let submit_resp = post_setup
+        .bitcoin_cli
+        .command::<String, _, _, _, _>([], "submitblock", [serialize_hex(&block)])
+        .run_utf8()
+        .await?;
+    anyhow::ensure!(
+        submit_resp.is_empty(),
+        "submitblock unexpectedly rejected: `{submit_resp}`"
+    );
+
+    Ok(block_hash)
+}

--- a/integration_tests/integration_test.rs
+++ b/integration_tests/integration_test.rs
@@ -1014,6 +1014,17 @@ pub fn tests(
         crate::test_sidechain_ack_policy::test_sidechain_ack_policy,
     ));
     async_trials.push(new_trial_with_setup(
+        "m4_vote_array".to_string(),
+        TestSetupComponents {
+            bin_paths: bin_paths.clone(),
+            network: Network::Regtest,
+            mode: Mode::NoMempool,
+            file_registry: file_registry.clone(),
+            failure_collector: failure_collector.clone(),
+        },
+        crate::test_m4_vote_array::test_m4_vote_array,
+    ));
+    async_trials.push(new_trial_with_setup(
         "invalid_block".to_string(),
         TestSetupComponents {
             bin_paths: bin_paths.clone(),

--- a/integration_tests/lib.rs
+++ b/integration_tests/lib.rs
@@ -1,5 +1,6 @@
 pub mod block_verdict;
 pub mod bmm_block;
+pub mod custom_coinbase;
 pub mod integration_test;
 pub mod mine;
 pub mod setup;
@@ -11,6 +12,7 @@ mod test_file_based_block_parser;
 mod test_generate_to_address;
 mod test_inactive_drivechain_output;
 mod test_invalid_block;
+mod test_m4_vote_array;
 mod test_mempool_dat_sync;
 mod test_no_secrets_in_logs;
 mod test_peer_bmm_request;

--- a/integration_tests/test_invalid_block.rs
+++ b/integration_tests/test_invalid_block.rs
@@ -6,12 +6,9 @@ use bip300301_enforcer_lib::{
     types::{BmmCommitment, SidechainDescription, op_drivechain_script},
 };
 use bitcoin::{
-    Amount, Block, BlockHash, CompactTarget, OutPoint, ScriptBuf, Sequence, Transaction, TxIn,
-    TxMerkleNode, TxOut, Txid, Witness,
-    block::Header,
-    consensus::encode::{deserialize_hex, serialize_hex},
+    Amount, BlockHash, OutPoint, ScriptBuf, Transaction, TxIn, TxOut, Txid,
+    consensus::encode::serialize_hex,
     hashes::{Hash as _, sha256d},
-    script::{Builder as ScriptBuilder, PushBytesBuf},
     transaction::Version,
 };
 use futures::channel::mpsc;
@@ -20,6 +17,7 @@ use serde::Deserialize;
 use crate::{
     block_verdict::{Expect, assert_enforcer_verdict, wait_for_enforcer_height},
     bmm_block::{submit_block_with_bmm_accepts, wait_past_mtp},
+    custom_coinbase::{submit_block_with_coinbase_outputs, zero_value},
     integration_test::{activate_sidechain, fund_enforcer, propose_sidechain},
     setup::{DummySidechain, PostSetup, Sidechain},
 };
@@ -471,120 +469,5 @@ async fn submit_invalid_block(
     post_setup: &PostSetup,
     case: &BadBlockCase,
 ) -> anyhow::Result<BlockHash> {
-    let template_json = post_setup
-        .bitcoin_cli
-        .command::<String, _, _, _, _>([], "getblocktemplate", [r#"{"rules":["segwit"]}"#])
-        .run_utf8()
-        .await?;
-    let template: BlockTemplate = serde_json::from_str(&template_json)?;
-    anyhow::ensure!(
-        template.transactions.is_empty(),
-        "test assumes empty mempool for witness-commitment shortcut; \
-         got {} extra tx(s) in template",
-        template.transactions.len()
-    );
-
-    const WITNESS_RESERVED_VALUE: [u8; 32] = [0; 32];
-    let coinbase_input = TxIn {
-        previous_output: OutPoint::null(),
-        script_sig: ScriptBuilder::new()
-            .push_int(template.height as i64)
-            .into_script(),
-        sequence: Sequence::MAX,
-        witness: Witness::from_slice(&[WITNESS_RESERVED_VALUE]),
-    };
-
-    // All-zero witness merkle root because the coinbase wtxid is 0x00..00 (BIP141).
-    let witness_commitment = Block::compute_witness_commitment(
-        &bitcoin::WitnessMerkleNode::all_zeros(),
-        &WITNESS_RESERVED_VALUE,
-    );
-    let witness_commit_script = {
-        const WITNESS_COMMITMENT_HEADER: [u8; 4] = [0xaa, 0x21, 0xa9, 0xed];
-        let mut payload = PushBytesBuf::from(WITNESS_COMMITMENT_HEADER);
-        payload.extend_from_slice(witness_commitment.as_byte_array())?;
-        ScriptBuf::new_op_return(payload)
-    };
-
-    let mut outputs = vec![
-        TxOut {
-            script_pubkey: post_setup.mining_address.script_pubkey(),
-            value: Amount::from_sat(template.coinbasevalue),
-        },
-        TxOut {
-            script_pubkey: witness_commit_script,
-            value: Amount::ZERO,
-        },
-    ];
-    outputs.extend((case.extra_coinbase_outputs)()?);
-    let coinbase = Transaction {
-        version: Version::TWO,
-        lock_time: bitcoin::locktime::absolute::LockTime::ZERO,
-        input: vec![coinbase_input],
-        output: outputs,
-    };
-
-    let merkle_root = TxMerkleNode::from(coinbase.compute_txid().to_raw_hash());
-    let header = Header {
-        version: bitcoin::block::Version::from_consensus(template.version),
-        prev_blockhash: template.previousblockhash,
-        merkle_root,
-        time: std::cmp::max(template.curtime, template.mintime),
-        bits: template.bits,
-        nonce: 0,
-    };
-    let header_hex = post_setup
-        .bitcoin_util()?
-        .command::<String, _, _, _, _>([], "grind", [serialize_hex(&header)])
-        .run_utf8()
-        .await?;
-    let header: Header = deserialize_hex(header_hex.trim())?;
-
-    let block = Block {
-        header,
-        txdata: vec![coinbase],
-    };
-    let block_hash = block.block_hash();
-    let submit_resp = post_setup
-        .bitcoin_cli
-        .command::<String, _, _, _, _>([], "submitblock", [serialize_hex(&block)])
-        .run_utf8()
-        .await?;
-    anyhow::ensure!(
-        submit_resp.is_empty(),
-        "submitblock unexpectedly rejected: `{submit_resp}`"
-    );
-
-    Ok(block_hash)
-}
-
-fn zero_value(script_pubkey: ScriptBuf) -> TxOut {
-    TxOut {
-        script_pubkey,
-        value: Amount::ZERO,
-    }
-}
-
-/// Block-template fields we read from bitcoind's `getblocktemplate`. The test
-/// talks to bitcoind directly (not via the enforcer's GBT proxy) because the
-/// proxy is disabled in `Mode::NoMempool`.
-#[derive(Deserialize)]
-struct BlockTemplate {
-    previousblockhash: BlockHash,
-    version: i32,
-    #[serde(deserialize_with = "deserialize_bits")]
-    bits: CompactTarget,
-    height: u32,
-    coinbasevalue: u64,
-    mintime: u32,
-    curtime: u32,
-    #[serde(default)]
-    transactions: Vec<serde_json::Value>,
-}
-
-fn deserialize_bits<'de, D: serde::Deserializer<'de>>(de: D) -> Result<CompactTarget, D::Error> {
-    let hex = String::deserialize(de)?;
-    u32::from_str_radix(&hex, 16)
-        .map(CompactTarget::from_consensus)
-        .map_err(serde::de::Error::custom)
+    submit_block_with_coinbase_outputs(post_setup, (case.extra_coinbase_outputs)()?).await
 }

--- a/integration_tests/test_m4_vote_array.rs
+++ b/integration_tests/test_m4_vote_array.rs
@@ -1,0 +1,474 @@
+//! BIP300 M4 vote-array validation, end to end.
+//!
+//! The vote array `A` is indexed against `ASN`, the active sidechain slots
+//! sorted ascending. `A` may cover fewer slots than are active — the trailing
+//! slots it omits abstain — but never more, and it may not omit slots in a
+//! coinbase where an earlier M2 has already grown `ASN`.
+//!
+//! Every case here mines a hand-built coinbase: the block producer only emits
+//! M4s it believes are valid, so the rejected shapes are unreachable through
+//! it, and the accepted ones need vote values the producer would never pick.
+//!
+//! <https://github.com/LayerTwo-Labs/bip300_bip301_specifications/blob/master/bip300.md#m4-ack-bundle>
+
+use std::time::Duration;
+
+use bip300301_enforcer_lib::{
+    messages::{M2AckSidechain, M4AckBundles},
+    proto::{
+        self,
+        mainchain::{
+            BroadcastWithdrawalBundleRequest, GetChainInfoRequest, GetSidechainProposalsRequest,
+            GetSidechainProposalsResponse, GetSidechainsRequest,
+            GetWithdrawalBundleProposalsRequest, GetWithdrawalBundleProposalsResponse,
+            SetAckAllProposalsRequest, SetSidechainAckRequest,
+        },
+    },
+    types::SidechainNumber,
+};
+use bitcoin::{Amount, ScriptBuf, TxOut, Txid, hashes::sha256d};
+
+use crate::{
+    block_verdict::{Expect, assert_enforcer_verdict},
+    custom_coinbase::{submit_block_with_coinbase_outputs, zero_value},
+    integration_test::{activate_sidechain, propose_sidechain, propose_sidechain_for_slot},
+    mine::mine,
+    setup::{DummySidechain, PostSetup},
+    test_blinded_m6_roundtrip::{make_blinded_m6, serialize_zero_input_legacy},
+};
+
+/// The slot [`DummySidechain`] occupies, and the lowest of the three used here.
+const SLOT_LOW: SidechainNumber = SidechainNumber(0);
+/// Activated last, by an M2 in a hand-built coinbase. Sorts *between* the other
+/// two, so activating it shifts `SLOT_HIGH` from index 1 to index 2 — the
+/// misalignment that makes a shortened array ambiguous.
+const SLOT_MID: SidechainNumber = SidechainNumber(1);
+/// Holds a pending bundle, and sits mid-`ASN` once `SLOT_MID` activates.
+const SLOT_HIGH: SidechainNumber = SidechainNumber(5);
+/// Holds a pending bundle, and is the trailing entry of `ASN` throughout.
+///
+/// A fourth slot is what makes the shift `SLOT_MID`'s activation causes
+/// *dangerous* rather than merely wrong: with three slots the only displaced
+/// vote lands on the freshly activated slot, which holds no bundle, so the
+/// pre-existing out-of-range rule rejects the block regardless. Here a
+/// displaced vote can instead land on `SLOT_HIGH`, whose bundle it would
+/// silently upvote.
+const SLOT_EXTRA: SidechainNumber = SidechainNumber(7);
+
+const VERDICT_TIMEOUT: Duration = Duration::from_secs(10);
+
+async fn sidechains_active(post_setup: &mut PostSetup) -> anyhow::Result<usize> {
+    let resp = post_setup
+        .validator_service_client
+        .get_sidechains(GetSidechainsRequest::default())
+        .await?
+        .into_owned();
+    Ok(resp.sidechains.len())
+}
+
+/// The vote count of the only pending withdrawal bundle in `slot`.
+async fn bundle_vote_count(
+    post_setup: &mut PostSetup,
+    slot: SidechainNumber,
+    expected_m6id: Txid,
+) -> anyhow::Result<u32> {
+    let proposals = post_setup
+        .validator_service_client
+        .get_withdrawal_bundle_proposals(GetWithdrawalBundleProposalsRequest {
+            sidechain_id: proto::wrap_u32(slot.0.into()),
+        })
+        .await?
+        .into_owned()
+        .proposals;
+    let [bundle] = proposals.as_slice() else {
+        anyhow::bail!(
+            "expected exactly 1 pending withdrawal bundle in slot {slot}, got {}",
+            proposals.len()
+        )
+    };
+    let m6id: Txid = bundle
+        .m6id
+        .clone()
+        .into_option()
+        .ok_or_else(|| anyhow::anyhow!("withdrawal bundle proposal missing m6id"))?
+        .decode::<GetWithdrawalBundleProposalsResponse, _>("m6id")?;
+    anyhow::ensure!(
+        m6id == expected_m6id,
+        "slot {slot} bundle m6id mismatch: {m6id} != {expected_m6id}"
+    );
+    proto::unwrap_u32(bundle.vote_count.clone())
+        .ok_or_else(|| anyhow::anyhow!("withdrawal bundle proposal missing vote_count"))
+}
+
+/// The pending proposal for `slot`, as `(description hash, ACK count)`.
+async fn proposal_for_slot(
+    post_setup: &mut PostSetup,
+    slot: SidechainNumber,
+) -> anyhow::Result<(sha256d::Hash, u32)> {
+    let proposals = post_setup
+        .validator_service_client
+        .get_sidechain_proposals(GetSidechainProposalsRequest::default())
+        .await?
+        .into_owned()
+        .sidechain_proposals;
+    for proposal in proposals {
+        let number = proto::unwrap_u32(proposal.sidechain_number.clone());
+        if number != Some(slot.0.into()) {
+            continue;
+        }
+        let description_hash: sha256d::Hash = proposal
+            .description_sha256d_hash
+            .clone()
+            .into_option()
+            .ok_or_else(|| anyhow::anyhow!("proposal missing description_sha256d_hash"))?
+            .decode::<GetSidechainProposalsResponse, _>("description_sha256d_hash")?;
+        let vote_count = proto::unwrap_u32(proposal.vote_count.clone())
+            .ok_or_else(|| anyhow::anyhow!("proposal missing vote_count"))?;
+        return Ok((description_hash, vote_count));
+    }
+    anyhow::bail!("no pending sidechain proposal for slot {slot}")
+}
+
+/// Register a withdrawal bundle for `slot` and mine the M3 that proposes it.
+/// Per BIP300 M3 a freshly proposed bundle starts at an ACK score of 1.
+async fn propose_bundle(
+    post_setup: &mut PostSetup,
+    slot: SidechainNumber,
+    payout_sats: u64,
+) -> anyhow::Result<Txid> {
+    let bundle_tx = make_blinded_m6(payout_sats, Amount::from_sat(50_000));
+    let m6id = bundle_tx.compute_txid();
+    let _resp = post_setup
+        .wallet_service_client
+        .broadcast_withdrawal_bundle(BroadcastWithdrawalBundleRequest {
+            sidechain_id: proto::wrap_u32(slot.0.into()),
+            transaction: buffa::MessageField::some(buffa_types::google::protobuf::BytesValue {
+                value: serialize_zero_input_legacy(&bundle_tx),
+                ..Default::default()
+            }),
+        })
+        .await?;
+    let () = mine::<DummySidechain>(post_setup, 1, Some(false)).await?;
+    anyhow::ensure!(
+        bundle_vote_count(post_setup, slot, m6id).await? == 1,
+        "expected the slot {slot} bundle to sit at its initial M3 ACK score of 1"
+    );
+    Ok(m6id)
+}
+
+/// Propose a sidechain for `slot` and register an explicit ACK for it, so that
+/// later blocks keep ACKing it without ack-all — and so without an M4 riding
+/// along and disturbing the bundle vote counts.
+async fn propose_and_ack(
+    post_setup: &mut PostSetup,
+    slot: SidechainNumber,
+) -> anyhow::Result<sha256d::Hash> {
+    let () = propose_sidechain_for_slot::<DummySidechain>(post_setup, slot).await?;
+    let (description_hash, _) = proposal_for_slot(post_setup, slot).await?;
+    let () = post_setup
+        .block_producer_service_client
+        .set_sidechain_ack(SetSidechainAckRequest {
+            sidechain_number: proto::wrap_u32(slot.0.into()),
+            description_sha256d_hash: proto::common::ReverseHex::encode(&description_hash).into(),
+            ack: true,
+        })
+        .await
+        .map(|_| ())?;
+    Ok(description_hash)
+}
+
+/// Mine `slot`'s proposal to exactly one ACK short of activation.
+///
+/// The count is polled rather than computed: how many ACKs the proposal already
+/// carries when it lands depends on the ACK policy in force at propose time.
+async fn mine_to_activation_brink(
+    post_setup: &mut PostSetup,
+    slot: SidechainNumber,
+    threshold: u32,
+) -> anyhow::Result<()> {
+    // Activation needs strictly more ACKs than the threshold, so the brink is
+    // an ACK count of exactly `threshold`.
+    loop {
+        let (_, vote_count) = proposal_for_slot(post_setup, slot).await?;
+        anyhow::ensure!(
+            vote_count <= threshold,
+            "slot {slot} proposal overshot the activation brink: {vote_count} > {threshold}"
+        );
+        if vote_count == threshold {
+            return Ok(());
+        }
+        let () = mine::<DummySidechain>(post_setup, 1, Some(false)).await?;
+    }
+}
+
+/// The three bundles this test votes on, one per slot that holds one.
+#[derive(Clone, Copy)]
+struct Bundles {
+    low: Txid,
+    high: Txid,
+    extra: Txid,
+}
+
+/// Vote counts for all three bundles, as `(low, high, extra)`. Read together so
+/// a case can state the whole expected outcome, including the slots it left
+/// alone, in one assertion.
+async fn counts(post_setup: &mut PostSetup, bundles: Bundles) -> anyhow::Result<(u32, u32, u32)> {
+    Ok((
+        bundle_vote_count(post_setup, SLOT_LOW, bundles.low).await?,
+        bundle_vote_count(post_setup, SLOT_HIGH, bundles.high).await?,
+        bundle_vote_count(post_setup, SLOT_EXTRA, bundles.extra).await?,
+    ))
+}
+
+fn m2_output(slot: SidechainNumber, description_hash: sha256d::Hash) -> anyhow::Result<TxOut> {
+    let script: ScriptBuf = M2AckSidechain {
+        sidechain_number: slot,
+        description_hash,
+    }
+    .try_into()?;
+    Ok(zero_value(script))
+}
+
+fn m4_output(upvotes: Vec<u8>) -> anyhow::Result<TxOut> {
+    let script: ScriptBuf = M4AckBundles::OneByte { upvotes }.try_into()?;
+    Ok(zero_value(script))
+}
+
+pub async fn test_m4_vote_array(mut post_setup: PostSetup) -> anyhow::Result<()> {
+    let constants = post_setup
+        .validator_service_client
+        .get_chain_info(GetChainInfoRequest::default())
+        .await?
+        .into_owned()
+        .bip300_constants
+        .into_option()
+        .ok_or_else(|| anyhow::anyhow!("GetChainInfo returned no bip300_constants"))?;
+    let threshold = constants.unused_sidechain_slot_activation_threshold;
+    // The cases below upvote each bundle twice, on top of its M3 ACK score of
+    // 1. A bundle that crossed the inclusion threshold would have to be paid
+    // out by an M6 in the same block, and this test never deposits, so there
+    // would be no CTIP to spend.
+    anyhow::ensure!(
+        constants.withdrawal_bundle_inclusion_threshold > 3,
+        "regtest inclusion threshold {} leaves no room to vote a bundle up twice",
+        constants.withdrawal_bundle_inclusion_threshold
+    );
+
+    // Three active slots: `SLOT_LOW`, `SLOT_HIGH` and `SLOT_EXTRA`. Everything
+    // that mines with ack-all on happens here, before any bundle exists: with
+    // nothing to vote on, the M4s in these blocks cannot disturb a vote count.
+    let () = propose_sidechain::<DummySidechain>(&mut post_setup).await?;
+    let () = activate_sidechain::<DummySidechain>(&mut post_setup).await?;
+    for (slot, expected_active) in [(SLOT_HIGH, 2), (SLOT_EXTRA, 3)] {
+        tracing::info!("Activating slot {slot}");
+        let () = propose_sidechain_for_slot::<DummySidechain>(&mut post_setup, slot).await?;
+        while sidechains_active(&mut post_setup).await? < expected_active {
+            let () = mine::<DummySidechain>(&mut post_setup, 1, Some(true)).await?;
+        }
+    }
+    // Proposed while that is still true. `propose_sidechain_for_slot` mines
+    // its M1 block with ack-all on, which would otherwise cost each bundle a
+    // vote.
+    let mid_description_hash = propose_and_ack(&mut post_setup, SLOT_MID).await?;
+
+    // From here on every M4 in the chain is one this test hand-builds: with
+    // ack-all off the producer emits no M4 at all, so the bundle vote counts
+    // move only when a case says they should. `SLOT_MID`'s explicit ACK keeps
+    // its M2s coming regardless.
+    let () = post_setup
+        .block_producer_service_client
+        .set_ack_all_proposals(SetAckAllProposalsRequest { ack_all: false })
+        .await
+        .map(|_| ())?;
+
+    tracing::info!("Proposing a withdrawal bundle in each active slot");
+    let low_bundle = propose_bundle(&mut post_setup, SLOT_LOW, 1_000).await?;
+    let high_bundle = propose_bundle(&mut post_setup, SLOT_HIGH, 2_000).await?;
+    let extra_bundle = propose_bundle(&mut post_setup, SLOT_EXTRA, 3_000).await?;
+
+    let () = mine_to_activation_brink(&mut post_setup, SLOT_MID, threshold).await?;
+    anyhow::ensure!(
+        sidechains_active(&mut post_setup).await? == 3,
+        "slot {SLOT_MID} activated before its final ACK"
+    );
+
+    // Counts must be untouched by all of the above: no M4 has been mined since
+    // each bundle's own M3.
+    let bundles = Bundles {
+        low: low_bundle,
+        high: high_bundle,
+        extra: extra_bundle,
+    };
+    anyhow::ensure!(
+        counts(&mut post_setup, bundles).await? == (1, 1, 1),
+        "a bundle gathered votes before the first hand-built M4: {:?}",
+        counts(&mut post_setup, bundles).await?
+    );
+
+    // ── Case A ────────────────────────────────────────────────────────────
+    // `ASN` is [LOW, HIGH, EXTRA]; the M2 in this coinbase activates MID,
+    // making it [LOW, MID, HIGH, EXTRA]. A two-element array sized against the
+    // pre-activation list would put its second vote on MID rather than HIGH.
+    //
+    // MID holds no bundle, so this particular displacement would also be
+    // caught by the out-of-range rule — Case A' is the one that would
+    // otherwise pass silently.
+    tracing::info!("Case A: a shortened M4 in a coinbase that activates a slot");
+    let block_hash = submit_block_with_coinbase_outputs(
+        &post_setup,
+        vec![
+            m2_output(SLOT_MID, mid_description_hash)?,
+            m4_output(vec![0, 0])?,
+        ],
+    )
+    .await?;
+    let () = assert_enforcer_verdict(
+        &mut post_setup,
+        block_hash,
+        Expect::Rejected {
+            log_contains: "an M2 earlier in this coinbase activated a new sidechain slot",
+        },
+        VERDICT_TIMEOUT,
+    )
+    .await?;
+    anyhow::ensure!(
+        sidechains_active(&mut post_setup).await? == 3,
+        "the rejected block's M2 activated a slot anyway"
+    );
+    anyhow::ensure!(
+        counts(&mut post_setup, bundles).await? == (1, 1, 1),
+        "the rejected block's M4 moved bundle vote counts"
+    );
+
+    // ── Case A' ───────────────────────────────────────────────────────────
+    // The displacement rule 4 uniquely prevents. Read against the
+    // pre-activation [LOW, HIGH, EXTRA], this array upvotes LOW, abstains on
+    // HIGH and upvotes EXTRA. Read against the post-activation [LOW, MID,
+    // HIGH, EXTRA], every index past MID slides by one: the abstain lands on
+    // MID and the second upvote lands on HIGH — a real bundle in a sidechain
+    // the miner did not vote for, and no index is out of range, so nothing
+    // else in the validator would object.
+    tracing::info!("Case A': a shortened M4 whose displaced vote would hit a populated slot");
+    let block_hash = submit_block_with_coinbase_outputs(
+        &post_setup,
+        vec![
+            m2_output(SLOT_MID, mid_description_hash)?,
+            m4_output(vec![0, M4AckBundles::ABSTAIN_ONE_BYTE, 0])?,
+        ],
+    )
+    .await?;
+    let () = assert_enforcer_verdict(
+        &mut post_setup,
+        block_hash,
+        Expect::Rejected {
+            log_contains: "an M2 earlier in this coinbase activated a new sidechain slot",
+        },
+        VERDICT_TIMEOUT,
+    )
+    .await?;
+    anyhow::ensure!(
+        counts(&mut post_setup, bundles).await? == (1, 1, 1),
+        "the rejected block's M4 moved bundle vote counts"
+    );
+
+    // ── Case B ────────────────────────────────────────────────────────────
+    // The same coinbase with a vote per active slot is unambiguous, and the
+    // votes must resolve against the *post*-activation list: index 2 is HIGH
+    // and index 3 is EXTRA, with MID — the slot the M2 just activated —
+    // abstaining at index 1.
+    tracing::info!("Case B: a full-length M4 in a coinbase that activates a slot");
+    let block_hash = submit_block_with_coinbase_outputs(
+        &post_setup,
+        vec![
+            m2_output(SLOT_MID, mid_description_hash)?,
+            m4_output(vec![0, M4AckBundles::ABSTAIN_ONE_BYTE, 0, 0])?,
+        ],
+    )
+    .await?;
+    let () = assert_enforcer_verdict(
+        &mut post_setup,
+        block_hash,
+        Expect::Accepted,
+        VERDICT_TIMEOUT,
+    )
+    .await?;
+    anyhow::ensure!(
+        sidechains_active(&mut post_setup).await? == 4,
+        "the M2 did not activate slot {SLOT_MID}"
+    );
+    anyhow::ensure!(
+        counts(&mut post_setup, bundles).await? == (2, 2, 2),
+        "votes did not land one per slot against the post-activation list: {:?}",
+        counts(&mut post_setup, bundles).await?
+    );
+
+    // ── Case C ────────────────────────────────────────────────────────────
+    // `ASN` is now [LOW, MID, HIGH, EXTRA] and stays that way. A one-element
+    // array omits three slots, two of which hold real pending bundles, so an
+    // omitted slot has to *abstain* rather than merely have nothing to vote
+    // on. No M2 here, so nothing has grown `ASN` within the block.
+    tracing::info!("Case C: a shortened M4 omitting slots that hold pending bundles");
+    let block_hash =
+        submit_block_with_coinbase_outputs(&post_setup, vec![m4_output(vec![0])?]).await?;
+    let () = assert_enforcer_verdict(
+        &mut post_setup,
+        block_hash,
+        Expect::Accepted,
+        VERDICT_TIMEOUT,
+    )
+    .await?;
+    anyhow::ensure!(
+        counts(&mut post_setup, bundles).await? == (3, 2, 2),
+        "the omitted trailing slots did not abstain: {:?}",
+        counts(&mut post_setup, bundles).await?
+    );
+
+    // ── Case D ────────────────────────────────────────────────────────────
+    // An abstain that is not trailing still has to hold its index, or the vote
+    // after it lands on the wrong slot. Only `EXTRA` is omitted here.
+    tracing::info!("Case D: abstains ahead of a vote hold their slots' indices");
+    let block_hash = submit_block_with_coinbase_outputs(
+        &post_setup,
+        vec![m4_output(vec![
+            M4AckBundles::ABSTAIN_ONE_BYTE,
+            M4AckBundles::ABSTAIN_ONE_BYTE,
+            0,
+        ])?],
+    )
+    .await?;
+    let () = assert_enforcer_verdict(
+        &mut post_setup,
+        block_hash,
+        Expect::Accepted,
+        VERDICT_TIMEOUT,
+    )
+    .await?;
+    anyhow::ensure!(
+        counts(&mut post_setup, bundles).await? == (3, 3, 2),
+        "the vote at index 2 did not land on slot {SLOT_HIGH} alone: {:?}",
+        counts(&mut post_setup, bundles).await?
+    );
+
+    // ── Case E ────────────────────────────────────────────────────────────
+    // More votes than active slots sets votes in slots that are not active.
+    tracing::info!("Case E: an M4 with more votes than there are active slots");
+    let block_hash =
+        submit_block_with_coinbase_outputs(&post_setup, vec![m4_output(vec![0, 0, 0, 0, 0])?])
+            .await?;
+    let () = assert_enforcer_verdict(
+        &mut post_setup,
+        block_hash,
+        Expect::Rejected {
+            log_contains: "Invalid votes: expected at most",
+        },
+        VERDICT_TIMEOUT,
+    )
+    .await?;
+    anyhow::ensure!(
+        counts(&mut post_setup, bundles).await? == (3, 3, 2),
+        "the rejected over-long M4 moved bundle vote counts"
+    );
+
+    drop(post_setup);
+    Ok(())
+}

--- a/integration_tests/test_sidechain_ack_policy.rs
+++ b/integration_tests/test_sidechain_ack_policy.rs
@@ -367,20 +367,21 @@ pub async fn test_sidechain_ack_policy(mut post_setup: PostSetup) -> anyhow::Res
         "the bundle gathered a vote from a block that carries no M4"
     );
 
-    // With both slots active, the M4 carries a vote per active slot, ordered
-    // by slot number: the bundle's slot first, then the freshly activated one,
-    // which has no pending bundle to vote on.
-    tracing::info!("Mining with both slots active: the M4 must cover both, in slot order");
+    // With both slots active, the freshly activated slot sorts *after* the
+    // bundle's slot and has no pending bundle of its own, so it is a trailing
+    // abstain and the producer omits it. This is the shortened-array case:
+    // a one-element M4 against a two-slot active list, which the validator
+    // must resolve to the bundle's slot with the omitted slot abstaining.
+    tracing::info!("Mining with both slots active: the M4 must omit the trailing abstain");
     let () = mine::<DummySidechain>(&mut post_setup, 1, Some(true)).await?;
     let coinbase_messages = tip_coinbase_messages(&mut post_setup).await?;
     anyhow::ensure!(
         coinbase_messages.iter().any(|message| matches!(
             message,
             CoinbaseMessage::M4AckBundles(M4AckBundles::OneByte { upvotes })
-                if upvotes.as_slice() == [0u8, M4AckBundles::ABSTAIN_ONE_BYTE].as_slice()
+                if upvotes.as_slice() == [0u8].as_slice()
         )),
-        "expected an M4 with one vote per active slot, upvoting only the bundle's slot: \
-         `{coinbase_messages:?}`"
+        "expected a shortened M4 covering only the bundle's slot: `{coinbase_messages:?}`"
     );
     // Had the votes been shifted by the activation, the upvote at index 0
     // would have landed on the newly activated slot instead.

--- a/integration_tests/test_sidechain_ack_policy.rs
+++ b/integration_tests/test_sidechain_ack_policy.rs
@@ -300,6 +300,94 @@ pub async fn test_sidechain_ack_policy(mut post_setup: PostSetup) -> anyhow::Res
         proto::unwrap_u32(other_slot_proposal.vote_count.clone()) == Some(1),
         "the other slot's proposal was not ACKed: `{other_slot_proposal:?}`"
     );
+    let other_slot_description_hash = other_slot_proposal.description_sha256d_hash.clone();
+
+    // The converse case: a block whose M2 *does* activate a new slot. The
+    // active-slot list an M4 is indexed against grows within that block, so
+    // the producer must omit the M4, and the votes in the following block must
+    // land on the same sidechains the validator resolves them to.
+
+    // Drive the other slot's proposal to one ACK short of activation with
+    // ack-all off, so the M2s keep coming from the explicit ACK while no M4 is
+    // emitted. Leaving the M4 off here also keeps the bundle below the
+    // inclusion threshold: this test never deposits, so an approved bundle
+    // would have no CTIP to spend.
+    let () = post_setup
+        .block_producer_service_client
+        .set_ack_all_proposals(SetAckAllProposalsRequest { ack_all: false })
+        .await
+        .map(|_| ())?;
+    let () = post_setup
+        .block_producer_service_client
+        .set_sidechain_ack(SetSidechainAckRequest {
+            sidechain_number: proto::wrap_u32(OTHER_SLOT.0.into()),
+            description_sha256d_hash: other_slot_description_hash,
+            ack: true,
+        })
+        .await
+        .map(|_| ())?;
+    tracing::info!("Mining the other slot's proposal to one ACK short of activation");
+    let () = mine::<DummySidechain>(&mut post_setup, blocks_to_activate - 2, Some(false)).await?;
+    anyhow::ensure!(
+        sidechains_active(&mut post_setup).await? == 1,
+        "the other slot activated before its final ACK"
+    );
+    anyhow::ensure!(
+        bundle_vote_count(&mut post_setup, bundle_m6id).await? == 2,
+        "the bundle gathered votes from blocks that carry no M4"
+    );
+
+    let () = post_setup
+        .block_producer_service_client
+        .set_ack_all_proposals(SetAckAllProposalsRequest { ack_all: true })
+        .await
+        .map(|_| ())?;
+    tracing::info!("Mining the activating block: its M2 grows the active set, so it carries no M4");
+    let () = mine::<DummySidechain>(&mut post_setup, 1, Some(true)).await?;
+    anyhow::ensure!(
+        sidechains_active(&mut post_setup).await? == 2,
+        "the other slot did not activate on its final ACK"
+    );
+    let coinbase_messages = tip_coinbase_messages(&mut post_setup).await?;
+    anyhow::ensure!(
+        coinbase_messages.iter().any(|message| matches!(
+            message,
+            CoinbaseMessage::M2AckSidechain(m2) if m2.sidechain_number == OTHER_SLOT
+        )),
+        "expected the activating M2 for slot {OTHER_SLOT} in the coinbase"
+    );
+    anyhow::ensure!(
+        !coinbase_messages
+            .iter()
+            .any(|message| matches!(message, CoinbaseMessage::M4AckBundles(_))),
+        "expected no M4 in a coinbase whose M2 activates a new slot"
+    );
+    anyhow::ensure!(
+        bundle_vote_count(&mut post_setup, bundle_m6id).await? == 2,
+        "the bundle gathered a vote from a block that carries no M4"
+    );
+
+    // With both slots active, the M4 carries a vote per active slot, ordered
+    // by slot number: the bundle's slot first, then the freshly activated one,
+    // which has no pending bundle to vote on.
+    tracing::info!("Mining with both slots active: the M4 must cover both, in slot order");
+    let () = mine::<DummySidechain>(&mut post_setup, 1, Some(true)).await?;
+    let coinbase_messages = tip_coinbase_messages(&mut post_setup).await?;
+    anyhow::ensure!(
+        coinbase_messages.iter().any(|message| matches!(
+            message,
+            CoinbaseMessage::M4AckBundles(M4AckBundles::OneByte { upvotes })
+                if upvotes.as_slice() == [0u8, M4AckBundles::ABSTAIN_ONE_BYTE].as_slice()
+        )),
+        "expected an M4 with one vote per active slot, upvoting only the bundle's slot: \
+         `{coinbase_messages:?}`"
+    );
+    // Had the votes been shifted by the activation, the upvote at index 0
+    // would have landed on the newly activated slot instead.
+    anyhow::ensure!(
+        bundle_vote_count(&mut post_setup, bundle_m6id).await? == 3,
+        "the bundle did not gather the vote at its own index"
+    );
 
     drop(post_setup);
     Ok(())

--- a/lib/block_producer/coinbase.rs
+++ b/lib/block_producer/coinbase.rs
@@ -300,7 +300,7 @@ impl BlockProducer {
                 next_height,
             )?
         {
-            let upvotes = active_sidechains
+            let mut upvotes = active_sidechains
                 .iter()
                 .map(|sidechain| {
                     if self
@@ -313,7 +313,18 @@ impl BlockProducer {
                         Ok(0)
                     }
                 })
-                .collect::<Result<_, crate::validator::GetPendingWithdrawalsError>>()?;
+                .collect::<Result<Vec<u8>, crate::validator::GetPendingWithdrawalsError>>()?;
+            // BIP300 M4: a vote array may cover fewer slots than are active,
+            // and the trailing slots it omits abstain implicitly. Dropping the
+            // trailing abstains saves a byte per slot, and keeps the shortened
+            // array on the path our own blocks take through validation rather
+            // than only in tests.
+            //
+            // Only *trailing* abstains can go: an abstain with any later vote
+            // after it still has to hold that later vote's index in place.
+            while upvotes.last() == Some(&M4AckBundles::ABSTAIN_ONE_BYTE) {
+                upvotes.pop();
+            }
             coinbase_builder.ack_bundles(M4AckBundles::OneByte { upvotes })?;
         }
         let () = coinbase_builder.build()?;

--- a/lib/validator/task/error.rs
+++ b/lib/validator/task/error.rs
@@ -106,9 +106,21 @@ pub(in crate::validator) enum HandleM4Votes {
     #[error(transparent)]
     #[fatal(true)]
     Db(Box<db::Error>),
-    #[error("Invalid votes: expected {expected}, but found {len}")]
+    #[error("Invalid votes: expected at most {active_sidechains}, but found {len}")]
     #[fatal(false)]
-    InvalidVotes { expected: usize, len: usize },
+    TooManyVotes {
+        active_sidechains: usize,
+        len: usize,
+    },
+    #[error(
+        "Invalid votes: found {len} for {active_sidechains} active sidechains, but an M2 earlier in this coinbase activated a new sidechain slot. \
+         A vote array that omits trailing slots is ambiguous once the active-slot list has grown within the block"
+    )]
+    #[fatal(false)]
+    ShortVotesAfterSlotActivation {
+        active_sidechains: usize,
+        len: usize,
+    },
     #[error(
         "No pending withdrawal for sidechain `{}` at index `{}`",
         .sidechain_number,

--- a/lib/validator/task/mod.rs
+++ b/lib/validator/task/mod.rs
@@ -368,17 +368,39 @@ impl BlockHandler<'_> {
     /// Core M4 upvote resolver: for each active sidechain, interprets the vote
     /// value (index into pending bundles, ABSTAIN `0xFFFF`, or ALARM `0xFFFE`).
     ///
+    /// The vote array may cover fewer slots than are active. The trailing
+    /// slots it omits abstain implicitly. Only an array longer than the
+    /// active-slot list is invalid.
+    ///
+    /// `slot_activated` reports whether an M2 earlier in the same coinbase
+    /// already activated a previously unused slot — see
+    /// [`error::HandleM4Votes::ShortVotesAfterSlotActivation`].
+    ///
     /// <https://github.com/LayerTwo-Labs/bip300_bip301_specifications/blob/master/bip300.md#m4-ack-bundle>
     fn handle_m4_votes(
         &self,
         rotxn: &RoTxn,
         upvotes: &[u16],
+        slot_activated: bool,
     ) -> Result<diff::AckBundles, error::HandleM4Votes> {
         let dbs = self.dbs;
         let active_sidechains = dbs.active_sidechains.numbers(rotxn)?;
-        if upvotes.len() != active_sidechains.len() {
-            return Err(error::HandleM4Votes::InvalidVotes {
-                expected: active_sidechains.len(),
+        if upvotes.len() > active_sidechains.len() {
+            return Err(error::HandleM4Votes::TooManyVotes {
+                active_sidechains: active_sidechains.len(),
+                len: upvotes.len(),
+            });
+        }
+        // `active_sidechains` is ordered by slot number, and an activation
+        // earlier in this coinbase inserts the new slot at its numeric
+        // position -- ahead of every higher-numbered slot. Truncation is only
+        // meaningful relative to a known list, so a short array here cannot be
+        // told apart from one the miner sized against the pre-activation list,
+        // whose votes would then land on the wrong sidechains. Require a vote
+        // per active slot instead, which is unambiguous either way.
+        if slot_activated && upvotes.len() != active_sidechains.len() {
+            return Err(error::HandleM4Votes::ShortVotesAfterSlotActivation {
+                active_sidechains: active_sidechains.len(),
                 len: upvotes.len(),
             });
         }
@@ -555,12 +577,17 @@ impl BlockHandler<'_> {
     /// OneByte (0x01), TwoBytes (0x02), LeadingBy50 (0x03), RepeatPrevious
     /// (0x00).
     ///
+    /// `slot_activated` is forwarded to [`Self::handle_m4_votes`]; the
+    /// versions that carry no vote array derive their targets from the active
+    /// set directly, so it does not apply to them.
+    ///
     /// <https://github.com/LayerTwo-Labs/bip300_bip301_specifications/blob/master/bip300.md#m4-ack-bundle>
     fn handle_m4_ack_bundles(
         &self,
         rotxn: &RoTxn,
         prev_block_hash: BlockHash,
         m4: &M4AckBundles,
+        slot_activated: bool,
     ) -> Result<diff::AckBundles, error::HandleM4AckBundles> {
         match m4 {
             M4AckBundles::LeadingBy50 => self
@@ -576,7 +603,7 @@ impl BlockHandler<'_> {
                         vote => vote as u16,
                     })
                     .collect();
-                self.handle_m4_votes(rotxn, &upvotes)
+                self.handle_m4_votes(rotxn, &upvotes, slot_activated)
                     .map_err(error::HandleM4AckBundles::from)
             }
             M4AckBundles::TwoBytes { upvotes } => {
@@ -585,7 +612,7 @@ impl BlockHandler<'_> {
                 if upvotes.iter().all(|v| *v <= 253) {
                     return Err(error::HandleM4AckBundles::TwoBytesWithinByteRange);
                 }
-                self.handle_m4_votes(rotxn, upvotes)
+                self.handle_m4_votes(rotxn, upvotes, slot_activated)
                     .map_err(error::HandleM4AckBundles::from)
             }
         }
@@ -871,6 +898,10 @@ impl BlockHandler<'_> {
     /// Dispatches a single coinbase OP_RETURN message to its handler. M1/M2/M3/M4
     /// are BIP 300; M7 is BIP 301.
     ///
+    /// `slot_activated` reports whether an earlier message in this same
+    /// coinbase activated a previously unused sidechain slot; only the M4
+    /// handler needs it.
+    ///
     /// <https://github.com/LayerTwo-Labs/bip300_bip301_specifications/blob/master/bip300.md>
     /// <https://github.com/LayerTwo-Labs/bip300_bip301_specifications/blob/master/bip301.md#m7-bmm-accept>
     #[expect(clippy::result_large_err)]
@@ -881,6 +912,7 @@ impl BlockHandler<'_> {
         prev_block_hash: BlockHash,
         accepted_bmm_requests: &mut BmmCommitments,
         message: CoinbaseMessage,
+        slot_activated: bool,
     ) -> Result<(Option<CoinbaseMessageEvent>, Option<diff::CoinbaseMsg>), error::ConnectBlock>
     {
         match message {
@@ -935,7 +967,8 @@ impl BlockHandler<'_> {
                 Ok((Some(event), Some(diff::CoinbaseMsg::ProposeBundle(diff))))
             }
             CoinbaseMessage::M4AckBundles(m4) => {
-                let diff = self.handle_m4_ack_bundles(rotxn, prev_block_hash, &m4)?;
+                let diff =
+                    self.handle_m4_ack_bundles(rotxn, prev_block_hash, &m4, slot_activated)?;
                 let diff = if diff.0.is_empty() {
                     None
                 } else {
@@ -1135,6 +1168,11 @@ impl BlockHandler<'_> {
         let mut events = Vec::<BlockEvent>::new();
         let mut coinbase_msg_diffs = diff::DiffBuilder::new(rwtxn, dbs, height);
         let m4_exists = coinbase_messages.m4_exists();
+        // Whether an M2 already handled in this coinbase activated a
+        // previously unused slot, growing the active-slot list the M4 is
+        // indexed against. Diffs are applied message by message, so only the
+        // messages before the M4 can have moved it.
+        let mut slot_activated = false;
         for (message, _vout) in coinbase_messages {
             let (event, diff) = coinbase_msg_diffs.rotxn(|rotxn, _dbs| {
                 self.handle_coinbase_message(
@@ -1143,6 +1181,7 @@ impl BlockHandler<'_> {
                     parent,
                     &mut accepted_bmm_requests,
                     message,
+                    slot_activated,
                 )
             })?;
             match event {
@@ -1162,6 +1201,14 @@ impl BlockHandler<'_> {
                 None => (),
             };
             if let Some(diff) = diff {
+                if let diff::CoinbaseMsg::AckSidechainProposal(ack) = &diff
+                    && matches!(
+                        ack.effect,
+                        diff::ack_sidechain_proposal::Effect::SlotActivation
+                    )
+                {
+                    slot_activated = true;
+                }
                 let () = coinbase_msg_diffs.apply(diff)?;
             }
         }
@@ -1171,7 +1218,7 @@ impl BlockHandler<'_> {
                 let upvotes =
                     vec![M4AckBundles::ABSTAIN_ONE_BYTE; active_sidechains_count as usize];
                 let m4 = M4AckBundles::OneByte { upvotes };
-                let diff = self.handle_m4_ack_bundles(rotxn, parent, &m4)?;
+                let diff = self.handle_m4_ack_bundles(rotxn, parent, &m4, slot_activated)?;
                 Ok::<_, error::ConnectBlock>(diff)
             })?;
             if !diff.0.is_empty() {
@@ -3408,7 +3455,7 @@ mod tests {
             .into_diagnostic()?;
 
         let diff = test_handler(&dbs)
-            .handle_m4_votes(&rwtxn, &[M4AckBundles::ABSTAIN_TWO_BYTES])
+            .handle_m4_votes(&rwtxn, &[M4AckBundles::ABSTAIN_TWO_BYTES], false)
             .into_diagnostic()?;
         assert!(diff.0.is_empty());
 
@@ -3417,9 +3464,28 @@ mod tests {
             .put_pending_m6id(&mut rwtxn, &sc, m6id, 0)
             .into_diagnostic()?;
         let diff = test_handler(&dbs)
-            .handle_m4_votes(&rwtxn, &[0])
+            .handle_m4_votes(&rwtxn, &[0], false)
             .into_diagnostic()?;
         assert!(diff.0.contains_key(&sc));
+
+        // BIP 300 permits the vote array to omit trailing active slots; those
+        // slots abstain implicitly. The same one-element array now covers only
+        // the first of two active slots.
+        let trailing = SidechainNumber(2);
+        dbs.active_sidechains
+            .put_sidechain(&mut rwtxn, &trailing, &test_sidechain(trailing.0, 0))
+            .into_diagnostic()?;
+        dbs.active_sidechains
+            .put_pending_m6id(&mut rwtxn, &trailing, test_m6id(0xBB), 0)
+            .into_diagnostic()?;
+        let diff = test_handler(&dbs)
+            .handle_m4_votes(&rwtxn, &[0], false)
+            .into_diagnostic()?;
+        assert!(diff.0.contains_key(&sc));
+        assert!(
+            !diff.0.contains_key(&trailing),
+            "an omitted trailing slot must abstain, not receive a vote"
+        );
         Ok(())
     }
 
@@ -3445,7 +3511,7 @@ mod tests {
             .into_diagnostic()?;
 
         let diff = test_handler(&dbs)
-            .handle_m4_votes(&rwtxn, &[M4AckBundles::ALARM_TWO_BYTES])
+            .handle_m4_votes(&rwtxn, &[M4AckBundles::ALARM_TWO_BYTES], false)
             .into_diagnostic()?;
         assert!(diff.0.contains_key(&sc));
         Ok(())
@@ -3461,20 +3527,195 @@ mod tests {
             .into_diagnostic()?;
 
         let err = test_handler(&dbs)
-            .handle_m4_votes(&rwtxn, &[0, 0])
-            .expect_err("wrong vote count must error");
+            .handle_m4_votes(&rwtxn, &[0, 0], false)
+            .expect_err("more votes than active sidechains must error");
         assert!(matches!(
             err,
-            error::HandleM4Votes::InvalidVotes {
-                expected: 1,
+            error::HandleM4Votes::TooManyVotes {
+                active_sidechains: 1,
                 len: 2
             }
         ));
 
         let err = test_handler(&dbs)
-            .handle_m4_votes(&rwtxn, &[0])
+            .handle_m4_votes(&rwtxn, &[0], false)
             .expect_err("upvote with no pending must error");
         assert!(matches!(err, error::HandleM4Votes::UpvoteFailed { .. }));
+        Ok(())
+    }
+
+    /// Omitting trailing slots is only unambiguous while the active-slot list
+    /// is the one the miner sized the M4 against. Once an M2 in the same
+    /// coinbase has activated a slot, a short array must be rejected rather
+    /// than silently reinterpreted against the grown list.
+    #[test]
+    fn handle_m4_votes_rejects_short_array_after_slot_activation() -> Result<()> {
+        let (_dir, dbs) = create_test_dbs()?;
+        let mut rwtxn = dbs.write_txn().into_diagnostic()?;
+        let activated = SidechainNumber(1);
+        let sc = SidechainNumber(2);
+        for sidechain_number in [activated, sc] {
+            dbs.active_sidechains
+                .put_sidechain(
+                    &mut rwtxn,
+                    &sidechain_number,
+                    &test_sidechain(sidechain_number.0, 0),
+                )
+                .into_diagnostic()?;
+        }
+        dbs.active_sidechains
+            .put_pending_m6id(&mut rwtxn, &sc, test_m6id(0xAA), 0)
+            .into_diagnostic()?;
+
+        let err = test_handler(&dbs)
+            .handle_m4_votes(&rwtxn, &[0], true)
+            .expect_err("a short vote array after a slot activation must error");
+        assert!(matches!(
+            err,
+            error::HandleM4Votes::ShortVotesAfterSlotActivation {
+                active_sidechains: 2,
+                len: 1
+            }
+        ));
+        assert!(!err.is_fatal());
+
+        // A vote per active slot is unambiguous, and still accepted.
+        let diff = test_handler(&dbs)
+            .handle_m4_votes(&rwtxn, &[M4AckBundles::ABSTAIN_TWO_BYTES, 0], true)
+            .into_diagnostic()?;
+        assert!(diff.0.contains_key(&sc));
+        assert!(!diff.0.contains_key(&activated));
+        Ok(())
+    }
+
+    /// Slot `5` active and holding a pending bundle, plus a proposal for the
+    /// lower slot `1` that is one ack short of activating. The returned block
+    /// carries that ack ahead of an M4 with `upvotes`, so the activation is
+    /// applied before the votes are resolved and the active-slot list the M4
+    /// indexes into grows a new *first* entry.
+    fn build_slot_activation_m4_block(
+        dbs: &Dbs,
+        rwtxn: &mut RwTxn,
+        height: u32,
+        upvotes: Vec<u8>,
+    ) -> Result<Block> {
+        let active = SidechainNumber(5);
+        dbs.active_sidechains
+            .put_sidechain(rwtxn, &active, &test_sidechain(active.0, 0))
+            .into_diagnostic()?;
+        dbs.active_sidechains
+            .put_pending_m6id(rwtxn, &active, test_m6id(0xAA), 0)
+            .into_diagnostic()?;
+
+        let mut proposal = test_sidechain(1, 0);
+        proposal.status.vote_count = NetworkParams::for_network(bitcoin::Network::Regtest)
+            .thresholds
+            .unused_sidechain_slot_activation_threshold;
+        let proposal_id = proposal.proposal.compute_id();
+        dbs.proposal_id_to_sidechain
+            .put(rwtxn, &proposal_id, &proposal)
+            .into_diagnostic()?;
+
+        let m2_script: ScriptBuf = M2AckSidechain {
+            sidechain_number: proposal_id.sidechain_number,
+            description_hash: proposal_id.description_hash,
+        }
+        .try_into()
+        .into_diagnostic()?;
+        let m4_script: ScriptBuf = M4AckBundles::OneByte { upvotes }
+            .try_into()
+            .into_diagnostic()?;
+        let block = build_test_block(
+            BlockHash::all_zeros(),
+            TestBlockParts {
+                extra_coinbase_outputs: vec![
+                    TxOut {
+                        script_pubkey: m2_script,
+                        value: Amount::ZERO,
+                    },
+                    TxOut {
+                        script_pubkey: m4_script,
+                        value: Amount::ZERO,
+                    },
+                ],
+                ..Default::default()
+            },
+        );
+        dbs.block_hashes
+            .put_headers(rwtxn, &[(block.header, height)])
+            .into_diagnostic()?;
+        Ok(block)
+    }
+
+    /// BIP 300 M4: a shortened vote array in a coinbase that activates a
+    /// lower-numbered slot must invalidate the block. The activation inserts
+    /// that slot ahead of every higher-numbered one, so votes the miner sized
+    /// against the pre-activation list would land on the wrong sidechains.
+    #[test]
+    fn connect_block_rejects_short_m4_after_same_block_slot_activation() -> Result<()> {
+        let (_dir, dbs) = create_test_dbs()?;
+        let mut rwtxn = dbs.write_txn().into_diagnostic()?;
+        // One vote for what will be two active sidechains by the time the M4
+        // is handled.
+        let block = build_slot_activation_m4_block(&dbs, &mut rwtxn, 1, vec![0])?;
+
+        let err = test_handler(&dbs)
+            .connect_block(&mut rwtxn, &block)
+            .expect_err("a short M4 in a block that activates a slot must be rejected");
+        assert!(matches!(
+            err,
+            error::ConnectBlock::M4AckBundles(error::HandleM4AckBundles::Votes(
+                error::HandleM4Votes::ShortVotesAfterSlotActivation {
+                    active_sidechains: 2,
+                    len: 1
+                }
+            ))
+        ));
+        assert!(!err.is_fatal());
+        Ok(())
+    }
+
+    /// The same coinbase with a vote per active slot is accepted, and the
+    /// votes are not shifted: index 1 is the pre-existing slot `5`, not the
+    /// slot `1` the M2 just activated.
+    #[test]
+    fn connect_block_accepts_full_m4_after_same_block_slot_activation() -> Result<()> {
+        let (_dir, dbs) = create_test_dbs()?;
+        let mut rwtxn = dbs.write_txn().into_diagnostic()?;
+        let block = build_slot_activation_m4_block(
+            &dbs,
+            &mut rwtxn,
+            1,
+            vec![M4AckBundles::ABSTAIN_ONE_BYTE, 0],
+        )?;
+
+        let _event = test_handler(&dbs)
+            .connect_block(&mut rwtxn, &block)
+            .into_diagnostic()?;
+
+        let active_sidechains = dbs
+            .active_sidechains
+            .numbers(&rwtxn)
+            .into_diagnostic()
+            .map_err(|err| miette::miette!("{err}"))?;
+        assert_eq!(
+            active_sidechains,
+            vec![SidechainNumber(1), SidechainNumber(5)],
+            "the M2 must have activated the lower slot ahead of the existing one"
+        );
+        let pending = dbs
+            .active_sidechains
+            .pending_m6ids()
+            .get(&rwtxn, &SidechainNumber(5))
+            .into_diagnostic()?;
+        // Initial M3 ACK score of 1, plus the upvote at index 1. Had the votes
+        // been resolved against the pre-activation list, index 0's abstain
+        // would have covered slot 5 and left the count at 1.
+        assert_eq!(
+            pending[&test_m6id(0xAA)].vote_count,
+            2,
+            "the vote at index 1 must land on slot 5's bundle"
+        );
         Ok(())
     }
 
@@ -3505,7 +3746,7 @@ mod tests {
         // Upvote target (index 0). Spec: target +1; other_positive -1;
         // other_zero unchanged (saturating at 0).
         let diff = test_handler(&dbs)
-            .handle_m4_votes(&rwtxn, &[0])
+            .handle_m4_votes(&rwtxn, &[0], false)
             .into_diagnostic()?;
         let Some(diff::AckBundleAction::Upvote {
             m6id,
@@ -3559,7 +3800,7 @@ mod tests {
         // The single vote fits in one byte (≤ 253), so TwoBytes is wasteful.
         let m4 = M4AckBundles::TwoBytes { upvotes: vec![253] };
         let err = test_handler(&dbs)
-            .handle_m4_ack_bundles(&rwtxn, BlockHash::all_zeros(), &m4)
+            .handle_m4_ack_bundles(&rwtxn, BlockHash::all_zeros(), &m4, false)
             .expect_err("TwoBytes with all elements ≤ 253 must be rejected");
         assert!(matches!(
             err,
@@ -3587,7 +3828,7 @@ mod tests {
             upvotes: vec![M4AckBundles::ALARM_TWO_BYTES],
         };
         let _diff = test_handler(&dbs)
-            .handle_m4_ack_bundles(&rwtxn, BlockHash::all_zeros(), &m4)
+            .handle_m4_ack_bundles(&rwtxn, BlockHash::all_zeros(), &m4, false)
             .into_diagnostic()?;
         Ok(())
     }
@@ -3627,14 +3868,24 @@ mod tests {
         set_vote_count(&mut rwtxn, &dbs, &sc, leader, 60);
         set_vote_count(&mut rwtxn, &dbs, &sc, rival, 11);
         let diff = test_handler(&dbs)
-            .handle_m4_ack_bundles(&rwtxn, BlockHash::all_zeros(), &M4AckBundles::LeadingBy50)
+            .handle_m4_ack_bundles(
+                &rwtxn,
+                BlockHash::all_zeros(),
+                &M4AckBundles::LeadingBy50,
+                false,
+            )
             .into_diagnostic()?;
         assert!(diff.0.is_empty(), "lead of 49 should not trigger upvote");
 
         // Lead of exactly 50 → upvote leader
         set_vote_count(&mut rwtxn, &dbs, &sc, rival, 10);
         let diff = test_handler(&dbs)
-            .handle_m4_ack_bundles(&rwtxn, BlockHash::all_zeros(), &M4AckBundles::LeadingBy50)
+            .handle_m4_ack_bundles(
+                &rwtxn,
+                BlockHash::all_zeros(),
+                &M4AckBundles::LeadingBy50,
+                false,
+            )
             .into_diagnostic()?;
         assert!(matches!(
             diff.0.get(&sc),
@@ -3645,7 +3896,12 @@ mod tests {
         set_vote_count(&mut rwtxn, &dbs, &sc, leader, 100);
         set_vote_count(&mut rwtxn, &dbs, &sc, rival, 100);
         let diff = test_handler(&dbs)
-            .handle_m4_ack_bundles(&rwtxn, BlockHash::all_zeros(), &M4AckBundles::LeadingBy50)
+            .handle_m4_ack_bundles(
+                &rwtxn,
+                BlockHash::all_zeros(),
+                &M4AckBundles::LeadingBy50,
+                false,
+            )
             .into_diagnostic()?;
         assert!(diff.0.is_empty(), "ties should not trigger upvote");
         Ok(())
@@ -3667,14 +3923,24 @@ mod tests {
         // vote_count 49, no rival → lead = 49 (vs implicit 0) → no upvote
         set_vote_count(&mut rwtxn, &dbs, &sc, m6id, 49);
         let diff = test_handler(&dbs)
-            .handle_m4_ack_bundles(&rwtxn, BlockHash::all_zeros(), &M4AckBundles::LeadingBy50)
+            .handle_m4_ack_bundles(
+                &rwtxn,
+                BlockHash::all_zeros(),
+                &M4AckBundles::LeadingBy50,
+                false,
+            )
             .into_diagnostic()?;
         assert!(diff.0.is_empty());
 
         // vote_count 50 → lead = 50 → upvote
         set_vote_count(&mut rwtxn, &dbs, &sc, m6id, 50);
         let diff = test_handler(&dbs)
-            .handle_m4_ack_bundles(&rwtxn, BlockHash::all_zeros(), &M4AckBundles::LeadingBy50)
+            .handle_m4_ack_bundles(
+                &rwtxn,
+                BlockHash::all_zeros(),
+                &M4AckBundles::LeadingBy50,
+                false,
+            )
             .into_diagnostic()?;
         assert!(matches!(
             diff.0.get(&sc),
@@ -3690,7 +3956,12 @@ mod tests {
 
         // No sidechains → empty diff
         let diff = test_handler(&dbs)
-            .handle_m4_ack_bundles(&rwtxn, BlockHash::all_zeros(), &M4AckBundles::LeadingBy50)
+            .handle_m4_ack_bundles(
+                &rwtxn,
+                BlockHash::all_zeros(),
+                &M4AckBundles::LeadingBy50,
+                false,
+            )
             .into_diagnostic()?;
         assert!(diff.0.is_empty());
 
@@ -3700,7 +3971,12 @@ mod tests {
             .put_sidechain(&mut rwtxn, &sc, &test_sidechain(1, 0))
             .into_diagnostic()?;
         let diff = test_handler(&dbs)
-            .handle_m4_ack_bundles(&rwtxn, BlockHash::all_zeros(), &M4AckBundles::LeadingBy50)
+            .handle_m4_ack_bundles(
+                &rwtxn,
+                BlockHash::all_zeros(),
+                &M4AckBundles::LeadingBy50,
+                false,
+            )
             .into_diagnostic()?;
         assert!(diff.0.is_empty());
         Ok(())
@@ -3722,7 +3998,12 @@ mod tests {
 
         // Leader already at u16::MAX → no further upvote
         let diff = test_handler(&dbs)
-            .handle_m4_ack_bundles(&rwtxn, BlockHash::all_zeros(), &M4AckBundles::LeadingBy50)
+            .handle_m4_ack_bundles(
+                &rwtxn,
+                BlockHash::all_zeros(),
+                &M4AckBundles::LeadingBy50,
+                false,
+            )
             .into_diagnostic()?;
         assert!(diff.0.is_empty());
         Ok(())
@@ -3793,7 +4074,7 @@ mod tests {
         let prev_hash = store_block_diff(&mut rwtxn, &dbs, BlockHash::all_zeros(), Some(prior));
 
         let diff = test_handler(&dbs)
-            .handle_m4_ack_bundles(&rwtxn, prev_hash, &M4AckBundles::RepeatPrevious)
+            .handle_m4_ack_bundles(&rwtxn, prev_hash, &M4AckBundles::RepeatPrevious, false)
             .into_diagnostic()?;
         assert!(matches!(
             diff.0.get(&sc),
@@ -3811,7 +4092,7 @@ mod tests {
         let prev_hash = store_block_diff(&mut rwtxn, &dbs, BlockHash::all_zeros(), None);
 
         let diff = test_handler(&dbs)
-            .handle_m4_ack_bundles(&rwtxn, prev_hash, &M4AckBundles::RepeatPrevious)
+            .handle_m4_ack_bundles(&rwtxn, prev_hash, &M4AckBundles::RepeatPrevious, false)
             .into_diagnostic()?;
         assert!(
             diff.0.is_empty(),
@@ -3846,7 +4127,7 @@ mod tests {
         let prev_hash = store_block_diff(&mut rwtxn, &dbs, BlockHash::all_zeros(), Some(prior));
 
         let diff = test_handler(&dbs)
-            .handle_m4_ack_bundles(&rwtxn, prev_hash, &M4AckBundles::RepeatPrevious)
+            .handle_m4_ack_bundles(&rwtxn, prev_hash, &M4AckBundles::RepeatPrevious, false)
             .into_diagnostic()?;
         assert!(
             diff.0.is_empty(),
@@ -3902,7 +4183,7 @@ mod tests {
         let prev_hash = store_block_diff(&mut rwtxn, &dbs, BlockHash::all_zeros(), Some(stale));
 
         let rebuilt = test_handler(&dbs)
-            .handle_m4_ack_bundles(&rwtxn, prev_hash, &M4AckBundles::RepeatPrevious)
+            .handle_m4_ack_bundles(&rwtxn, prev_hash, &M4AckBundles::RepeatPrevious, false)
             .into_diagnostic()?;
         let Some(diff::AckBundleAction::Upvote {
             m6id,
@@ -3956,7 +4237,7 @@ mod tests {
         let prev_hash = store_block_diff(&mut rwtxn, &dbs, BlockHash::all_zeros(), Some(stale));
 
         let rebuilt = test_handler(&dbs)
-            .handle_m4_ack_bundles(&rwtxn, prev_hash, &M4AckBundles::RepeatPrevious)
+            .handle_m4_ack_bundles(&rwtxn, prev_hash, &M4AckBundles::RepeatPrevious, false)
             .into_diagnostic()?;
         let Some(diff::AckBundleAction::Alarm {
             positive_votes_proposals,
@@ -3986,6 +4267,7 @@ mod tests {
                 &rwtxn,
                 BlockHash::all_zeros(),
                 &M4AckBundles::RepeatPrevious,
+                false,
             )
             .into_diagnostic()?;
         assert!(diff.0.is_empty());
@@ -4024,7 +4306,7 @@ mod tests {
         let prev_hash = store_block_diff(&mut rwtxn, &dbs, BlockHash::all_zeros(), Some(prior));
 
         let diff = test_handler(&dbs)
-            .handle_m4_ack_bundles(&rwtxn, prev_hash, &M4AckBundles::RepeatPrevious)
+            .handle_m4_ack_bundles(&rwtxn, prev_hash, &M4AckBundles::RepeatPrevious, false)
             .into_diagnostic()?;
         assert!(
             diff.0.is_empty(),
@@ -4057,7 +4339,12 @@ mod tests {
         set_vote_count(&mut rwtxn, &dbs, &sc, tied_b, 60);
 
         let diff = test_handler(&dbs)
-            .handle_m4_ack_bundles(&rwtxn, BlockHash::all_zeros(), &M4AckBundles::LeadingBy50)
+            .handle_m4_ack_bundles(
+                &rwtxn,
+                BlockHash::all_zeros(),
+                &M4AckBundles::LeadingBy50,
+                false,
+            )
             .into_diagnostic()?;
         assert!(matches!(
             diff.0.get(&sc),


### PR DESCRIPTION
## Problem

The LayerTwo-Labs BIP300 M4 encoding permits a vote array `A` whenever `A.len() <= ASN.len()`, where `ASN` is the ordered active-slot list. The validator currently requires exact equality, so it rejects valid M4s that omit trailing active slots. Omitted slots should abstain implicitly.

## Fix

Reject only vote arrays longer than the active-slot list. Existing indexed vote validation remains unchanged for every supplied element.

## Tests

- Added a regression with two active slots and a one-element M4; the first slot is voted and the omitted trailing slot is unchanged.
- Existing oversized-array and invalid-index tests remain in place.
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --workspace` (134 library tests plus app tests)
- nightly rustfmt check and `git diff --check`

## Scope

M4 array-length validation only; no vote-index or bundle-order changes.
