### PR TITLE
block producer: return mined block when BMM cleanup fails

### DIFF
--- a/lib/block_producer/error.rs
+++ b/lib/block_producer/error.rs
@@ -444,8 +444,6 @@ impl ToStatus for GenerateSignetBlock {
 pub enum GenerateBlock {
     #[error(transparent)]
     CoinbaseBuilder(#[from] CoinbaseMessagesError),
-    #[error("failed to delete BMM requests")]
-    DeleteBmmRequests(#[source] rusqlite::Error),
     #[error(transparent)]
     GenerateCoinbaseTxouts(#[from] GenerateCoinbaseTxouts),
     #[error(transparent)]
@@ -471,9 +469,7 @@ impl ToStatus for GenerateBlock {
             Self::Mine(err) => err.builder(),
             Self::SelectBlockTxs(err) => err.builder(),
             Self::TryGetMainchainTip(err) => err.builder(),
-            Self::DeleteBmmRequests(_) | Self::PushBytesBuf(_) | Self::ValidatorNotSynced => {
-                StatusBuilder::new(self)
-            }
+            Self::PushBytesBuf(_) | Self::ValidatorNotSynced => StatusBuilder::new(self),
         }
     }
 }

--- a/lib/block_producer/mine.rs
+++ b/lib/block_producer/mine.rs
@@ -33,8 +33,27 @@ use bitcoin_jsonrpsee::{
 use crate::{
     bins::{self, CommandExt as _},
     block_producer::{BlockProducer, error},
+    errors::ErrorChain,
     messages::CoinbaseBuilder,
 };
+
+/// BMM request cleanup happens after the block has been submitted and observed
+/// by the validator. Keep the mined block as the operation's result even if the
+/// best-effort cleanup fails, so callers are not invited to retry an operation
+/// that has already happened.
+fn finish_bmm_request_cleanup(
+    block_hash: BlockHash,
+    result: Result<(), rusqlite::Error>,
+) -> BlockHash {
+    if let Err(err) = result {
+        tracing::error!(
+            %block_hash,
+            "failed to delete BMM requests for mined block: {:#}",
+            ErrorChain::new(&err),
+        );
+    }
+    block_hash
+}
 
 fn target_block_interval(signet_challenge: &bitcoin::Script) -> std::time::Duration {
     const L2L_SIGNET_CHALLENGE: &[u8] = b"00141551188e5153533b4fdd555449e640d9cc129456";
@@ -635,10 +654,26 @@ impl BlockProducer {
         let block_hash = self
             .mine(coinbase_spk, &coinbase_outputs, transactions)
             .await?;
-        self.db()
+        let cleanup_result = self
+            .db()
             .delete_bmm_requests(&mainchain_tip, &block_hash)
-            .await
-            .map_err(error::GenerateBlock::DeleteBmmRequests)?;
-        Ok(block_hash)
+            .await;
+        Ok(finish_bmm_request_cleanup(block_hash, cleanup_result))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bitcoin::{BlockHash, hashes::Hash as _};
+
+    use super::finish_bmm_request_cleanup;
+
+    #[test]
+    fn cleanup_failure_preserves_mined_block_result() {
+        let block_hash = BlockHash::from_byte_array([0x42; 32]);
+        assert_eq!(
+            finish_bmm_request_cleanup(block_hash, Err(rusqlite::Error::InvalidQuery)),
+            block_hash
+        );
     }
 }


### PR DESCRIPTION
Reimplement #480 as an API-correctness fix on the current block producer.