### PR TITLE
Caching improvements for Docker build + integration deps

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,5 @@
 .git
 **/target
 .worktrees
+.integration-deps
+integrationtests*.env

--- a/.github/workflows/build_docker.yaml
+++ b/.github/workflows/build_docker.yaml
@@ -31,8 +31,10 @@ jobs:
         include:
           - platform: linux/amd64
             runner: ubuntu-latest-large
+            cache-suffix: linux-amd64
           - platform: linux/arm64
             runner: ubuntu-24.04-arm
+            cache-suffix: linux-arm64
     runs-on: ${{ matrix.runner }}
     # needed to push to GHCR
     permissions:
@@ -61,7 +63,7 @@ jobs:
       - name: Determine Rust version
         id: rust-version
         run: |
-          RUST_VERSION=$(awk -F'"' '/^[[:space:]]*channel[[:space:]]*=/{split($2,v,"."); print v[1]"."v[2]; exit}' rust-toolchain.toml)
+          RUST_VERSION=$(awk -F'"' '/^[[:space:]]*channel[[:space:]]*=/{print $2; exit}' rust-toolchain.toml)
           echo "rust-version=$RUST_VERSION" >> $GITHUB_OUTPUT
 
       - name: Build (and maybe push) Docker image by digest
@@ -74,16 +76,22 @@ jobs:
           # a fork.
           # prettier-ignore
           outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
-          # Caching Docker builds on CI is an eternally
-          # difficult task. From the official docs:
-          # "In most cases you want to use the inline cache exporter"
-          #
-          # https://docs.docker.com/build/ci/github-actions/cache/#inline-cache
-          #
-          # `:latest` is a multi-arch manifest list, so buildx resolves it
-          # to the cache image matching the platform being built.
-          cache-from: type=registry,ref=${{ env.IMAGE }}:latest
-          cache-to: type=inline
+          # The dedicated per-platform cache is exported with mode=max so it
+          # retains intermediate builder stages, including cargo-chef's
+          # dependency build. Keep :latest as a fallback while the new caches
+          # warm up. Fork PRs can read the public cache but cannot update it.
+          cache-from: |
+            type=registry,ref=${{ env.IMAGE }}:buildcache-${{ matrix.cache-suffix }}
+            type=registry,ref=${{ env.IMAGE }}:latest
+          cache-to: >-
+            ${{
+              (github.event_name != 'pull_request' ||
+                github.event.pull_request.head.repo.full_name ==
+            github.repository) &&
+              format('type=registry,ref={0}:buildcache-{1},mode=max', env.IMAGE,
+            matrix.cache-suffix) ||
+              ''
+            }}
           build-args:
             RUST_VERSION=${{ steps.rust-version.outputs.rust-version }}
 

--- a/.github/workflows/check_lint_build_release.yaml
+++ b/.github/workflows/check_lint_build_release.yaml
@@ -196,9 +196,53 @@ jobs:
           echo "matrix=${MATRIX}" >> "$GITHUB_OUTPUT"
           echo "$MATRIX"
 
+  build-integration-binaries:
+    name: Build integration-test binaries
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+
+      # Must happen /after/ the checkout step, to pick up the toolchain from
+      # rust-toolchain.toml.
+      - name: Install Rust toolchain
+        run: rustup install
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: x86_64-unknown-linux-gnu
+
+      # Build the two flavor-independent executables once. The matrix jobs
+      # only vary the Bitcoin Core binary and can all run these same builds.
+      - name: Build integration-test binaries
+        run: |
+          cargo build --locked \
+            --package bip300301_enforcer \
+            --bin bip300301_enforcer
+          cargo build --locked \
+            --package bip300301_enforcer_integration_tests \
+            --example integration_tests
+
+      - name: Stage integration-test binaries
+        run: |
+          mkdir -p "$RUNNER_TEMP/integration-test-binaries"
+          cp target/debug/bip300301_enforcer \
+            "$RUNNER_TEMP/integration-test-binaries/"
+          cp target/debug/examples/integration_tests \
+            "$RUNNER_TEMP/integration-test-binaries/"
+
+      - name: Upload integration-test binaries
+        uses: actions/upload-artifact@v7
+        with:
+          name: integration-test-binaries
+          path: ${{ runner.temp }}/integration-test-binaries
+          retention-days: 1
+          if-no-files-found: error
+
   integration-test:
     name: Integration test (${{ matrix.name }})
-    needs: compute-integration-matrix
+    needs: [compute-integration-matrix, build-integration-binaries]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
@@ -284,19 +328,15 @@ jobs:
 
       - uses: actions/checkout@v7
 
-      # `rustup` is already installed on GitHub Actions runners, so
-      # this reads the content from our `rust-toolchain.toml` file.
-      # Must happen /after/ the checkout step.
-      - name: Install Rust toolchain
-        run: rustup install
-
-      - name: Rust Cache
-        uses: Swatinem/rust-cache@v2
+      - name: Download integration-test binaries
+        uses: actions/download-artifact@v8
         with:
-          shared-key: x86_64-unknown-linux-gnu
+          name: integration-test-binaries
+          path: ${{ runner.temp }}/integration-test-binaries
 
-      - name: Build (debug)
-        run: cargo build
+      # upload-artifact does not preserve executable permissions.
+      - name: Make integration-test binaries executable
+        run: chmod +x "$RUNNER_TEMP"/integration-test-binaries/*
 
       # A signet chain can only be extended by real proof-of-work, and no
       # coinbase is spendable until it is 100 blocks deep — so mining one per
@@ -355,7 +395,7 @@ jobs:
         run: |
           export PATH="$HOME/grpcurl-bin:$PATH"
           export BITCOIND='../bitcoin-bins/bitcoind'
-          export BIP300301_ENFORCER='target/debug/bip300301_enforcer'
+          export BIP300301_ENFORCER="$RUNNER_TEMP/integration-test-binaries/bip300301_enforcer"
           ./scripts/verify_reflection.sh
 
       - name: Run integration tests
@@ -376,7 +416,8 @@ jobs:
         # here while rejecting deposits with -26 "scriptpubkey" in
         # production, where chain=main forbids the flag.
         run: |
-          export BIP300301_ENFORCER='target/debug/bip300301_enforcer'
+          export BIP300301_ENFORCER="$RUNNER_TEMP/integration-test-binaries/bip300301_enforcer"
+          INTEGRATION_TEST_RUNNER="$RUNNER_TEMP/integration-test-binaries/integration_tests"
           export BITCOIND='../bitcoin-bins/bitcoind'
           export BITCOIN_CLI='../bitcoin-bins/bitcoin-cli'
           export BITCOIN_UTIL='../bitcoin-bins/bitcoin-util'
@@ -400,14 +441,12 @@ jobs:
           if [ -n '${{ matrix.version }}' ]; then
             export BITCOIND_UNPATCHED='../bitcoin-bins/bitcoind'
             export BITCOIND_HAS_DRIVECHAIN=0
-            cargo run --example integration_tests -- --skip deposit_withdraw_roundtrip \
+            "$INTEGRATION_TEST_RUNNER" --skip deposit_withdraw_roundtrip \
               ${SKIP_ARGS[@]+"${SKIP_ARGS[@]}"}
           else
             export BITCOIND_UNPATCHED='../bitcoin-unpatched-bins/bitcoind'
             export BITCOIND_HAS_DRIVECHAIN=1
-            # `--` is required even when SKIP_ARGS is empty: without it cargo
-            # parses a leading --skip as its own flag and exits.
-            cargo run --example integration_tests -- ${SKIP_ARGS[@]+"${SKIP_ARGS[@]}"}
+            "$INTEGRATION_TEST_RUNNER" ${SKIP_ARGS[@]+"${SKIP_ARGS[@]}"}
           fi
 
       # Did the run end up with a chain worth caching? A run that never needed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,25 @@
 ARG RUST_VERSION=1
 
-FROM rust:${RUST_VERSION}-slim-bookworm AS builder
+FROM rust:${RUST_VERSION}-slim-bookworm AS chef
+RUN cargo install cargo-chef --locked --version 0.1.73
 WORKDIR /workspace
+
+# cargo-chef turns the workspace manifests into a stable dependency recipe.
+# Source-only changes leave the `cook` layer below reusable.
+FROM chef AS planner
 COPY . .
-RUN cargo build --locked --release
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS builder
+COPY --from=planner /workspace/recipe.json recipe.json
+RUN cargo chef cook --locked --release \
+    --package bip300301_enforcer \
+    --bin bip300301_enforcer \
+    --recipe-path recipe.json
+COPY . .
+RUN cargo build --locked --release \
+    --package bip300301_enforcer \
+    --bin bip300301_enforcer
 
 # Runtime stage
 FROM debian:bookworm-slim


### PR DESCRIPTION
Improve the Docker build by using `cargo chef` to cache layers correctly. Avoid building the integration dependencies in more places than required by doing this as a prequisite CI step before fanning out.