### PR TITLE
block producer: skip withdrawal bundles that cannot be paid out

### DIFF
--- a/integration_tests/block_verdict.rs
+++ b/integration_tests/block_verdict.rs
@@ -39,6 +39,23 @@ async fn enforcer_tip(post_setup: &PostSetup) -> anyhow::Result<(BlockHash, u32)
     Ok((hash, info.height))
 }
 
+/// Wait until the enforcer's validated tip *is* `tip_hash`.
+///
+/// Unlike [`wait_for_enforcer_height`], this also covers the chain getting
+/// shorter: after an `invalidateblock` the enforcer is briefly still on the
+/// abandoned tip, which is *higher* than the one it must roll back to, so a
+/// height comparison would report success before the disconnect had happened.
+pub async fn wait_for_enforcer_tip_hash(
+    post_setup: &PostSetup,
+    tip_hash: BlockHash,
+) -> anyhow::Result<()> {
+    wait_until(&format!("the enforcer's tip to be {tip_hash}"), || async {
+        let (enforcer_tip_hash, _height) = enforcer_tip(post_setup).await?;
+        Ok(enforcer_tip_hash == tip_hash)
+    })
+    .await
+}
+
 /// Wait until the enforcer has validated the chain up to `height`.
 ///
 /// Mining RPCs return once *bitcoind* has the blocks; the enforcer connects

--- a/integration_tests/integration_test.rs
+++ b/integration_tests/integration_test.rs
@@ -13,16 +13,15 @@ use bip300301_enforcer_lib::{
             ListSidechainDepositTransactionsRequest, block_info, withdrawal_bundle_event,
         },
     },
-    types::SidechainNumber,
+    types::{SidechainNumber, Thresholds},
 };
 use bitcoin::Amount;
-use either::Either;
 use futures::{FutureExt as _, channel::mpsc};
 use tokio::time::sleep;
 use tracing::Instrument as _;
 
 use crate::{
-    mine::{mine, mine_check_block_events, mine_generateblocks_check, mine_signet_check},
+    mine::{mine, mine_check_block_events, mine_signet_check},
     setup::{
         Directories, DummySidechain, MiningMode, Mode, Network, PostSetup, PreSetup, Sidechain,
         wait_for_pending_proposal, wait_for_tx_in_mempool,
@@ -454,7 +453,7 @@ where
 }
 
 // returns M6id and event
-fn expect_withdrawal_bundle_event(
+pub(crate) fn expect_withdrawal_bundle_event(
     event: &block_info::Event,
 ) -> anyhow::Result<(&ConsensusHex, &withdrawal_bundle_event::event::Event)> {
     let block_info::event::Event::WithdrawalBundle(wbe) = event
@@ -476,6 +475,62 @@ fn expect_withdrawal_bundle_event(
         .as_ref()
         .ok_or_else(|| anyhow::anyhow!("withdrawal bundle event missing oneof"))?;
     Ok((event_m6id, inner_event))
+}
+
+/// Mine blocks until an approved-but-unpayable withdrawal bundle expires,
+/// asserting that every block in the window still connects and that the bundle
+/// produces no event beyond its initial submission and final failure --
+/// notably no payout, which would be consensus-invalid.
+///
+/// This is the shared tail of the unpayable-bundle tests. The enforcer
+/// (re-)proposes the stored bundle in the first block (age 0) and, with
+/// ack-all on, upvotes it each block after that, so it crosses the inclusion
+/// threshold while it cannot be paid out and stays pending until its age
+/// exceeds `withdrawal_bundle_max_age`, with the failure event landing one
+/// block later. Every one of these blocks still has to be produced: only a
+/// connected block can retire the bundle, so a block builder that fails on it
+/// instead of skipping it wedges block production permanently.
+pub(crate) async fn mine_until_unpayable_bundle_expires<S>(
+    post_setup: &mut PostSetup,
+    m6id_hex: &ConsensusHex,
+) -> anyhow::Result<()>
+where
+    S: Sidechain,
+{
+    // Proposal block + max-age blocks of aging + the block whose connect emits
+    // the failure event. Non-mainnet networks all use the `SHORT` thresholds.
+    let blocks_to_expiry = u32::from(Thresholds::SHORT.withdrawal_bundle_max_age) + 2;
+    let mut saw_expiry = false;
+    mine_check_block_events::<_, S>(
+        post_setup,
+        blocks_to_expiry,
+        Some(true),
+        |seq, block_info| {
+            for event in &block_info.events {
+                let (event_m6id, event) = expect_withdrawal_bundle_event(event)?;
+                anyhow::ensure!(
+                    event_m6id == m6id_hex,
+                    "unexpected withdrawal bundle event for a different m6id: {event_m6id:?}"
+                );
+                match event {
+                    withdrawal_bundle_event::event::Event::Submitted(_) if seq == 0 => (),
+                    withdrawal_bundle_event::event::Event::Failed(_) => saw_expiry = true,
+                    event => anyhow::bail!(
+                        "unexpected withdrawal bundle event in block {seq} while the unpayable \
+                         bundle was pending: {event:?}"
+                    ),
+                }
+            }
+            Ok(())
+        },
+    )
+    .await?;
+    anyhow::ensure!(
+        saw_expiry,
+        "the bundle never expired, so this never exercised the window in which it was approved \
+         but unpayable"
+    );
+    Ok(())
 }
 
 const WITHDRAW_AMOUNT_0: Amount = Amount::from_sat(18_000_000);
@@ -644,16 +699,16 @@ where
 /// bundle structure but does not bound it against the treasury (which is unknown
 /// at submission time). Once the enforcer's own miner upvotes the bundle past the
 /// withdrawal-bundle inclusion threshold, every block-template build runs the
-/// treasury subtraction `treasury - fee - payout`. Before the fix this was an
-/// unchecked `Amount` subtraction that panicked, aborting block production; the
-/// fix routes it through `Wallet::new_treasury_value`, which returns an
-/// `AmountUnderflowError` instead.
+/// treasury subtraction `treasury - fee - payout`. That subtraction was once an
+/// unchecked `Amount` subtraction that panicked; then a hard error, which still
+/// stopped the node from producing any block at all until the bundle expired.
 ///
-/// This drives the full path — broadcast an over-value bundle, then mine until
-/// the enforcer's auto-upvote pushes it past the threshold — and asserts that
-/// block production surfaces a clean amount-underflow error and the enforcer
-/// stays responsive, rather than crashing.
-async fn withdrawal_bundle_treasury_underflow_is_graceful<S>(
+/// Such a bundle can never be paid out — an M6 spending more than the CTIP is
+/// consensus-invalid — so the block producer skips it and carries on. This
+/// drives the full path: broadcast an over-value bundle, mine until the
+/// enforcer's auto-upvote pushes it past the threshold, and assert that blocks
+/// keep being produced across that window and the bundle expires unpaid.
+async fn withdrawal_bundle_exceeding_treasury_is_skipped<S>(
     post_setup: &mut PostSetup,
 ) -> anyhow::Result<()>
 where
@@ -677,41 +732,14 @@ where
         })
         .await?;
 
-    // The enforcer auto-proposes the stored bundle and, with `ack_all_proposals`,
-    // upvotes it each block. Once `vote_count` crosses the inclusion threshold the
-    // next `GenerateToAddress` builds a block whose suffix txs run the treasury
-    // subtraction, which must fail with an amount-underflow rather than panicking.
-    // After the crossing no block is produced, so the failure is sticky; cap the
-    // loop generously above the regtest threshold.
-    const MAX_BLOCKS: u32 = 16;
-    let mut underflow_status = None;
-    for _ in 0..MAX_BLOCKS {
-        match mine_generateblocks_check(post_setup, 1, Some(true), |_| {
-            Ok::<(), std::convert::Infallible>(())
-        })
-        .await
-        {
-            Ok(()) => continue,
-            Err(Either::Left(status)) => {
-                underflow_status = Some(status);
-                break;
-            }
-            Err(Either::Right(never)) => match never {},
-        }
-    }
-    let status = underflow_status.ok_or_else(|| {
-        anyhow::anyhow!(
-            "expected `GenerateToAddress` to fail once the over-value bundle crossed the \
-             withdrawal-bundle inclusion threshold, but mined {MAX_BLOCKS} blocks without error"
-        )
-    })?;
-    anyhow::ensure!(
-        status.to_string().to_lowercase().contains("underflow"),
-        "expected an amount-underflow error from block production, got: {status}"
-    );
+    // Once the auto-upvotes push the bundle past the inclusion threshold,
+    // every block-template build reaches the treasury subtraction for a bundle
+    // it cannot pay.
+    let m6id_hex = ConsensusHex::encode(&over_value_bundle.compute_txid());
+    mine_until_unpayable_bundle_expires::<S>(post_setup, &m6id_hex).await?;
 
-    // The fix returns the error gracefully, so the enforcer must still be serving.
-    // Before the fix the treasury subtraction panicked instead.
+    // Nothing above touches the enforcer if it died, so confirm it is serving:
+    // this subtraction once panicked, taking the process with it.
     let _tip = post_setup
         .validator_service_client
         .get_chain_tip(GetChainTipRequest::default())
@@ -719,7 +747,7 @@ where
         .map_err(|err| {
             anyhow::anyhow!("enforcer unresponsive after over-value bundle (possible crash): {err}")
         })?;
-    tracing::info!("Enforcer rejected the over-value withdrawal bundle gracefully");
+    tracing::info!("Enforcer skipped the over-value withdrawal bundle and kept producing blocks");
     Ok(())
 }
 
@@ -789,7 +817,7 @@ where
     // auto-upvotes bundle proposals; the GBT/signet modes build templates
     // externally and so cannot drive a bundle past the inclusion threshold here.
     if let MiningMode::GenerateBlocks = post_setup.mode.mining_mode() {
-        let () = withdrawal_bundle_treasury_underflow_is_graceful::<S>(post_setup).await?;
+        let () = withdrawal_bundle_exceeding_treasury_is_skipped::<S>(post_setup).await?;
         tracing::info!("Over-value withdrawal bundle handled gracefully");
     }
     Ok(sidechain)

--- a/integration_tests/setup.rs
+++ b/integration_tests/setup.rs
@@ -36,7 +36,7 @@ use reserve_port::ReservedPort;
 use temp_dir::TempDir;
 use thiserror::Error;
 use tokio::{
-    net::TcpStream,
+    net::{TcpListener, TcpStream},
     time::{Duration, sleep, timeout},
 };
 
@@ -319,13 +319,25 @@ pub async fn wait_for_port(
     }
 }
 
-/// Inverse of [`wait_for_port`]: wait until nothing is listening on a port
-/// anymore. `AbortOnDrop`'s `Drop` impl only calls `JoinHandle::abort`, which
-/// schedules cancellation but doesn't guarantee the underlying child process
-/// (and the port it holds) is actually gone by the time `drop` returns -- so
-/// a kill immediately followed by a respawn on the same port can race the
-/// old process's teardown. Poll for the port to actually free up instead of
+/// Inverse of [`wait_for_port`]: wait until a port can be bound again.
+/// `AbortOnDrop`'s `Drop` impl only calls `JoinHandle::abort`, which schedules
+/// cancellation but doesn't guarantee the underlying child process (and the
+/// port it holds) is actually gone by the time `drop` returns -- so a kill
+/// immediately followed by a respawn on the same port can race the old
+/// process's teardown. Poll for the port to actually free up instead of
 /// guessing at a fixed delay.
+///
+/// This binds rather than connecting, because binding is the question the
+/// caller actually has: can the process I am about to spawn take this port?
+/// Every child here binds a specific `127.0.0.1` address, so the bind fails
+/// while one still holds the port and succeeds once it is gone.
+///
+/// A connect probe cannot tell our child from an unrelated process listening on
+/// the *wildcard* address, which answers connections to `127.0.0.1` forever and
+/// so hangs the wait until it times out. That is not hypothetical: BSD
+/// `SO_REUSEADDR` semantics let a specific bind coexist with a wildcard one, so
+/// a port held that way still looks free to `reserve-port` and does get handed
+/// out. A container publishing `0.0.0.0:8090` is enough to do it.
 pub async fn wait_for_port_free(
     host: &str,
     port: u16,
@@ -339,9 +351,14 @@ pub async fn wait_for_port_free(
 
     let task = async {
         loop {
-            match TcpStream::connect(target_addr).await {
-                Err(e) if e.kind() == std::io::ErrorKind::ConnectionRefused => return,
-                _ => {
+            match TcpListener::bind(target_addr).await {
+                // Hand it straight back: the caller is about to spawn something
+                // that needs to bind it.
+                Ok(listener) => {
+                    drop(listener);
+                    return;
+                }
+                Err(_) => {
                     tracing::trace!(
                         "Port {port} on {host} still held, waiting for it to free up..."
                     );

--- a/integration_tests/test_blinded_m6_roundtrip.rs
+++ b/integration_tests/test_blinded_m6_roundtrip.rs
@@ -1,19 +1,28 @@
 use std::borrow::Cow;
 
 use bip300301_enforcer_lib::{
-    bins::CommandExt as _, messages::CoinbaseMessage,
-    proto::mainchain::BroadcastWithdrawalBundleRequest, types::BlindedM6,
+    bins::CommandExt as _,
+    messages::CoinbaseMessage,
+    proto::{
+        common::ConsensusHex,
+        mainchain::{BroadcastWithdrawalBundleRequest, GetCtipRequest},
+    },
+    types::BlindedM6,
 };
 use bitcoin::{
-    Amount, Block, ScriptBuf, Transaction, TxOut, blockdata::locktime::absolute::LockTime,
-    consensus::Encodable, hashes::Hash as _, opcodes::all::OP_RETURN, script::Builder,
-    transaction::Version,
+    Amount, Block, BlockHash, ScriptBuf, Transaction, TxOut,
+    blockdata::locktime::absolute::LockTime, consensus::Encodable, hashes::Hash as _,
+    opcodes::all::OP_RETURN, script::Builder, transaction::Version,
 };
 use either::Either;
 use futures::channel::mpsc;
 
 use crate::{
-    integration_test::{activate_sidechain, deposit, fund_enforcer, propose_sidechain},
+    block_verdict::wait_for_enforcer_tip_hash,
+    integration_test::{
+        activate_sidechain, deposit, fund_enforcer, mine_until_unpayable_bundle_expires,
+        propose_sidechain,
+    },
     mine::mine_generateblocks_check,
     setup::{DummySidechain, PostSetup, Sidechain as _},
 };
@@ -65,6 +74,40 @@ pub(crate) fn serialize_zero_input_legacy(tx: &Transaction) -> Vec<u8> {
     buf
 }
 
+async fn chain_height(post_setup: &PostSetup) -> anyhow::Result<u32> {
+    Ok(post_setup
+        .bitcoin_cli
+        .command::<String, _, String, _, _>([], "getblockcount", [])
+        .run_utf8()
+        .await?
+        .trim()
+        .parse()?)
+}
+
+async fn block_hash_at(post_setup: &PostSetup, height: u32) -> anyhow::Result<BlockHash> {
+    Ok(post_setup
+        .bitcoin_cli
+        .command::<String, _, _, _, _>([], "getblockhash", [height.to_string()])
+        .run_utf8()
+        .await?
+        .trim()
+        .parse()?)
+}
+
+/// The sidechain's current treasury UTXO, if it has one.
+async fn ctip(post_setup: &mut PostSetup) -> anyhow::Result<Option<u64>> {
+    let resp = post_setup
+        .validator_service_client
+        .get_ctip(GetCtipRequest {
+            sidechain_number: bip300301_enforcer_lib::proto::wrap_u32(
+                DummySidechain::SIDECHAIN_NUMBER.0.into(),
+            ),
+        })
+        .await?
+        .into_owned();
+    Ok(resp.ctip.into_option().map(|ctip| ctip.value))
+}
+
 async fn mine_block_and_collect_proposed_m6ids(
     post_setup: &mut PostSetup,
 ) -> anyhow::Result<Vec<[u8; 32]>> {
@@ -107,6 +150,11 @@ pub async fn test_blinded_m6_zero_input_roundtrip(mut post_setup: PostSetup) -> 
     let mut sidechain = DummySidechain::setup((), &post_setup, sidechain_res_tx).await?;
     propose_sidechain::<DummySidechain>(&mut post_setup).await?;
     activate_sidechain::<DummySidechain>(&mut post_setup).await?;
+
+    // The height the sidechain is active but unfunded at. The final section of
+    // this test rolls the chain back here to strand the stored bundle without a
+    // treasury; everything the funding and deposit below add is undone.
+    let active_unfunded_height = chain_height(&post_setup).await?;
 
     let blinded_tx = make_blinded_m6(1_000, Amount::from_sat(50_000));
 
@@ -234,5 +282,40 @@ pub async fn test_blinded_m6_zero_input_roundtrip(mut post_setup: PostSetup) -> 
         status.code == connectrpc::ErrorCode::FailedPrecondition,
         "expected FailedPrecondition rejecting an inactive-slot bundle, got: {status}"
     );
+
+    // A stored bundle whose sidechain loses its treasury must not stop the
+    // block producer.
+    //
+    // Rolling the chain back to the active-but-unfunded height strands exactly
+    // that state: the enforcer's funding coinbases go with it, and a
+    // disconnected coinbase can never be re-mined, so the deposit that created
+    // the treasury is evicted rather than re-confirmed. The sidechain stays
+    // active (it activated before the funding) and the bundle stays in the block
+    // producer's own DB, which is not chain state. No ingestion-time check can
+    // cover this: the treasury existed when the bundle was accepted.
+    let rollback_to = block_hash_at(&post_setup, active_unfunded_height).await?;
+    let first_invalid = block_hash_at(&post_setup, active_unfunded_height + 1).await?;
+    tracing::info!(
+        %first_invalid,
+        %rollback_to,
+        "invalidating the funding and deposit under the stored bundle"
+    );
+    post_setup
+        .bitcoin_cli
+        .command::<String, _, _, _, _>([], "invalidateblock", [first_invalid.to_string()])
+        .run_utf8()
+        .await?;
+    wait_for_enforcer_tip_hash(&post_setup, rollback_to).await?;
+    anyhow::ensure!(
+        ctip(&mut post_setup).await?.is_none(),
+        "sidechain still has a treasury UTXO after its deposit was reorged out"
+    );
+
+    // The bundle crosses the inclusion threshold with no treasury to pay it
+    // from. Before the fix the first template built after the crossing failed
+    // with a missing-CTIP error, and since only a connected block can retire
+    // the bundle, nothing could ever clear it.
+    let m6id_hex = ConsensusHex::encode(&m6id);
+    mine_until_unpayable_bundle_expires::<DummySidechain>(&mut post_setup, &m6id_hex).await?;
     Ok(())
 }

--- a/lib/block_producer/coinbase.rs
+++ b/lib/block_producer/coinbase.rs
@@ -8,7 +8,7 @@ use crate::{
     messages::{CoinbaseBuilder, CoinbaseMessage, CoinbaseMessages, M4AckBundles},
     types::{
         AmountUnderflowError, BlindedM6, Ctip, Sidechain, SidechainAck, SidechainNumber,
-        SidechainProposal, SidechainProposalId,
+        SidechainProposal, SidechainProposalId, Thresholds,
     },
 };
 
@@ -375,32 +375,91 @@ impl BlockProducer {
     /// Generate the M6 suffix txs for a new block. These are fully determined by
     /// the approved bundle and the CTIP: treasury outputs are anyone-can-spend
     /// and consensus-gated, so an M6 is constructed, never signed.
+    ///
+    /// Fails only while *reading* the bundles to pay out. The payout rules
+    /// themselves cannot fail: a bundle that cannot be paid is skipped, so that
+    /// one unpayable bundle does not stop the node from producing blocks. See
+    /// [`Self::suffix_txs_for_proposals`].
     pub(crate) async fn generate_suffix_txs(
         &self,
         ctips: &HashMap<SidechainNumber, Ctip>,
-    ) -> Result<Vec<Transaction>, error::GenerateSuffixTxs> {
+    ) -> Result<Vec<Transaction>, error::GetBundleProposals> {
         let thresholds = self.validator().network_params().thresholds;
+        let bundle_proposals = self.get_bundle_proposals().await?;
+        Ok(Self::suffix_txs_for_proposals(
+            bundle_proposals,
+            ctips,
+            &thresholds,
+        ))
+    }
+
+    /// The M6 suffix implied by `bundle_proposals` and the treasury state the
+    /// suffix will be built against. Split out from
+    /// [`Self::generate_suffix_txs`] so the payout rules are exercisable without
+    /// a validator or a DB.
+    ///
+    /// Infallible by construction: a bundle that cannot be paid out is skipped,
+    /// never fatal. The suffix is the *rest* of a block that is being built, so
+    /// refusing to produce one over a single unpayable bundle stops the node
+    /// from producing blocks at all -- and only a connected block can retire the
+    /// bundle that is blocking it.
+    fn suffix_txs_for_proposals(
+        bundle_proposals: HashMap<SidechainNumber, BundleProposals>,
+        ctips: &HashMap<SidechainNumber, Ctip>,
+        thresholds: &Thresholds,
+    ) -> Vec<Transaction> {
         let mut res = Vec::new();
-        for (sidechain_id, m6ids) in self.get_bundle_proposals().await? {
+        for (sidechain_id, m6ids) in bundle_proposals {
             let mut ctip = None;
-            for (_m6id, blinded_m6, m6id_info) in m6ids {
+            for (m6id, blinded_m6, m6id_info) in m6ids {
                 let Some(m6id_info) = m6id_info else { continue };
-                if m6id_info.vote_count > thresholds.withdrawal_bundle_inclusion_threshold {
-                    let current_ctip = if let Some(ctip) = ctip {
-                        ctip
-                    } else {
-                        *ctips
-                            .get(&sidechain_id)
-                            .ok_or_else(|| error::GenerateSuffixTxs::MissingCtip { sidechain_id })?
-                    };
-                    let (m6, successor_ctip) =
-                        Self::finalize_m6(sidechain_id, current_ctip, blinded_m6)?;
-                    ctip = Some(successor_ctip);
-                    res.push(m6);
+                if m6id_info.vote_count <= thresholds.withdrawal_bundle_inclusion_threshold {
+                    continue;
                 }
+                let current_ctip = if let Some(ctip) = ctip {
+                    ctip
+                } else if let Some(ctip) = ctips.get(&sidechain_id) {
+                    *ctip
+                } else {
+                    // An approved bundle for a sidechain with no treasury has
+                    // nothing to spend, so it cannot be paid out. Skip the
+                    // sidechain and let the bundle age out instead. Failing here
+                    // would abort the entire suffix, so one unpayable bundle
+                    // would take every other sidechain's payouts -- and this
+                    // node's block production -- down with it, and no block
+                    // could ever connect to retire the bundle.
+                    tracing::warn!(
+                        %sidechain_id,
+                        %m6id,
+                        "skipping an approved withdrawal bundle: sidechain has no CTIP"
+                    );
+                    break;
+                };
+                // A bundle that pays out more than the treasury holds can never
+                // be included -- the only way finalizing it can fail. Skip just
+                // this bundle and let it age out: a smaller one behind it is
+                // still payable. (The missing-CTIP arm `break`s instead, but
+                // only to warn once per sidechain -- with no treasury nothing
+                // behind it could pay out either, so the output is the same.)
+                let (fee, payout) = (*blinded_m6.fee(), *blinded_m6.payout());
+                let Ok((m6, successor_ctip)) =
+                    Self::finalize_m6(sidechain_id, current_ctip, blinded_m6)
+                else {
+                    tracing::warn!(
+                        %sidechain_id,
+                        %m6id,
+                        %fee,
+                        %payout,
+                        treasury = %current_ctip.value,
+                        "skipping an approved withdrawal bundle: payout and fee exceed the treasury"
+                    );
+                    continue;
+                };
+                ctip = Some(successor_ctip);
+                res.push(m6);
             }
         }
-        Ok(res)
+        res
     }
 }
 
@@ -414,10 +473,11 @@ mod tests {
     };
 
     use crate::{
-        block_producer::BlockProducer,
+        block_producer::{BlockProducer, BundleProposals},
         types::{
-            AmountUnderflowError, BlindedM6, Ctip, SidechainAck, SidechainDescription,
-            SidechainNumber, SidechainProposal, op_drivechain_script,
+            AmountUnderflowError, BlindedM6, Ctip, PendingM6idInfo, SidechainAck,
+            SidechainDescription, SidechainNumber, SidechainProposal, Thresholds,
+            op_drivechain_script,
         },
     };
 
@@ -426,6 +486,161 @@ mod tests {
             sidechain_number,
             description: SidechainDescription(description.to_vec()),
         }
+    }
+
+    const THRESHOLDS: Thresholds = Thresholds::SHORT;
+    const TREASURY_VALUE: Amount = Amount::from_sat(1_000_000);
+    const FEE_SATS: u64 = 1_000;
+    const PAYOUT: Amount = Amount::from_sat(50_000);
+
+    /// A single bundle proposal with enough votes to be paid out.
+    fn approved_bundle() -> BundleProposals {
+        approved_bundle_paying(PAYOUT)
+    }
+
+    /// [`approved_bundle`], for a chosen payout. Distinct payouts give distinct
+    /// m6ids, so several can be pending for one sidechain at once.
+    fn approved_bundle_paying(payout: Amount) -> BundleProposals {
+        let fee_output = TxOut {
+            value: Amount::ZERO,
+            script_pubkey: Builder::new()
+                .push_opcode(OP_RETURN)
+                .push_slice(FEE_SATS.to_be_bytes())
+                .into_script(),
+        };
+        let payout_output = TxOut {
+            value: payout,
+            script_pubkey: ScriptBuf::from_bytes([vec![0x00, 0x14], vec![0x11; 20]].concat()),
+        };
+        let tx = bitcoin::Transaction {
+            version: Version::TWO,
+            lock_time: LockTime::ZERO,
+            input: Vec::new(), // a blinded M6 has no inputs
+            output: vec![fee_output, payout_output],
+        };
+        let blinded_m6 = BlindedM6::try_from(Cow::Owned(tx))
+            .expect("test fixture is not a valid blinded M6")
+            .into_owned();
+        let info = PendingM6idInfo {
+            vote_count: THRESHOLDS.withdrawal_bundle_inclusion_threshold + 1,
+            proposal_height: 1,
+        };
+        vec![(blinded_m6.compute_m6id(), blinded_m6, Some(info))]
+    }
+
+    fn ctip(byte: u8) -> Ctip {
+        Ctip {
+            outpoint: OutPoint {
+                txid: Txid::from_byte_array([byte; 32]),
+                vout: 0,
+            },
+            value: TREASURY_VALUE,
+        }
+    }
+
+    /// A bundle whose sidechain has no treasury cannot be paid out, but it must
+    /// not stop the block: erroring out here aborts the whole suffix, which
+    /// wedges block production entirely (and then no block can connect to retire
+    /// the offending bundle).
+    #[test]
+    fn suffix_txs_skip_a_sidechain_without_a_ctip() {
+        const NO_CTIP: SidechainNumber = SidechainNumber(0);
+        const WITH_CTIP: SidechainNumber = SidechainNumber(1);
+        let bundle_proposals =
+            HashMap::from_iter([(NO_CTIP, approved_bundle()), (WITH_CTIP, approved_bundle())]);
+        let ctips = HashMap::from_iter([(WITH_CTIP, ctip(1))]);
+
+        let suffix_txs =
+            BlockProducer::suffix_txs_for_proposals(bundle_proposals, &ctips, &THRESHOLDS);
+
+        // The payable sidechain still gets its M6, spending its own CTIP.
+        assert_eq!(suffix_txs.len(), 1);
+        assert_eq!(
+            suffix_txs[0]
+                .input
+                .first()
+                .expect("an M6 spends the treasury")
+                .previous_output,
+            ctip(1).outpoint
+        );
+    }
+
+    /// The same, with nothing left to pay out: an empty suffix, not an error.
+    #[test]
+    fn suffix_txs_are_empty_when_no_sidechain_has_a_ctip() {
+        let bundle_proposals = HashMap::from_iter([(SidechainNumber(0), approved_bundle())]);
+        let suffix_txs =
+            BlockProducer::suffix_txs_for_proposals(bundle_proposals, &HashMap::new(), &THRESHOLDS);
+        assert!(suffix_txs.is_empty());
+    }
+
+    /// A bundle whose payout and fee exceed the treasury can never be included
+    /// -- an M6 spending more than the CTIP is consensus-invalid -- so it is
+    /// skipped *alone*, rather than aborting the suffix: the payable bundles
+    /// around it still go through, and the one behind it chains onto the CTIP
+    /// the one before it advanced.
+    #[test]
+    fn suffix_txs_skip_only_the_bundle_exceeding_the_treasury() {
+        const SIDECHAIN: SidechainNumber = SidechainNumber(0);
+        const SECOND_PAYOUT: Amount = Amount::from_sat(30_000);
+        // Payable against the treasury the block starts with, but not against
+        // what remains of it once the first bundle is paid: skipping has to be
+        // judged against the advanced CTIP, not the initial one.
+        let overdrawing_payout = TREASURY_VALUE - PAYOUT;
+        let mut bundles = approved_bundle_paying(PAYOUT);
+        bundles.extend(approved_bundle_paying(overdrawing_payout));
+        bundles.extend(approved_bundle_paying(SECOND_PAYOUT));
+        let bundle_proposals = HashMap::from_iter([(SIDECHAIN, bundles)]);
+        let ctips = HashMap::from_iter([(SIDECHAIN, ctip(0))]);
+
+        let suffix_txs =
+            BlockProducer::suffix_txs_for_proposals(bundle_proposals, &ctips, &THRESHOLDS);
+
+        let [first_m6, second_m6] = suffix_txs.as_slice() else {
+            panic!("expected exactly the two payable M6s, got {suffix_txs:?}");
+        };
+        let fee = Amount::from_sat(FEE_SATS);
+        // The first payable bundle spends the initial CTIP and leaves the
+        // reduced treasury at vout 0, as BIP300 M6 requires.
+        assert_eq!(
+            first_m6
+                .input
+                .first()
+                .expect("an M6 spends the treasury")
+                .previous_output,
+            ctip(0).outpoint
+        );
+        let advanced_treasury = TREASURY_VALUE - PAYOUT - fee;
+        assert_eq!(first_m6.output[0].value, advanced_treasury);
+        assert!(
+            first_m6.output.iter().any(|output| output.value == PAYOUT),
+            "the first surviving M6 is not the first payable bundle: {first_m6:?}"
+        );
+        // The skip leaves the advanced CTIP intact: the second payable bundle
+        // chains directly onto the first M6's treasury output, untouched by the
+        // overdrawing bundle between them.
+        assert_eq!(
+            second_m6
+                .input
+                .first()
+                .expect("an M6 spends the treasury")
+                .previous_output,
+            OutPoint {
+                txid: first_m6.compute_txid(),
+                vout: 0,
+            }
+        );
+        assert_eq!(
+            second_m6.output[0].value,
+            advanced_treasury - SECOND_PAYOUT - fee
+        );
+        assert!(
+            second_m6
+                .output
+                .iter()
+                .any(|output| output.value == SECOND_PAYOUT),
+            "the second surviving M6 is not the second payable bundle: {second_m6:?}"
+        );
     }
 
     #[test]

--- a/lib/block_producer/error.rs
+++ b/lib/block_producer/error.rs
@@ -7,7 +7,6 @@ use crate::{
     errors::ErrorChain,
     messages::CoinbaseMessagesError,
     proto::{StatusBuilder, ToStatus},
-    types::SidechainNumber,
     validator::Validator,
 };
 
@@ -90,26 +89,6 @@ impl ToStatus for GenerateCoinbaseTxouts {
             Self::GetSidechains(err) => err.builder(),
             Self::PushBytes(err) => StatusBuilder::new(err),
             Self::Rusqlite(_) => StatusBuilder::new(self),
-        }
-    }
-}
-
-#[derive(Debug, Diagnostic, Error)]
-pub enum GenerateSuffixTxs {
-    #[error(transparent)]
-    GetBundleProposals(#[from] GetBundleProposals),
-    #[error(transparent)]
-    M6(#[from] crate::types::AmountUnderflowError),
-    #[error("Missing ctip for sidechain {sidechain_id}")]
-    MissingCtip { sidechain_id: SidechainNumber },
-}
-
-impl ToStatus for GenerateSuffixTxs {
-    fn builder(&self) -> StatusBuilder<'_> {
-        match self {
-            Self::GetBundleProposals(err) => err.builder(),
-            Self::M6(err) => err.builder(),
-            Self::MissingCtip { .. } => StatusBuilder::new(self),
         }
     }
 }
@@ -205,7 +184,7 @@ impl ToStatus for GetBlockTemplate {
 #[derive(Debug, Diagnostic, Error)]
 pub enum SelectBlockTxs {
     #[error(transparent)]
-    GenerateSuffixTxs(#[from] GenerateSuffixTxs),
+    GenerateSuffixTxs(#[from] GetBundleProposals),
     #[error(transparent)]
     GetBlockTemplate(#[from] GetBlockTemplate),
     #[error(transparent)]
@@ -500,7 +479,7 @@ pub(in crate::block_producer) enum InitialBlockTemplateInner {
     #[error(transparent)]
     GenerateCoinbaseTxouts(#[from] GenerateCoinbaseTxouts),
     #[error(transparent)]
-    GenerateSuffixTxs(#[from] GenerateSuffixTxs),
+    GenerateSuffixTxs(#[from] GetBundleProposals),
     #[error("Failed to read the ACK-all-proposals setting")]
     GetAckAllProposals(#[source] rusqlite::Error),
     #[error("the `coinbasetxn` GBT capability is required")]
@@ -530,7 +509,7 @@ pub(in crate::block_producer) enum FinalizeBlockTemplateInner {
     #[error("Failed to generate coinbase txouts suffix")]
     GenerateSuffixCoinbaseTxouts(#[source] bitcoin::script::PushBytesError),
     #[error(transparent)]
-    GenerateSuffixTxs(#[from] GenerateSuffixTxs),
+    GenerateSuffixTxs(#[from] GetBundleProposals),
     #[error(transparent)]
     GetCtipsAfter(#[from] crate::validator::cusf_enforcer::GetCtipsAfterError),
     #[error(transparent)]

--- a/lib/server/wallet/grpc.rs
+++ b/lib/server/wallet/grpc.rs
@@ -114,8 +114,8 @@ impl WalletService for crate::wallet::Wallet {
         // treasury UTXO there is nothing for an M6 to spend, so the bundle could
         // never become a valid withdrawal. NB: as with the active-slot gate
         // above, this cannot cover a CTIP that a reorg removes *after* a bundle
-        // is stored. In that state block building fails with `MissingCtip` once
-        // the bundle clears the inclusion threshold.
+        // is stored. In that state the block producer skips the bundle when
+        // building the M6 suffix and it ages out unpaid.
         match self.validator().try_get_ctip(sidechain_id) {
             Ok(None) => {
                 return Err(ConnectError::failed_precondition(format!(

--- a/lib/wallet/error.rs
+++ b/lib/wallet/error.rs
@@ -8,8 +8,8 @@ use serde::Deserialize;
 use thiserror::Error;
 
 pub use crate::block_producer::error::{
-    BitcoinCoreRPC, FinalizeBlockTemplate, GenerateCoinbaseTxouts, GenerateSuffixTxs,
-    GetBundleProposals, InitDbConnection, InitialBlockTemplate,
+    BitcoinCoreRPC, FinalizeBlockTemplate, GenerateCoinbaseTxouts, GetBundleProposals,
+    InitDbConnection, InitialBlockTemplate,
 };
 use crate::{
     proto::{StatusBuilder, ToStatus},


### PR DESCRIPTION
Bundles with no treasury, or bundles with payouts bigger than the treasury, would halt block production until the bundle expired. Skip them instead!