### PR TITLE
validator: ignore same-block duplicate M3s

### DIFF
--- a/lib/messages.rs
+++ b/lib/messages.rs
@@ -455,6 +455,7 @@ pub struct CoinbaseMessages {
     messages: Vec<(CoinbaseMessage, usize)>,
     m1_sidechain_proposal_id_to_index: HashMap<SidechainProposalId, usize>,
     m2_ack_slot_to_index: HashMap<SidechainNumber, usize>,
+    m3_proposals: HashSet<(SidechainNumber, [u8; 32])>,
     m4_index: Option<usize>,
     /// Maps M7 slots to commitment and index
     m7_slot_to_commitment_index: HashMap<SidechainNumber, (BmmCommitment, usize)>,
@@ -558,8 +559,16 @@ impl CoinbaseMessages {
                     }
                 }
             }
-            CoinbaseMessage::M3ProposeBundle(_) => {
-                self.messages.push((msg, vout));
+            CoinbaseMessage::M3ProposeBundle(m3) => {
+                // Repeated copies of the same M3 in one coinbase are allowed.
+                // Keep only the first so the second is not mistaken for a
+                // re-proposal of an entry inherited from an ancestor block.
+                if self
+                    .m3_proposals
+                    .insert((m3.sidechain_number, m3.bundle_txid))
+                {
+                    self.messages.push((msg, vout));
+                }
                 Ok(())
             }
         }

--- a/lib/validator/task/mod.rs
+++ b/lib/validator/task/mod.rs
@@ -3096,6 +3096,60 @@ mod tests {
 
     // ── handle_m3 ──
 
+    #[test]
+    fn connect_block_ignores_duplicate_m3_in_same_coinbase() -> Result<()> {
+        let (_dir, dbs) = create_test_dbs()?;
+        let mut rwtxn = dbs.write_txn().into_diagnostic()?;
+        let sc = SidechainNumber(1);
+        dbs.active_sidechains
+            .put_sidechain(&mut rwtxn, &sc, &test_sidechain(1, 0))
+            .into_diagnostic()?;
+        let m6id = test_m6id(0xAA);
+        let m3_script = || -> Result<ScriptBuf> {
+            M3ProposeBundle {
+                sidechain_number: sc,
+                bundle_txid: m6id.0.to_byte_array(),
+            }
+            .try_into()
+            .into_diagnostic()
+        };
+        let block = build_test_block(
+            BlockHash::all_zeros(),
+            TestBlockParts {
+                extra_coinbase_outputs: vec![
+                    TxOut {
+                        script_pubkey: m3_script()?,
+                        value: Amount::ZERO,
+                    },
+                    TxOut {
+                        script_pubkey: m3_script()?,
+                        value: Amount::ZERO,
+                    },
+                ],
+                ..Default::default()
+            },
+        );
+        dbs.block_hashes
+            .put_headers(&mut rwtxn, &[(block.header, 1)])
+            .into_diagnostic()?;
+
+        let event = test_handler(&dbs)
+            .connect_block(&mut rwtxn, &block)
+            .into_diagnostic()?;
+        let pending = dbs
+            .active_sidechains
+            .pending_m6ids()
+            .get(&rwtxn, &sc)
+            .into_diagnostic()?;
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[&m6id].vote_count, 1);
+        let Event::ConnectBlock { block_info, .. } = event else {
+            panic!("expected connect-block event");
+        };
+        assert_eq!(block_info.events.len(), 1);
+        Ok(())
+    }
+
     /// BIP 300 M3: a newly proposed bundle starts with an ACK score of 1
     /// (the proposer's implicit vote), not 0.
     #[test]


### PR DESCRIPTION
## Problem

The current LayerTwo-Labs BIP300 block-validation rules explicitly permit duplicate M3s with the same slot and M6ID in one coinbase. The validator processes parsed messages sequentially: after applying the first M3, the second sees the newly-created pending entry and is mistaken for a re-proposal inherited from an ancestor block, causing the block to be rejected.

## Fix

Deduplicate exact `(sidechain slot, M6ID)` pairs while collecting one coinbase's messages, retaining the first occurrence and its vout order. Distinct M3s for the same slot remain ordered and processed independently.

## Tests

- Added a block-level regression with two identical M3 outputs.
- Verifies the block connects, exactly one pending bundle exists with its initial vote, and exactly one submission event is emitted.
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --workspace` (134 library tests plus app tests)
- nightly rustfmt check and `git diff --check`

## Scope

Only exact duplicates within one coinbase are ignored. Re-proposing an M6ID already pending from an ancestor block remains rejected, preserving the behavior requested by #414.
