### PR TITLE
wallet: pin OP_RETURN to output 0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,6 +437,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1284fb23acc3e3022673712b55f4d5ce7e38aadc2c49bbef830dc3935f0a3289"
 dependencies = [
+ "anyhow",
  "bdk_chain",
  "bip39",
  "bitcoin",
@@ -444,6 +445,7 @@ dependencies = [
  "rand_core 0.6.4",
  "serde",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]
@@ -1413,7 +1415,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1517,6 +1519,12 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "file-guard"
@@ -2646,9 +2654,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -3297,7 +3305,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3589,15 +3597,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags 2.10.0",
  "errno 0.3.14",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3933,7 +3941,7 @@ version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
- "errno 0.3.14",
+ "errno 0.2.8",
  "libc",
 ]
 
@@ -4183,6 +4191,19 @@ dependencies = [
 name = "temp-dir"
 version = "0.2.0"
 source = "git+https://gitlab.com/A-Manning/leonhard-llc-ops.git?branch=temp-dir-leak#1894242ca67ccfb922ebacfefa8b521f486bd640"
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "terminal_size"
@@ -4961,7 +4982,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -72,6 +72,7 @@ rustls = ["bdk_electrum/use-rustls"]
 rustls-ring = ["bdk_electrum/use-rustls-ring"]
 
 [dev-dependencies]
+bdk_wallet = { workspace = true, features = ["test-utils"] }
 temp-dir = { workspace = true }
 
 [lints]

--- a/lib/wallet/mod.rs
+++ b/lib/wallet/mod.rs
@@ -1384,6 +1384,9 @@ impl Wallet {
 
         if let Some(op_return_message) = params.op_return_message {
             let op_return_output = Self::create_op_return_output(op_return_message)?;
+            // BIP300/BIP301 messages are only read from output 0, and BDK
+            // shuffles outputs by default.
+            builder.ordering(bdk_wallet::TxOrdering::Untouched);
             builder.add_recipient(op_return_output.script_pubkey, op_return_output.value);
 
             tracing::debug!("Added OP_RETURN output in {:?}", timestamp.elapsed());
@@ -1934,5 +1937,54 @@ impl Wallet {
         password: Option<&str>,
     ) -> Result<(), error::CreateNewWallet> {
         self.inner.create_new_wallet(mnemonic, password).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use bdk_wallet::{
+        bitcoin::{Amount, ScriptBuf, script::PushBytesBuf},
+        test_utils::get_funded_wallet_wpkh,
+    };
+
+    use super::{CreateTransactionParams, M8BmmRequest, Wallet};
+
+    /// A BMM request only counts as an M8 when its OP_RETURN sits at output 0,
+    /// and a shuffle lands it there half the time, so one build proves nothing.
+    #[test]
+    fn op_return_is_always_output_zero() {
+        const ROUNDS: usize = 64;
+
+        let message = [
+            &M8BmmRequest::TAG[..],
+            &[13],
+            &[0x11; 32][..],
+            &[0x22; 32][..],
+        ]
+        .concat();
+        let expected = ScriptBuf::new_op_return(PushBytesBuf::try_from(message.clone()).unwrap());
+
+        for _ in 0..ROUNDS {
+            let (mut wallet, _) = get_funded_wallet_wpkh();
+
+            let psbt = Wallet::build_send_psbt(
+                &mut wallet,
+                HashMap::new(),
+                CreateTransactionParams {
+                    op_return_message: Some(message.clone()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+
+            let outputs = psbt.unsigned_tx.output;
+            assert_eq!(outputs.len(), 2, "want an OP_RETURN and change");
+            assert_eq!(outputs[0].script_pubkey, expected);
+            assert_eq!(outputs[0].value, Amount::ZERO);
+            M8BmmRequest::parse(&outputs[0].script_pubkey.to_bytes())
+                .expect("output 0 must parse as an M8 BMM request");
+        }
     }
 }

--- a/lib/wallet/mod.rs
+++ b/lib/wallet/mod.rs
@@ -1374,96 +1374,94 @@ impl Wallet {
             .collect()
     }
 
+    fn build_send_psbt(
+        wallet: &mut bdk_wallet::Wallet,
+        destinations: HashMap<bitcoin::Address, Amount>,
+        params: CreateTransactionParams,
+    ) -> Result<bdk_wallet::bitcoin::psbt::Psbt, error::CreateSendPsbt> {
+        let mut timestamp = Instant::now();
+        let mut builder = wallet.build_tx();
+
+        if let Some(op_return_message) = params.op_return_message {
+            let op_return_output = Self::create_op_return_output(op_return_message)?;
+            builder.add_recipient(op_return_output.script_pubkey, op_return_output.value);
+
+            tracing::debug!("Added OP_RETURN output in {:?}", timestamp.elapsed());
+            timestamp = Instant::now();
+        }
+
+        let destinations_len = destinations.len();
+
+        // Add outputs for each destination address
+        for (address, value) in destinations {
+            builder.add_recipient(address.script_pubkey(), value);
+        }
+
+        tracing::debug!(
+            "Added {} destinations in {:?}",
+            destinations_len,
+            timestamp.elapsed()
+        );
+        timestamp = Instant::now();
+
+        if let Some(drain_wallet_to) = params.drain_wallet_to {
+            tracing::debug!("Draining wallet to {}", drain_wallet_to);
+            builder
+                .drain_to(drain_wallet_to.script_pubkey())
+                .drain_wallet();
+        }
+
+        if !params.required_utxos.is_empty() {
+            builder
+                // TODO: this does not work at all for wallets past a certain scale....
+                // 25s pr. UTXO for a wallet with 40k UTXOs in total
+                .add_utxos(&params.required_utxos)
+                .map_err(|err| match err {
+                    bdk_wallet::tx_builder::AddUtxoError::UnknownUtxo(outpoint) => {
+                        error::CreateSendPsbt::UnknownUTXO(outpoint)
+                    }
+                })?;
+
+            builder.manually_selected_only();
+
+            tracing::debug!(
+                "Added {} required UTXOs in {:?}",
+                params.required_utxos.len(),
+                timestamp.elapsed()
+            );
+            timestamp = Instant::now();
+        }
+
+        match params.fee_policy {
+            Some(crate::types::FeePolicy::Absolute(fee)) => {
+                builder.fee_absolute(fee);
+            }
+            Some(crate::types::FeePolicy::Rate(rate)) => {
+                builder.fee_rate(rate);
+            }
+            None => (),
+        }
+
+        tracing::debug!("Set fee policy in {:?}", timestamp.elapsed());
+        timestamp = Instant::now();
+
+        builder
+            .finish()
+            .inspect(|_| {
+                tracing::debug!("Finished transaction builder in {:?}", timestamp.elapsed());
+            })
+            .map_err(error::CreateSendPsbt::CreateTx)
+    }
+
     async fn create_send_psbt(
         &self,
         destinations: HashMap<bitcoin::Address, Amount>,
         params: CreateTransactionParams,
     ) -> Result<bdk_wallet::bitcoin::psbt::Psbt, error::CreateSendPsbt> {
-        let mut timestamp = Instant::now();
-        let psbt = {
-            let mut wallet_write = self.inner.write_wallet().await?;
-            tokio::task::block_in_place(|| {
-                wallet_write.with_mut(|wallet| {
-                    let mut builder = wallet.build_tx();
-
-                    if let Some(op_return_message) = params.op_return_message {
-                        let op_return_output = Self::create_op_return_output(op_return_message)?;
-                        builder
-                            .add_recipient(op_return_output.script_pubkey, op_return_output.value);
-
-                        tracing::debug!("Added OP_RETURN output in {:?}", timestamp.elapsed());
-                        timestamp = Instant::now();
-                    }
-
-                    let destinations_len = destinations.len();
-
-                    // Add outputs for each destination address
-                    for (address, value) in destinations {
-                        builder.add_recipient(address.script_pubkey(), value);
-                    }
-
-                    tracing::debug!(
-                        "Added {} destinations in {:?}",
-                        destinations_len,
-                        timestamp.elapsed()
-                    );
-                    timestamp = Instant::now();
-
-                    if let Some(drain_wallet_to) = params.drain_wallet_to {
-                        tracing::debug!("Draining wallet to {}", drain_wallet_to);
-                        builder
-                            .drain_to(drain_wallet_to.script_pubkey())
-                            .drain_wallet();
-                    }
-
-                    if !params.required_utxos.is_empty() {
-                        builder
-                            // TODO: this does not work at all for wallets past a certain scale....
-                            // 25s pr. UTXO for a wallet with 40k UTXOs in total
-                            .add_utxos(&params.required_utxos)
-                            .map_err(|err| match err {
-                                bdk_wallet::tx_builder::AddUtxoError::UnknownUtxo(outpoint) => {
-                                    error::CreateSendPsbt::UnknownUTXO(outpoint)
-                                }
-                            })?;
-
-                        builder.manually_selected_only();
-
-                        tracing::debug!(
-                            "Added {} required UTXOs in {:?}",
-                            params.required_utxos.len(),
-                            timestamp.elapsed()
-                        );
-                        timestamp = Instant::now();
-                    }
-
-                    match params.fee_policy {
-                        Some(crate::types::FeePolicy::Absolute(fee)) => {
-                            builder.fee_absolute(fee);
-                        }
-                        Some(crate::types::FeePolicy::Rate(rate)) => {
-                            builder.fee_rate(rate);
-                        }
-                        None => (),
-                    }
-
-                    tracing::debug!("Set fee policy in {:?}", timestamp.elapsed());
-                    timestamp = Instant::now();
-
-                    builder
-                        .finish()
-                        .inspect(|_| {
-                            tracing::debug!(
-                                "Finished transaction builder in {:?}",
-                                timestamp.elapsed()
-                            );
-                        })
-                        .map_err(error::CreateSendPsbt::CreateTx)
-                })
-            })?
-        };
-
-        Ok(psbt)
+        let mut wallet_write = self.inner.write_wallet().await?;
+        tokio::task::block_in_place(|| {
+            wallet_write.with_mut(|wallet| Self::build_send_psbt(wallet, destinations, params))
+        })
     }
 
     /// Creates a transaction, sends it, and returns the TXID.


### PR DESCRIPTION
BDK shuffles transaction outputs by default, so an OP_RETURN sent through `SendTransaction` landed at a random index. BIP300/BIP301 messages are only read from output 0, so a BMM request built that way was silently not an M8 about half the time.