### PR TITLE
Simplified BMM bids as high fee TXs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -656,7 +656,7 @@ dependencies = [
 [[package]]
 name = "bitcoin-jsonrpsee"
 version = "0.1.1"
-source = "git+https://github.com/LayerTwo-Labs/bitcoin-jsonrpsee.git?rev=cb6c0dbd21a069b5481eedb0268832df28a5aaf1#cb6c0dbd21a069b5481eedb0268832df28a5aaf1"
+source = "git+https://github.com/LayerTwo-Labs/bitcoin-jsonrpsee.git?rev=d32ba93d497c644394877aaa2a9f25185e7fca48#d32ba93d497c644394877aaa2a9f25185e7fca48"
 dependencies = [
  "base64 0.23.0",
  "bitcoin",
@@ -1156,7 +1156,7 @@ dependencies = [
 [[package]]
 name = "cusf-enforcer-mempool"
 version = "0.4.0"
-source = "git+https://github.com/LayerTwo-Labs/cusf-enforcer-mempool.git?rev=cf025dd6fda6d8c6026a9e33b5ef9ff0e07b6ac3#cf025dd6fda6d8c6026a9e33b5ef9ff0e07b6ac3"
+source = "git+https://github.com/LayerTwo-Labs/cusf-enforcer-mempool.git?rev=b5fc29e6b20baf4e10d4a295a3eff860bb4c50b9#b5fc29e6b20baf4e10d4a295a3eff860bb4c50b9"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,11 +90,11 @@ zeroize = "1.8.2"
 
 [workspace.dependencies.bitcoin-jsonrpsee]
 git = "https://github.com/LayerTwo-Labs/bitcoin-jsonrpsee.git"
-rev = "cb6c0dbd21a069b5481eedb0268832df28a5aaf1"
+rev = "d32ba93d497c644394877aaa2a9f25185e7fca48"
 
 [workspace.dependencies.cusf-enforcer-mempool]
 git = "https://github.com/LayerTwo-Labs/cusf-enforcer-mempool.git"
-rev = "cf025dd6fda6d8c6026a9e33b5ef9ff0e07b6ac3"
+rev = "b5fc29e6b20baf4e10d4a295a3eff860bb4c50b9"
 
 [workspace.dependencies.educe]
 version = "0.7.4"

--- a/integration_tests/integration_test.rs
+++ b/integration_tests/integration_test.rs
@@ -26,7 +26,8 @@ use crate::{
         Directories, DummySidechain, MiningMode, Mode, Network, PostSetup, PreSetup, Sidechain,
         wait_for_pending_proposal, wait_for_tx_in_mempool,
     },
-    test_peer_bmm_request, test_unconfirmed_transactions, test_zmq_sequence_gap,
+    test_bmm_bid_auction, test_peer_bmm_request, test_unconfirmed_transactions,
+    test_zmq_sequence_gap,
     util::{AsyncTrial, BinPaths, FileDumpConfig, TestFailureCollector, TestFileRegistry},
 };
 
@@ -927,6 +928,22 @@ pub fn tests(
         test_zmq_sequence_gap::test_zmq_sequence_gap,
     ));
     async_trials.push(peer_bmm_request_trial);
+    // Competing BMM bids, in both block production modes: the enforcer's own
+    // template server (GetBlockTemplate) and `GenerateToAddress` self-mining
+    // (Mempool).
+    async_trials.extend([Mode::GetBlockTemplate, Mode::Mempool].map(|mode| {
+        new_trial_with_setup(
+            format!("bmm_bid_auction (mode: {mode})"),
+            TestSetupComponents {
+                bin_paths: bin_paths.clone(),
+                network: Network::Regtest,
+                mode,
+                file_registry: file_registry.clone(),
+                failure_collector: failure_collector.clone(),
+            },
+            test_bmm_bid_auction::test_bmm_bid_auction,
+        )
+    }));
     async_trials.push(new_trial_with_setup_opts(
         "activation_height".to_string(),
         TestSetupComponents {

--- a/integration_tests/lib.rs
+++ b/integration_tests/lib.rs
@@ -6,6 +6,7 @@ pub mod setup;
 pub mod signet_chain_params;
 mod test_activation_height;
 mod test_blinded_m6_roundtrip;
+mod test_bmm_bid_auction;
 mod test_consecutive_deposits;
 mod test_file_based_block_parser;
 mod test_generate_to_address;

--- a/integration_tests/test_bmm_bid_auction.rs
+++ b/integration_tests/test_bmm_bid_auction.rs
@@ -1,0 +1,695 @@
+//! Competing BMM bids must resolve to one M7 accept per slot, with the
+//! highest bid winning, losers excluded from the block, stale requests kept
+//! out of later blocks, and losing bids evicted from the enforcer wallet.
+//!
+//! The enforcer wallet places at most one bid per tip: a second unconfirmed
+//! bid from the same BDK wallet either chains onto or conflicts with the
+//! first, depending on coin selection. Competing bids are crafted through
+//! Bitcoin Core's wallet from explicitly chosen mature UTXOs instead.
+
+use bip300301_enforcer_lib::{
+    bins::CommandExt,
+    messages::{CoinbaseMessage, M7BmmAccept, M8BmmRequest},
+    proto::{
+        self,
+        common::{ConsensusHex, ReverseHex},
+        mainchain::{
+            BlockHeaderInfo, CreateBmmCriticalDataTransactionRequest, GetChainTipRequest,
+            GetSidechainsRequest, ListUnspentOutputsRequest,
+        },
+    },
+    types::{BmmCommitment, SidechainNumber},
+};
+use bitcoin::{Amount, BlockHash, OutPoint, Txid, hashes::Hash as _};
+use buffa::MessageField;
+
+use crate::{
+    integration_test::{
+        fund_enforcer, propose_sidechain, propose_sidechain_for_slot, wait_for_wallet_sync,
+    },
+    mine::mine_check_block_events,
+    setup::{DummySidechain, Mode, PostSetup, Sidechain, wait_for_tx_in_mempool, wait_until},
+};
+
+const OTHER_SLOT: SidechainNumber = SidechainNumber(1);
+
+const LOW_BID: u64 = 2_000;
+const HIGH_BID: u64 = 25_000;
+const OTHER_SLOT_BID: u64 = 7_000;
+const LOSING_BID: u64 = 10_000;
+const OUTSIDE_BID: u64 = 40_000;
+/// Must exceed [`LOSING_BID`]: if coin selection reuses the freed UTXO while
+/// the lost bid still sits in Bitcoin Core's mempool, the broadcast has to be
+/// a valid RBF replacement.
+const REBID: u64 = 25_000;
+/// Far above Bitcoin Core's default RPC fee-rate cap (0.10 BTC/kvB, about
+/// 1.5M sats on a bid-sized transaction): the bid is a deliberate fee, so it
+/// must broadcast anyway.
+const JUMBO_BID: u64 = 5_000_000;
+/// More than the wallet holds, so bid creation must fail cleanly.
+const ABSURD_BID: u64 = 21_000_000 * 100_000_000;
+/// Round 5 pits fee rate against absolute fee: the small bid has the higher
+/// fee rate, the padded bid the higher absolute fee. The bid is the absolute
+/// fee, so the padded bid must win.
+const SMALL_HIGH_FEERATE_BID: u64 = 15_000;
+const BIG_LOW_FEERATE_BID: u64 = 30_000;
+/// Inflates the big bid to roughly 10x the small bid's size, putting its fee
+/// rate well below the small bid's.
+const BIG_BID_PAD_OUTPUTS: usize = 40;
+
+fn h_star(label: &str) -> [u8; 32] {
+    bitcoin::hashes::sha256::Hash::hash(label.as_bytes()).to_byte_array()
+}
+
+/// The validator's chain tip: the proto hash (for `prev_bytes`), the decoded
+/// hash, and the height.
+async fn chain_tip(post_setup: &mut PostSetup) -> anyhow::Result<(ReverseHex, BlockHash, u32)> {
+    let header_info = post_setup
+        .validator_service_client
+        .get_chain_tip(GetChainTipRequest::default())
+        .await?
+        .into_owned()
+        .block_header_info
+        .into_option()
+        .ok_or_else(|| anyhow::anyhow!("expected `block_header_info` in GetChainTipResponse"))?;
+    let height = header_info.height;
+    let proto_hash = header_info
+        .block_hash
+        .into_option()
+        .ok_or_else(|| anyhow::anyhow!("expected `block_hash` in BlockHeaderInfo"))?;
+    let hash: BlockHash = proto_hash
+        .clone()
+        .decode::<BlockHeaderInfo, _>("block_hash")?;
+    Ok((proto_hash, hash, height))
+}
+
+/// Create a BMM request via the enforcer wallet gRPC, returning its txid.
+async fn create_wallet_bid(
+    post_setup: &mut PostSetup,
+    slot: SidechainNumber,
+    bid_sats: u64,
+    h_star: &[u8; 32],
+    prev_bytes: ReverseHex,
+    tip_height: u32,
+) -> anyhow::Result<Txid> {
+    let txid = post_setup
+        .wallet_service_client
+        .create_bmm_critical_data_transaction(CreateBmmCriticalDataTransactionRequest {
+            sidechain_id: proto::wrap_u32(slot.0.into()),
+            value_sats: proto::wrap_u64(bid_sats),
+            height: proto::wrap_u32(tip_height),
+            critical_hash: MessageField::some(ConsensusHex::encode(h_star)),
+            prev_bytes: MessageField::some(prev_bytes),
+        })
+        .await?
+        .into_owned()
+        .txid
+        .into_option()
+        .and_then(|txid| proto::unwrap_string(txid.hex))
+        .ok_or_else(|| anyhow::anyhow!("expected `txid` in CreateBmmCriticalDataTransaction"))?
+        .parse::<Txid>()?;
+    let () = wait_for_tx_in_mempool(&post_setup.bitcoin_cli, &txid).await?;
+    Ok(txid)
+}
+
+/// Craft an M8 bid through Bitcoin Core's wallet: one explicitly chosen
+/// mature UTXO in, the M8 OP_RETURN at output zero, change back, the bid as
+/// the exact absolute fee. No coin selection, so crafted bids never chain
+/// onto unconfirmed change or touch earlier bids' UTXOs. `pad_outputs` extra
+/// change outputs inflate the transaction's size, lowering its fee rate
+/// without touching the bid.
+async fn craft_core_bid(
+    post_setup: &PostSetup,
+    slot: SidechainNumber,
+    bid_sats: u64,
+    h_star: &[u8; 32],
+    prev_hash: BlockHash,
+    pad_outputs: usize,
+) -> anyhow::Result<Txid> {
+    let unspent_json = post_setup
+        .bitcoin_cli
+        .command::<String, _, _, _, _>([], "listunspent", ["100".to_owned()])
+        .run_utf8()
+        .await?;
+    let unspent: serde_json::Value = serde_json::from_str(&unspent_json)?;
+    let utxo = unspent
+        .as_array()
+        .into_iter()
+        .flatten()
+        .find(|utxo| {
+            utxo["spendable"].as_bool() == Some(true)
+                && utxo["amount"].as_f64().is_some_and(|amount| amount >= 1.0)
+        })
+        .ok_or_else(|| anyhow::anyhow!("no mature Core wallet UTXO available for a crafted bid"))?;
+    let utxo_txid = utxo["txid"]
+        .as_str()
+        .ok_or_else(|| anyhow::anyhow!("listunspent entry without txid"))?;
+    let utxo_vout = utxo["vout"]
+        .as_u64()
+        .ok_or_else(|| anyhow::anyhow!("listunspent entry without vout"))?;
+    let utxo_value = Amount::from_btc(
+        utxo["amount"]
+            .as_f64()
+            .ok_or_else(|| anyhow::anyhow!("listunspent entry without amount"))?,
+    )?;
+    const PAD_OUTPUT_SATS: u64 = 10_000;
+    let change = utxo_value - Amount::from_sat(bid_sats + pad_outputs as u64 * PAD_OUTPUT_SATS);
+    // `createrawtransaction` rejects duplicated addresses across outputs, so
+    // every output needs its own.
+    let mut addresses = Vec::with_capacity(pad_outputs + 1);
+    for _ in 0..=pad_outputs {
+        addresses.push(
+            post_setup
+                .bitcoin_cli
+                .command::<String, _, String, _, _>([], "getnewaddress", [])
+                .run_utf8()
+                .await?
+                .trim()
+                .to_owned(),
+        );
+    }
+
+    let payload = M8BmmRequest::data(slot, BmmCommitment(*h_star), prev_hash)?;
+    let inputs = serde_json::json!([{"txid": utxo_txid, "vout": utxo_vout}]).to_string();
+    let outputs = {
+        let change_output = |address: &str, sats: Amount| {
+            let mut output = serde_json::Map::new();
+            output.insert(
+                address.to_owned(),
+                serde_json::Value::String(format!("{:.8}", sats.to_btc())),
+            );
+            serde_json::Value::Object(output)
+        };
+        let mut outputs = vec![serde_json::json!({"data": hex::encode(payload.as_bytes())})];
+        let (change_addr, pad_addrs) = addresses
+            .split_first()
+            .expect("addresses is never empty by construction");
+        outputs.push(change_output(change_addr, change));
+        outputs.extend(
+            pad_addrs
+                .iter()
+                .map(|addr| change_output(addr, Amount::from_sat(PAD_OUTPUT_SATS))),
+        );
+        serde_json::Value::Array(outputs).to_string()
+    };
+    let raw = post_setup
+        .bitcoin_cli
+        .command::<String, _, _, _, _>([], "createrawtransaction", [inputs, outputs])
+        .run_utf8()
+        .await?;
+    let signed_json = post_setup
+        .bitcoin_cli
+        .command::<String, _, _, _, _>([], "signrawtransactionwithwallet", [raw.trim().to_owned()])
+        .run_utf8()
+        .await?;
+    let signed: serde_json::Value = serde_json::from_str(&signed_json)?;
+    anyhow::ensure!(
+        signed["complete"].as_bool() == Some(true),
+        "failed to sign crafted bid: {signed}"
+    );
+    let signed_hex = signed["hex"]
+        .as_str()
+        .ok_or_else(|| anyhow::anyhow!("signrawtransactionwithwallet returned no hex"))?;
+    let txid = post_setup
+        .bitcoin_cli
+        .command::<String, _, _, _, _>([], "sendrawtransaction", [signed_hex.to_owned()])
+        .run_utf8()
+        .await?
+        .trim()
+        .parse::<Txid>()?;
+    Ok(txid)
+}
+
+async fn get_raw_transaction(
+    post_setup: &PostSetup,
+    txid: &Txid,
+) -> anyhow::Result<bitcoin::Transaction> {
+    let tx_hex = post_setup
+        .bitcoin_cli
+        .command::<String, _, _, _, _>([], "getrawtransaction", [txid.to_string()])
+        .run_utf8()
+        .await?;
+    let tx = bitcoin::consensus::deserialize(&hex::decode(tx_hex.trim())?)?;
+    Ok(tx)
+}
+
+async fn get_block(
+    post_setup: &PostSetup,
+    block_hash: &BlockHash,
+) -> anyhow::Result<bitcoin::Block> {
+    let block_hex = post_setup
+        .bitcoin_cli
+        .command::<String, _, _, _, _>([], "getblock", [block_hash.to_string(), "0".to_string()])
+        .run_utf8()
+        .await?;
+    let block = bitcoin::consensus::deserialize(&hex::decode(block_hex.trim())?)?;
+    Ok(block)
+}
+
+/// All M7 BMM accepts in a block's coinbase.
+fn coinbase_m7_accepts(block: &bitcoin::Block) -> anyhow::Result<Vec<M7BmmAccept>> {
+    let coinbase = block
+        .txdata
+        .first()
+        .ok_or_else(|| anyhow::anyhow!("block {} has no coinbase", block.block_hash()))?;
+    Ok(coinbase
+        .output
+        .iter()
+        .filter_map(|txout| match CoinbaseMessage::parse(&txout.script_pubkey) {
+            Ok((_rest, CoinbaseMessage::M7BmmAccept(m7))) => Some(m7),
+            _ => None,
+        })
+        .collect())
+}
+
+/// Wait until the enforcer's block template selects all of `want` and none
+/// of `not_want`. `Mode::GetBlockTemplate` only; the mempool mirror trails
+/// bitcoind's mempool, so this must gate mining on the bids.
+async fn wait_for_template_txs(
+    post_setup: &PostSetup,
+    want: Vec<Txid>,
+    not_want: Vec<Txid>,
+) -> anyhow::Result<()> {
+    use cusf_enforcer_mempool::server::RpcClient as _;
+    let gbt_client = post_setup.gbt_client.clone();
+    wait_until(
+        "enforcer block template to settle the BMM auction",
+        move || {
+            let gbt_client = gbt_client.clone();
+            let want = want.clone();
+            let not_want = not_want.clone();
+            async move {
+                let mut gbt_request = bitcoin_jsonrpsee::client::BlockTemplateRequest::default();
+                gbt_request.capabilities.insert("coinbasetxn".to_owned());
+                let template = gbt_client.get_block_template(gbt_request).await?;
+                let txids: Vec<Txid> = template.transactions.iter().map(|tx| tx.txid).collect();
+                Ok(want.iter().all(|txid| txids.contains(txid))
+                    && not_want.iter().all(|txid| !txids.contains(txid)))
+            }
+        },
+    )
+    .await
+}
+
+/// Wait until every one of `outpoints` shows up in the enforcer wallet's
+/// unspent set. A losing bid's inputs must be freed once the auction block
+/// evicts the bid, not stay locked behind an unconfirmable transaction.
+async fn wait_for_outpoints_unspent(
+    post_setup: &PostSetup,
+    outpoints: Vec<OutPoint>,
+) -> anyhow::Result<()> {
+    let wallet_service_client = post_setup.wallet_service_client.clone();
+    wait_until(
+        "the losing bid's inputs to be freed in the wallet",
+        move || {
+            let wallet_service_client = wallet_service_client.clone();
+            let outpoints = outpoints.clone();
+            async move {
+                let unspent = wallet_service_client
+                    .clone()
+                    .list_unspent_outputs(ListUnspentOutputsRequest::default())
+                    .await?
+                    .into_owned()
+                    .outputs;
+                Ok(outpoints.iter().all(|outpoint| {
+                    unspent.iter().any(|output| {
+                        output.txid.clone().into_option()
+                            == Some(ReverseHex::encode(&outpoint.txid))
+                            && output.vout == outpoint.vout
+                    })
+                }))
+            }
+        },
+    )
+    .await
+}
+
+/// Regtest halves the 50 BTC subsidy every 150 blocks.
+fn regtest_subsidy(height: u32) -> Amount {
+    Amount::from_sat((50 * Amount::ONE_BTC.to_sat()) >> (height / 150))
+}
+
+/// Mine one block, asserting the slot-0 BMM commitment its block event
+/// reports, and return the block with its height.
+async fn mine_and_check_commitment(
+    post_setup: &mut PostSetup,
+    expected_commitment: Option<&[u8; 32]>,
+) -> anyhow::Result<(bitcoin::Block, u32)> {
+    let () = mine_check_block_events::<_, DummySidechain>(post_setup, 1, None, |_, block_info| {
+        let bmm_commitment = block_info.bmm_commitment.into_option();
+        match expected_commitment {
+            Some(h_star) => anyhow::ensure!(
+                bmm_commitment == Some(ConsensusHex::encode(h_star)),
+                "expected the slot 0 BMM commitment to be the auction winner's"
+            ),
+            None => anyhow::ensure!(
+                bmm_commitment.is_none(),
+                "expected no slot 0 BMM commitment in this block"
+            ),
+        }
+        Ok(())
+    })
+    .await?;
+    let (_, block_hash, height) = chain_tip(post_setup).await?;
+    let block = get_block(post_setup, &block_hash).await?;
+    Ok((block, height))
+}
+
+fn block_txids(block: &bitcoin::Block) -> Vec<Txid> {
+    block.txdata.iter().map(|tx| tx.compute_txid()).collect()
+}
+
+fn coinbase_value(block: &bitcoin::Block) -> Amount {
+    block.txdata[0].output.iter().map(|txout| txout.value).sum()
+}
+
+/// * Round 1: the enforcer outbids a crafted bid on slot 0 while a lone
+///   crafted bid takes slot 1; one block settles both slots, excludes the
+///   loser, and (self-mining mode) collects the winning bids as fees
+/// * The stale losing bid stays out of the next block
+/// * Round 2: a crafted outside bid outbids the enforcer's own bid, and the
+///   losing bid's inputs are freed in the wallet
+/// * Round 3: the enforcer re-bids at the next tip and wins
+/// * Round 4: a bid above the wallet balance fails cleanly, then a bid above
+///   Bitcoin Core's default RPC fee-rate cap broadcasts and wins
+/// * Round 5: a large bid with the higher absolute fee beats a small bid
+///   with the higher fee rate
+pub async fn test_bmm_bid_auction(mut post_setup: PostSetup) -> anyhow::Result<()> {
+    let mode = post_setup.mode;
+
+    // Both proposals are pending before the acking blocks are mined, so both
+    // slots cross the activation threshold together.
+    let () = propose_sidechain::<DummySidechain>(&mut post_setup).await?;
+    let () = propose_sidechain_for_slot::<DummySidechain>(&mut post_setup, OTHER_SLOT).await?;
+    let () =
+        mine_check_block_events::<_, DummySidechain>(&mut post_setup, 6, Some(true), |_, _| Ok(()))
+            .await?;
+    let sidechains = post_setup
+        .validator_service_client
+        .get_sidechains(GetSidechainsRequest::default())
+        .await?
+        .into_owned()
+        .sidechains;
+    anyhow::ensure!(
+        sidechains.len() == 2,
+        "expected both sidechain slots active, got {}",
+        sidechains.len()
+    );
+    let () = fund_enforcer::<DummySidechain>(&mut post_setup).await?;
+    // The crafted bids spend from Core's wallet, which the served coinbases
+    // do not pay in GetBlockTemplate mode. 105 blocks leaves a few mature
+    // coinbases at the first auction tip.
+    let core_addr = post_setup
+        .bitcoin_cli
+        .command::<String, _, String, _, _>([], "getnewaddress", [])
+        .run_utf8()
+        .await?
+        .trim()
+        .to_owned();
+    let _mined: String = post_setup
+        .bitcoin_cli
+        .command::<String, _, _, _, _>([], "generatetoaddress", ["105".to_owned(), core_addr])
+        .run_utf8()
+        .await?;
+    let () = wait_for_wallet_sync(&mut post_setup).await?;
+    tracing::info!("Activated both sidechains and funded both wallets");
+
+    let h_high = h_star("round 1 winning bid");
+    let h_low = h_star("round 1 losing bid");
+    let h_other = h_star("round 1 other slot bid");
+    let (prev_bytes, prev_hash, tip_height) = chain_tip(&mut post_setup).await?;
+    let high_txid = create_wallet_bid(
+        &mut post_setup,
+        DummySidechain::SIDECHAIN_NUMBER,
+        HIGH_BID,
+        &h_high,
+        prev_bytes,
+        tip_height,
+    )
+    .await?;
+    let low_txid = craft_core_bid(
+        &post_setup,
+        DummySidechain::SIDECHAIN_NUMBER,
+        LOW_BID,
+        &h_low,
+        prev_hash,
+        0,
+    )
+    .await?;
+    let other_txid = craft_core_bid(
+        &post_setup,
+        OTHER_SLOT,
+        OTHER_SLOT_BID,
+        &h_other,
+        prev_hash,
+        0,
+    )
+    .await?;
+    tracing::info!(%high_txid, %low_txid, %other_txid, "Placed round 1 bids");
+    if let Mode::GetBlockTemplate = mode {
+        let () =
+            wait_for_template_txs(&post_setup, vec![high_txid, other_txid], vec![low_txid]).await?;
+    }
+
+    let (auction_block, auction_height) =
+        mine_and_check_commitment(&mut post_setup, Some(&h_high)).await?;
+    let auction_txids = block_txids(&auction_block);
+    anyhow::ensure!(
+        auction_txids.contains(&high_txid) && auction_txids.contains(&other_txid),
+        "the winning bids must be included in the block"
+    );
+    anyhow::ensure!(
+        !auction_txids.contains(&low_txid),
+        "the losing slot 0 bid must not be included in the block"
+    );
+    let m7s = coinbase_m7_accepts(&auction_block)?;
+    anyhow::ensure!(
+        m7s.len() == 2,
+        "expected exactly one M7 accept per bidding slot, got {}",
+        m7s.len()
+    );
+    for (slot, expected_h_star) in [
+        (DummySidechain::SIDECHAIN_NUMBER, h_high),
+        (OTHER_SLOT, h_other),
+    ] {
+        anyhow::ensure!(
+            m7s.iter()
+                .any(|m7| m7.sidechain_number == slot
+                    && m7.sidechain_block_hash.0 == expected_h_star),
+            "missing the expected M7 accept for slot {}",
+            slot.0
+        );
+    }
+    if let Mode::Mempool = mode {
+        let expected =
+            regtest_subsidy(auction_height) + Amount::from_sat(HIGH_BID + OTHER_SLOT_BID);
+        anyhow::ensure!(
+            coinbase_value(&auction_block) == expected,
+            "expected the coinbase to collect the winning bids as fees: \
+             got {}, expected {expected}",
+            coinbase_value(&auction_block)
+        );
+    }
+    tracing::info!("Round 1: auction block settled both slots correctly");
+
+    // The losing bid is now stale, but still sits in Bitcoin Core's mempool.
+    let (empty_block, _) = mine_and_check_commitment(&mut post_setup, None).await?;
+    anyhow::ensure!(
+        !block_txids(&empty_block).contains(&low_txid),
+        "the stale losing bid must not be included in a later block"
+    );
+    anyhow::ensure!(
+        coinbase_m7_accepts(&empty_block)?.is_empty(),
+        "expected no M7 accepts in a block mined without fresh bids"
+    );
+    tracing::info!("Stale losing bid stayed out of the next block");
+
+    let () = wait_for_wallet_sync(&mut post_setup).await?;
+    let h_losing = h_star("round 2 losing bid");
+    let h_outside = h_star("round 2 outside bid");
+    let (prev_bytes, prev_hash, tip_height) = chain_tip(&mut post_setup).await?;
+    let losing_txid = create_wallet_bid(
+        &mut post_setup,
+        DummySidechain::SIDECHAIN_NUMBER,
+        LOSING_BID,
+        &h_losing,
+        prev_bytes,
+        tip_height,
+    )
+    .await?;
+    let losing_bid_inputs: Vec<OutPoint> = get_raw_transaction(&post_setup, &losing_txid)
+        .await?
+        .input
+        .iter()
+        .map(|input| input.previous_output)
+        .collect();
+    let outside_txid = craft_core_bid(
+        &post_setup,
+        DummySidechain::SIDECHAIN_NUMBER,
+        OUTSIDE_BID,
+        &h_outside,
+        prev_hash,
+        0,
+    )
+    .await?;
+    tracing::info!(%losing_txid, %outside_txid, "Placed round 2 bids");
+    if let Mode::GetBlockTemplate = mode {
+        let () = wait_for_template_txs(&post_setup, vec![outside_txid], vec![losing_txid]).await?;
+    }
+
+    let (outside_block, outside_height) =
+        mine_and_check_commitment(&mut post_setup, Some(&h_outside)).await?;
+    let outside_txids = block_txids(&outside_block);
+    anyhow::ensure!(
+        outside_txids.contains(&outside_txid) && !outside_txids.contains(&losing_txid),
+        "the outside bid must win over the miner's own wallet's bid"
+    );
+    anyhow::ensure!(
+        coinbase_m7_accepts(&outside_block)?.len() == 1,
+        "expected exactly one M7 accept in the round 2 block"
+    );
+    if let Mode::Mempool = mode {
+        let expected = regtest_subsidy(outside_height) + Amount::from_sat(OUTSIDE_BID);
+        anyhow::ensure!(
+            coinbase_value(&outside_block) == expected,
+            "expected the coinbase to collect the outside bid as fee: \
+             got {}, expected {expected}",
+            coinbase_value(&outside_block)
+        );
+    }
+    let () = wait_for_outpoints_unspent(&post_setup, losing_bid_inputs.clone()).await?;
+    // The stale bid still sits in Bitcoin Core's mempool, so a chain-source
+    // sync can re-adopt it into the wallet; the eviction must survive the
+    // next sync cycle rather than flip back to locking the inputs.
+    tokio::time::sleep(std::time::Duration::from_secs(20)).await;
+    let () = wait_for_outpoints_unspent(&post_setup, losing_bid_inputs.clone()).await?;
+    // The eviction must also survive a restart: the bid is still in the
+    // wallet DB and in Bitcoin Core's mempool, and the block whose connect
+    // evicted it will not be connected again.
+    let bin_paths = crate::util::BinPaths::new();
+    let (restart_res_tx, _restart_res_rx) = futures::channel::mpsc::unbounded();
+    let () = post_setup
+        .restart_enforcer(&bin_paths, Vec::<String>::new(), restart_res_tx)
+        .await?;
+    let () = wait_for_wallet_sync(&mut post_setup).await?;
+    let () = wait_for_outpoints_unspent(&post_setup, losing_bid_inputs).await?;
+    tracing::info!("Round 2: enforcer's losing bid was evicted, inputs freed");
+
+    let () = wait_for_wallet_sync(&mut post_setup).await?;
+    let h_rebid = h_star("round 3 re-bid");
+    let (prev_bytes, _, tip_height) = chain_tip(&mut post_setup).await?;
+    let rebid_txid = create_wallet_bid(
+        &mut post_setup,
+        DummySidechain::SIDECHAIN_NUMBER,
+        REBID,
+        &h_rebid,
+        prev_bytes,
+        tip_height,
+    )
+    .await?;
+    tracing::info!(%rebid_txid, "Placed round 3 re-bid");
+    if let Mode::GetBlockTemplate = mode {
+        let () = wait_for_template_txs(&post_setup, vec![rebid_txid], vec![]).await?;
+    }
+    let (rebid_block, _) = mine_and_check_commitment(&mut post_setup, Some(&h_rebid)).await?;
+    anyhow::ensure!(
+        block_txids(&rebid_block).contains(&rebid_txid),
+        "the re-bid must be included in the block"
+    );
+    tracing::info!("Round 3: re-bid after losing was committed");
+
+    let () = wait_for_wallet_sync(&mut post_setup).await?;
+    let h_jumbo = h_star("round 4 jumbo bid");
+    let (prev_bytes, _, tip_height) = chain_tip(&mut post_setup).await?;
+    let absurd_bid_result = post_setup
+        .wallet_service_client
+        .create_bmm_critical_data_transaction(CreateBmmCriticalDataTransactionRequest {
+            sidechain_id: proto::wrap_u32(DummySidechain::SIDECHAIN_NUMBER.0.into()),
+            value_sats: proto::wrap_u64(ABSURD_BID),
+            height: proto::wrap_u32(tip_height),
+            critical_hash: MessageField::some(ConsensusHex::encode(&h_jumbo)),
+            prev_bytes: MessageField::some(prev_bytes.clone()),
+        })
+        .await;
+    anyhow::ensure!(
+        absurd_bid_result.is_err(),
+        "a bid exceeding the wallet balance must fail"
+    );
+    let jumbo_txid = create_wallet_bid(
+        &mut post_setup,
+        DummySidechain::SIDECHAIN_NUMBER,
+        JUMBO_BID,
+        &h_jumbo,
+        prev_bytes,
+        tip_height,
+    )
+    .await?;
+    tracing::info!(%jumbo_txid, "Placed round 4 jumbo bid");
+    if let Mode::GetBlockTemplate = mode {
+        let () = wait_for_template_txs(&post_setup, vec![jumbo_txid], vec![]).await?;
+    }
+    let (jumbo_block, jumbo_height) =
+        mine_and_check_commitment(&mut post_setup, Some(&h_jumbo)).await?;
+    anyhow::ensure!(
+        block_txids(&jumbo_block).contains(&jumbo_txid),
+        "the jumbo bid must be included in the block"
+    );
+    if let Mode::Mempool = mode {
+        let expected = regtest_subsidy(jumbo_height) + Amount::from_sat(JUMBO_BID);
+        anyhow::ensure!(
+            coinbase_value(&jumbo_block) == expected,
+            "expected the coinbase to collect the jumbo bid as fee: \
+             got {}, expected {expected}",
+            coinbase_value(&jumbo_block)
+        );
+    }
+    tracing::info!("Round 4: jumbo bid above the default RPC fee cap was committed");
+
+    let h_small = h_star("round 5 small high-feerate bid");
+    let h_big = h_star("round 5 big high-fee bid");
+    let (_, prev_hash, _) = chain_tip(&mut post_setup).await?;
+    let small_txid = craft_core_bid(
+        &post_setup,
+        DummySidechain::SIDECHAIN_NUMBER,
+        SMALL_HIGH_FEERATE_BID,
+        &h_small,
+        prev_hash,
+        0,
+    )
+    .await?;
+    let big_txid = craft_core_bid(
+        &post_setup,
+        DummySidechain::SIDECHAIN_NUMBER,
+        BIG_LOW_FEERATE_BID,
+        &h_big,
+        prev_hash,
+        BIG_BID_PAD_OUTPUTS,
+    )
+    .await?;
+    tracing::info!(%small_txid, %big_txid, "Placed round 5 bids");
+    for txid in [&small_txid, &big_txid] {
+        let () = wait_for_tx_in_mempool(&post_setup.bitcoin_cli, txid).await?;
+    }
+    if let Mode::GetBlockTemplate = mode {
+        let () = wait_for_template_txs(&post_setup, vec![big_txid], vec![small_txid]).await?;
+    }
+    let (skew_block, skew_height) =
+        mine_and_check_commitment(&mut post_setup, Some(&h_big)).await?;
+    let skew_txids = block_txids(&skew_block);
+    anyhow::ensure!(
+        skew_txids.contains(&big_txid) && !skew_txids.contains(&small_txid),
+        "the higher absolute fee must win the slot, not the higher fee rate"
+    );
+    if let Mode::Mempool = mode {
+        let expected = regtest_subsidy(skew_height) + Amount::from_sat(BIG_LOW_FEERATE_BID);
+        anyhow::ensure!(
+            coinbase_value(&skew_block) == expected,
+            "expected the coinbase to collect the big bid as fee: \
+             got {}, expected {expected}",
+            coinbase_value(&skew_block)
+        );
+    }
+    tracing::info!("Round 5: absolute fee beat fee rate for the slot");
+
+    Ok(())
+}

--- a/lib/block_producer/coinbase.rs
+++ b/lib/block_producer/coinbase.rs
@@ -179,8 +179,7 @@ impl BlockProducer {
     }
 
     /// Extend coinbase txouts for a new block with our drivechain messages:
-    /// M1 (propose), M2 (ack), M3 (bundle propose), M4 (bundle votes) and
-    /// M7 (BMM accept).
+    /// M1 (propose), M2 (ack), M3 (bundle propose) and M4 (bundle votes).
     pub(crate) async fn extend_coinbase_txouts(
         &self,
         ack_all_proposals: bool,
@@ -294,22 +293,6 @@ impl BlockProducer {
             )?;
         }
 
-        let bmm_hashes = self.db().get_bmm_requests(&mainchain_tip).await?;
-        for (sidechain_number, bmm_hash) in bmm_hashes {
-            if coinbase_builder
-                .messages()
-                .m7_bmm_accept_slot_vout(&sidechain_number)
-                .is_some()
-            {
-                continue;
-            }
-            tracing::info!(
-                "Adding BMM accept for SC {} with hash: {}",
-                sidechain_number,
-                bmm_hash
-            );
-            coinbase_builder.bmm_accept(sidechain_number, bmm_hash)?;
-        }
         for (sidechain_id, m6ids) in self.get_bundle_proposals().await? {
             for (m6id, _blinded_m6, m6id_info) in m6ids {
                 if m6id_info.is_none() {

--- a/lib/block_producer/error.rs
+++ b/lib/block_producer/error.rs
@@ -194,6 +194,11 @@ pub enum SelectBlockTxs {
         txid: bitcoin::Txid,
         source: bitcoin::consensus::encode::Error,
     },
+    #[error("negative fee `{fee}` for transaction `{txid}` from the block template")]
+    NegativeTemplateTransactionFee {
+        txid: bitcoin::Txid,
+        fee: bitcoin::SignedAmount,
+    },
     /// The block template was built on a different tip than the one the
     /// validator has caught up to. Building on the validator's tip while using
     /// the template's tx set produces a block Core rejects as `inconclusive`,
@@ -213,7 +218,8 @@ impl ToStatus for SelectBlockTxs {
             Self::GenerateSuffixTxs(err) => err.builder(),
             Self::GetBlockTemplate(err) => err.builder(),
             Self::GetCtips(err) => err.builder(),
-            Self::DecodeTemplateTransaction { .. } => {
+            Self::DecodeTemplateTransaction { .. }
+            | Self::NegativeTemplateTransactionFee { .. } => {
                 StatusBuilder::new(self).code(connectrpc::ErrorCode::Internal)
             }
             // Retryable: whichever side is behind just needs to catch up.

--- a/lib/block_producer/mine.rs
+++ b/lib/block_producer/mine.rs
@@ -5,7 +5,7 @@
 //! signed by the Bitcoin Core node's wallet.
 
 use std::{
-    collections::HashSet,
+    collections::{HashMap, HashSet},
     num::NonZeroU32,
     path::{Path, PathBuf},
     time::{Duration, SystemTime, UNIX_EPOCH},
@@ -35,7 +35,23 @@ use crate::{
     block_producer::{BlockProducer, error},
     errors::ErrorChain,
     messages::CoinbaseBuilder,
+    types::{BmmCommitment, SidechainNumber},
 };
+
+pub(in crate::block_producer) fn bmm_auction_winners(
+    bids: impl IntoIterator<Item = (SidechainNumber, BmmCommitment, Txid, Amount)>,
+) -> HashMap<SidechainNumber, (BmmCommitment, Txid, Amount)> {
+    let mut winners = HashMap::new();
+    for (sidechain_number, commitment, txid, fee) in bids {
+        let winner = winners
+            .entry(sidechain_number)
+            .or_insert((commitment, txid, fee));
+        if fee > winner.2 {
+            *winner = (commitment, txid, fee);
+        }
+    }
+    winners
+}
 
 /// BMM request cleanup happens after the block has been submitted and observed
 /// by the validator. Keep the mined block as the operation's result even if the
@@ -103,7 +119,7 @@ impl BlockProducer {
     async fn select_block_txs(
         &self,
         mainchain_tip: BlockHash,
-    ) -> Result<Vec<Transaction>, error::SelectBlockTxs> {
+    ) -> Result<Vec<(Transaction, Amount)>, error::SelectBlockTxs> {
         let template = self
             .fetch_block_template(vec!["segwit".to_string()])
             .await?;
@@ -129,7 +145,11 @@ impl BlockProducer {
             CoinbaseTxnOrValue::Txn(_) => Vec::new(),
             CoinbaseTxnOrValue::ValueSats(_) => {
                 let ctips = self.validator().get_ctips()?;
-                self.generate_suffix_txs(&ctips).await?
+                self.generate_suffix_txs(&ctips)
+                    .await?
+                    .into_iter()
+                    .map(|tx| (tx, Amount::ZERO))
+                    .collect()
             }
         };
 
@@ -139,24 +159,31 @@ impl BlockProducer {
                 bitcoin::consensus::deserialize(&template_tx.data).map_err(|err| {
                     error::SelectBlockTxs::DecodeTemplateTransaction { txid, source: err }
                 })?;
-            res.push(transaction);
+            let fee = template_tx.fee.to_unsigned().map_err(|_| {
+                error::SelectBlockTxs::NegativeTemplateTransactionFee {
+                    txid,
+                    fee: template_tx.fee,
+                }
+            })?;
+            res.push((transaction, fee));
         }
 
         Ok(res)
     }
 
-    /// Construct a coinbase tx paying out to `coinbase_spk`
+    /// Construct a coinbase tx paying out to `coinbase_spk`.
     fn finalize_coinbase(
         &self,
         best_block_height: u32,
         coinbase_spk: ScriptBuf,
         coinbase_outputs: &[TxOut],
+        fees: Amount,
     ) -> Transaction {
         let script_sig = bitcoin::blockdata::script::Builder::new()
             .push_int((best_block_height + 1) as i64)
             .push_opcode(OP_0)
             .into_script();
-        let value = get_block_value(best_block_height + 1, Amount::ZERO, Network::Regtest);
+        let value = get_block_value(best_block_height + 1, fees, Network::Regtest);
         let output = if value > Amount::ZERO {
             vec![TxOut {
                 script_pubkey: coinbase_spk,
@@ -190,13 +217,15 @@ impl BlockProducer {
         coinbase_spk: ScriptBuf,
         coinbase_outputs: &[TxOut],
         transactions: Vec<Transaction>,
+        fees: Amount,
     ) -> Result<Block, error::FinalizeBlock> {
         let best_block_hash = self.validator().get_mainchain_tip()?;
         let tip_header = self.validator().get_header_info(&best_block_hash)?;
         let best_block_height = tip_header.height;
         tracing::trace!(%best_block_hash, %best_block_height, "Found mainchain tip");
 
-        let coinbase_tx = self.finalize_coinbase(best_block_height, coinbase_spk, coinbase_outputs);
+        let coinbase_tx =
+            self.finalize_coinbase(best_block_height, coinbase_spk, coinbase_outputs, fees);
         let txdata = std::iter::once(coinbase_tx).chain(transactions).collect();
         // Keep block times strictly increasing so blocks mined faster than once
         // per second are not rejected as `time-too-old` (timestamp must exceed
@@ -244,10 +273,11 @@ impl BlockProducer {
         coinbase_spk: ScriptBuf,
         coinbase_outputs: &[TxOut],
         transactions: Vec<Transaction>,
+        fees: Amount,
     ) -> Result<BlockHash, error::Mine> {
         let transaction_count = transactions.len();
 
-        let mut block = self.finalize_block(coinbase_spk, coinbase_outputs, transactions)?;
+        let mut block = self.finalize_block(coinbase_spk, coinbase_outputs, transactions, fees)?;
         loop {
             block.header.nonce += 1;
             if block.header.validate_pow(block.header.target()).is_ok() {
@@ -628,31 +658,47 @@ impl BlockProducer {
         let () = self
             .extend_coinbase_txouts(ack_all_proposals, mainchain_tip, &mut coinbase_outputs)
             .await?;
-        let transactions = self.select_block_txs(mainchain_tip).await?;
+        let selected = self.select_block_txs(mainchain_tip).await?;
+        let winners = bmm_auction_winners(selected.iter().filter_map(|(tx, fee)| {
+            let request = crate::messages::parse_m8_tx(tx)?;
+            (request.prev_mainchain_block_hash == mainchain_tip).then(|| {
+                (
+                    request.sidechain_number,
+                    request.sidechain_block_hash,
+                    tx.compute_txid(),
+                    *fee,
+                )
+            })
+        }));
         let mut coinbase_builder = CoinbaseBuilder::new(&mut coinbase_outputs)?;
-        for tx in &transactions {
-            if let Some(bmm_request) = crate::messages::parse_m8_tx(tx)
-                && coinbase_builder
-                    .messages()
-                    .m7_bmm_accept_slot_vout(&bmm_request.sidechain_number)
-                    .is_none()
-            {
-                coinbase_builder.bmm_accept(
-                    bmm_request.sidechain_number,
-                    bmm_request.sidechain_block_hash,
-                )?;
+        let mut fees = Amount::ZERO;
+        let mut transactions = Vec::with_capacity(selected.len());
+        for (tx, fee) in selected {
+            if let Some(request) = crate::messages::parse_m8_tx(&tx) {
+                let txid = tx.compute_txid();
+                if winners
+                    .get(&request.sidechain_number)
+                    .is_none_or(|(_, winner_txid, _)| *winner_txid != txid)
+                {
+                    continue;
+                }
+                coinbase_builder
+                    .bmm_accept(request.sidechain_number, request.sidechain_block_hash)?;
             }
+            fees += fee;
+            transactions.push(tx);
         }
         let () = coinbase_builder.build()?;
 
         tracing::info!(
             coinbase_outputs = %coinbase_outputs.len(),
             transactions = %transactions.len(),
+            %fees,
             "Mining block",
         );
 
         let block_hash = self
-            .mine(coinbase_spk, &coinbase_outputs, transactions)
+            .mine(coinbase_spk, &coinbase_outputs, transactions, fees)
             .await?;
         let cleanup_result = self
             .db()
@@ -664,9 +710,41 @@ impl BlockProducer {
 
 #[cfg(test)]
 mod tests {
-    use bitcoin::{BlockHash, hashes::Hash as _};
+    use bitcoin::{Amount, BlockHash, Txid, hashes::Hash as _};
 
-    use super::finish_bmm_request_cleanup;
+    use super::{bmm_auction_winners, finish_bmm_request_cleanup};
+    use crate::types::{BmmCommitment, SidechainNumber};
+
+    #[test]
+    fn highest_bmm_fee_wins_each_sidechain_slot() {
+        let slot = SidechainNumber(7);
+        let low_txid = Txid::from_byte_array([1; 32]);
+        let high_txid = Txid::from_byte_array([2; 32]);
+        let other_txid = Txid::from_byte_array([3; 32]);
+        let winners = bmm_auction_winners([
+            (
+                slot,
+                BmmCommitment([1; 32]),
+                low_txid,
+                Amount::from_sat(1_000),
+            ),
+            (
+                slot,
+                BmmCommitment([2; 32]),
+                high_txid,
+                Amount::from_sat(2_000),
+            ),
+            (
+                SidechainNumber(8),
+                BmmCommitment([3; 32]),
+                other_txid,
+                Amount::from_sat(500),
+            ),
+        ]);
+
+        assert_eq!(winners[&slot].1, high_txid);
+        assert_eq!(winners[&SidechainNumber(8)].1, other_txid);
+    }
 
     #[test]
     fn cleanup_failure_preserves_mined_block_result() {

--- a/lib/block_producer/mod.rs
+++ b/lib/block_producer/mod.rs
@@ -108,6 +108,23 @@ impl BlockProducer {
         &self.inner.db
     }
 
+    /// The absolute fee of `txid` in the node's mempool, or `None` if the
+    /// entry is unavailable.
+    async fn bmm_bid_fee(&self, txid: Txid) -> Option<bitcoin::Amount> {
+        use bitcoin_jsonrpsee::MainClient as _;
+        match self.main_client().get_mempool_entry(txid).await {
+            Ok(entry) => Some(entry.fees.base),
+            Err(err) => {
+                tracing::debug!(
+                    %txid,
+                    "skipping BMM bid without a mempool entry: {:#}",
+                    ErrorChain::new(&err),
+                );
+                None
+            }
+        }
+    }
+
     pub fn last_gbt_error(&self) -> Option<String> {
         self.inner.last_gbt_error.read().clone()
     }
@@ -238,15 +255,8 @@ impl CusfEnforcer for BlockProducer {
 
     type AcceptTxError = <Validator as CusfEnforcer>::AcceptTxError;
 
-    fn accept_tx<TxRef>(
-        &mut self,
-        tx: &Transaction,
-        tx_inputs: &HashMap<Txid, TxRef>,
-    ) -> Result<TxAcceptAction, Self::AcceptTxError>
-    where
-        TxRef: std::borrow::Borrow<Transaction>,
-    {
-        self.inner.validator.clone().accept_tx(tx, tx_inputs)
+    fn accept_tx(&mut self, tx: &Transaction) -> Result<TxAcceptAction, Self::AcceptTxError> {
+        self.inner.validator.clone().accept_tx(tx)
     }
 }
 
@@ -338,27 +348,45 @@ impl BlockProducer {
             "Initial coinbase txouts post-extension: {:?}",
             coinbase_txouts
         );
-        // Exclude M8 txs with different h*
+        // Settle the per-slot BMM auction before tx selection, with the same
+        // rule as self-mining (`bmm_auction_winners`): the highest absolute
+        // fee wins each slot, and every other bid is excluded from the
+        // template. Without this, generic tx selection would pick between
+        // conflicting bids by ancestor fee rate. Excluded bids drop together
+        // with their descendants when the template is built.
         {
-            let coinbase_builder = CoinbaseBuilder::new(coinbase_txouts)?;
-            let coinbase_m7_accepts = coinbase_builder.messages().m7_bmm_accepts();
             let seen_bmm_requests = self
                 .validator()
                 .get_seen_bmm_requests_for_parent_block(*parent_block_hash)?;
-            let exclude = {
-                let mut exclude = seen_bmm_requests;
-                exclude.retain(|sidechain_number, txids| {
-                    let Some(commitment) = coinbase_m7_accepts.get(sidechain_number) else {
-                        return false;
-                    };
-                    txids.remove(commitment);
-                    true
-                });
-                exclude
-                    .into_values()
-                    .flat_map(|txids| txids.into_values().flatten())
-            };
-            template.exclude_mempool_txs.extend(exclude);
+            let mut bids = Vec::new();
+            for (sidechain_number, requests) in &seen_bmm_requests {
+                for (commitment, txids) in requests {
+                    for txid in txids {
+                        // A bid may have left the mempool since it was seen
+                        // (e.g. replaced). It cannot win, and excluding it is
+                        // harmless.
+                        let Some(fee) = self.bmm_bid_fee(*txid).await else {
+                            continue;
+                        };
+                        bids.push((*sidechain_number, *commitment, *txid, fee));
+                    }
+                }
+            }
+            let winners = mine::bmm_auction_winners(bids);
+            template
+                .exclude_mempool_txs
+                .extend(
+                    seen_bmm_requests
+                        .into_iter()
+                        .flat_map(|(sidechain_number, requests)| {
+                            let winner_txid =
+                                winners.get(&sidechain_number).map(|(_, txid, _)| *txid);
+                            requests
+                                .into_values()
+                                .flatten()
+                                .filter(move |txid| Some(*txid) != winner_txid)
+                        }),
+                );
         }
         // Reserve suffix txs
         {

--- a/lib/messages.rs
+++ b/lib/messages.rs
@@ -737,14 +737,15 @@ pub struct M8BmmRequest {
 impl M8BmmRequest {
     pub const TAG: [u8; 3] = [0x00, 0xBF, 0x00];
 
-    /// Build the OP_RETURN script for an M8 BMM request.
+    /// Build the data carried by an M8 BMM request.
     /// Argument order matches the on-wire layout:
     /// `TAG sidechain_number sidechain_block_hash prev_mainchain_block_hash`.
-    pub fn script_pubkey(
+    /// Docs: https://github.com/LayerTwo-Labs/bip300_bip301_specifications/blob/master/bip301.md#m8-bmm-request
+    pub fn data(
         sidechain_number: SidechainNumber,
         sidechain_block_hash: BmmCommitment,
         prev_mainchain_block_hash: BlockHash,
-    ) -> Result<ScriptBuf, bitcoin::script::PushBytesError> {
+    ) -> Result<PushBytesBuf, bitcoin::script::PushBytesError> {
         let message = [
             &Self::TAG[..],
             &[sidechain_number.into()],
@@ -752,8 +753,19 @@ impl M8BmmRequest {
             &prev_mainchain_block_hash.to_byte_array(),
         ]
         .concat();
-        let bytes = PushBytesBuf::try_from(message)?;
-        Ok(ScriptBuf::new_op_return(&bytes))
+        PushBytesBuf::try_from(message)
+    }
+
+    pub fn script_pubkey(
+        sidechain_number: SidechainNumber,
+        sidechain_block_hash: BmmCommitment,
+        prev_mainchain_block_hash: BlockHash,
+    ) -> Result<ScriptBuf, bitcoin::script::PushBytesError> {
+        Ok(ScriptBuf::new_op_return(Self::data(
+            sidechain_number,
+            sidechain_block_hash,
+            prev_mainchain_block_hash,
+        )?))
     }
 
     pub fn parse(input: &[u8]) -> IResult<&[u8], Self> {

--- a/lib/rpc_client.rs
+++ b/lib/rpc_client.rs
@@ -104,6 +104,7 @@ const MAX_BURN_AMOUNT: f64 = 21_000_000.0;
 async fn broadcast_transaction_with_tolerance<RpcClient>(
     rpc_client: &RpcClient,
     tx: &bdk_wallet::bitcoin::Transaction,
+    max_fee_rate: Option<f64>,
     tolerate_rejection: impl FnOnce(i32, &str) -> bool,
 ) -> Result<Option<bitcoin::Txid>, ClientError>
 where
@@ -111,7 +112,7 @@ where
 {
     let encoded_tx = bitcoin::consensus::encode::serialize_hex(tx);
     match rpc_client
-        .send_raw_transaction(encoded_tx, None, Some(MAX_BURN_AMOUNT))
+        .send_raw_transaction(encoded_tx, max_fee_rate, Some(MAX_BURN_AMOUNT))
         .await
     {
         Ok(txid) => {
@@ -142,6 +143,32 @@ pub async fn broadcast_transaction<RpcClient>(
 where
     RpcClient: MainClient + Sync,
 {
+    broadcast_transaction_with_max_fee_rate(rpc_client, tx, None).await
+}
+
+/// [`broadcast_transaction`], with Bitcoin Core's RPC fee-rate cap
+/// (`maxfeerate`) disabled. For transactions whose fee is a deliberate
+/// payment rather than an estimate, such as BMM requests, where the bid is
+/// paid as the fee.
+pub async fn broadcast_transaction_no_fee_limit<RpcClient>(
+    rpc_client: &RpcClient,
+    tx: &bdk_wallet::bitcoin::Transaction,
+) -> Result<Option<bitcoin::Txid>, ClientError>
+where
+    RpcClient: MainClient + Sync,
+{
+    // `sendrawtransaction` interprets a `maxfeerate` of 0 as "no limit".
+    broadcast_transaction_with_max_fee_rate(rpc_client, tx, Some(0.0)).await
+}
+
+async fn broadcast_transaction_with_max_fee_rate<RpcClient>(
+    rpc_client: &RpcClient,
+    tx: &bdk_wallet::bitcoin::Transaction,
+    max_fee_rate: Option<f64>,
+) -> Result<Option<bitcoin::Txid>, ClientError>
+where
+    RpcClient: MainClient + Sync,
+{
     const OP_DRIVECHAIN_NOT_SUPPORTED_ERR_MSG: &str =
         "non-mandatory-script-verify-flag (NOPx reserved for soft-fork upgrades)";
     // Bitcoind v30.0 changed the error message
@@ -149,7 +176,7 @@ where
         "mempool-script-verify-flag-failed (NOPx reserved for soft-fork upgrades)";
     // We used to check the exact error message. Looks like this slightly
     // varies across versions. Therefore use a substring check.
-    broadcast_transaction_with_tolerance(rpc_client, tx, |_code, msg| {
+    broadcast_transaction_with_tolerance(rpc_client, tx, max_fee_rate, |_code, msg| {
         msg.contains(OP_DRIVECHAIN_NOT_SUPPORTED_ERR_MSG)
             || msg.contains(OP_DRIVECHAIN_NOT_SUPPORTED_ERR_MSG_V30_0)
     })
@@ -172,7 +199,7 @@ pub async fn broadcast_transaction_tolerate_mempool_rejection<RpcClient>(
 where
     RpcClient: MainClient + Sync,
 {
-    broadcast_transaction_with_tolerance(rpc_client, tx, |code, _msg| {
+    broadcast_transaction_with_tolerance(rpc_client, tx, None, |code, _msg| {
         code == BITCOIN_CORE_RPC_TRANSACTION_REJECTED
     })
     .await

--- a/lib/server/wallet/grpc.rs
+++ b/lib/server/wallet/grpc.rs
@@ -227,13 +227,6 @@ impl WalletService for crate::wallet::Wallet {
             )
             .await
             .map_err(|err| err.builder().to_connect_error())
-            .and_then(|tx| {
-                tx.ok_or_else(|| {
-                    ConnectError::already_exists(
-                        "BMM request with same `sidechain_number` and `prev_bytes` already exists",
-                    )
-                })
-            })
             .inspect_err(|err| {
                 tracing::error!(
                     "Error creating BMM critical data transaction: {:#}",

--- a/lib/validator/cusf_enforcer.rs
+++ b/lib/validator/cusf_enforcer.rs
@@ -1,7 +1,6 @@
 //! Implementation of [`cusf_enforcer_mempool::cusf_enforcer::CusfEnforcer`]
 
 use std::{
-    borrow::Borrow,
     collections::{HashMap, HashSet},
     future::Future,
 };
@@ -432,14 +431,7 @@ impl CusfEnforcer for Validator {
 
     type AcceptTxError = AcceptTxError;
 
-    fn accept_tx<TxRef>(
-        &mut self,
-        tx: &Transaction,
-        _tx_inputs: &HashMap<bitcoin::Txid, TxRef>,
-    ) -> Result<TxAcceptAction, Self::AcceptTxError>
-    where
-        TxRef: Borrow<Transaction>,
-    {
+    fn accept_tx(&mut self, tx: &Transaction) -> Result<TxAcceptAction, Self::AcceptTxError> {
         let mut rwtxn = self.dbs.write_txn()?;
         // A fatal error here isn't something that means we should
         // call out to the `invalidateblock` RPC. It simply means

--- a/lib/wallet/cusf_block_producer.rs
+++ b/lib/wallet/cusf_block_producer.rs
@@ -1,11 +1,10 @@
 use std::{
     borrow::Cow,
-    collections::HashMap,
     future::Future,
     time::{SystemTime, UNIX_EPOCH},
 };
 
-use bitcoin::{BlockHash, Transaction, Txid};
+use bitcoin::{BlockHash, Transaction};
 use bitcoin_jsonrpsee::client::{GetBlockClient, U8Witness};
 use cusf_enforcer_mempool::{
     cusf_block_producer::{
@@ -289,13 +288,31 @@ impl CusfEnforcer for Wallet {
             ConnectBlockAction::Accept { remove_mempool_txs } => {
                 let () = sync_wallet_to_tip(self, block.block_hash(), Some(block)).await?;
                 let mut wallet_write = self.inner.write_wallet().await?;
+                // Lock order: wallet before `bdk_db`, see the `bdk_db` field
+                // docs
+                let mut bdk_db = self.inner.bdk_db.lock().await;
                 let now = SystemTime::now()
                     .duration_since(UNIX_EPOCH)
                     .unwrap()
                     .as_secs();
-                wallet_write.with_mut(|wallet| {
-                    wallet.apply_evicted_txs(remove_mempool_txs.iter().map(|txid| (*txid, now)))
-                })
+                let _changed: bool = wallet_write
+                    .with_mut(|wallet| {
+                        wallet
+                            .apply_evicted_txs(remove_mempool_txs.iter().map(|txid| (*txid, now)));
+                        // Sweep BMM requests the mempool machinery has not
+                        // tracked: any unconfirmed request not bidding on
+                        // this block can no longer confirm.
+                        let _stale = Wallet::evict_stale_bmm_requests(wallet, block.block_hash());
+                        // Persist, or a restart reloads the evicted requests
+                        // from the wallet DB and re-locks their inputs
+                        wallet.persist_async(&mut bdk_db)
+                    })
+                    .await
+                    .map_err(|err| {
+                        error::ConnectBlock::PersistBmmEviction(error::SqliteError::from(err))
+                    })?;
+                drop(bdk_db);
+                drop(wallet_write);
             }
             ConnectBlockAction::Reject => (),
         }
@@ -323,15 +340,11 @@ impl CusfEnforcer for Wallet {
 
     type AcceptTxError = <Validator as CusfEnforcer>::AcceptTxError;
 
-    fn accept_tx<TxRef>(
+    fn accept_tx(
         &mut self,
         tx: &Transaction,
-        tx_inputs: &HashMap<Txid, TxRef>,
-    ) -> std::result::Result<TxAcceptAction, Self::AcceptTxError>
-    where
-        TxRef: std::borrow::Borrow<Transaction>,
-    {
-        let res = self.inner.validator().clone().accept_tx(tx, tx_inputs)?;
+    ) -> std::result::Result<TxAcceptAction, Self::AcceptTxError> {
+        let res = self.inner.validator().clone().accept_tx(tx)?;
         match res {
             TxAcceptAction::Accept { .. } => {
                 // TODO: Ideally we could push these updates to a channel, and

--- a/lib/wallet/error.rs
+++ b/lib/wallet/error.rs
@@ -830,6 +830,8 @@ pub enum InitialSync {
 pub enum ConnectBlock {
     #[error(transparent)]
     NotUnlocked(#[from] NotUnlocked),
+    #[error("failed to persist wallet after evicting BMM requests")]
+    PersistBmmEviction(#[source] SqliteError),
     #[error(transparent)]
     Validator(#[from] <Validator as CusfEnforcer>::ConnectBlockError),
     #[error(transparent)]
@@ -988,8 +990,6 @@ pub(in crate::wallet) enum CreateBmmRequestInner {
     BroadcastUnsuccessful { txid: bitcoin::Txid },
     #[error(transparent)]
     GetHeaderInfo(#[from] validator::GetHeaderInfoError),
-    #[error("rusqlite error")]
-    Rusqlite(#[from] rusqlite::Error),
     #[error("failed to sign BMM tx")]
     SignTx(#[from] WalletSignTransaction),
 }
@@ -1002,8 +1002,7 @@ impl ToStatus for CreateBmmRequestInner {
             Self::SignTx(err) => StatusBuilder::with_code(self, err.builder()),
             Self::BroadcastNonstandardTx(_)
             | Self::BroadcastTxRpc(_)
-            | Self::BroadcastUnsuccessful { .. }
-            | Self::Rusqlite(_) => StatusBuilder::new(self),
+            | Self::BroadcastUnsuccessful { .. } => StatusBuilder::new(self),
         }
     }
 }

--- a/lib/wallet/mod.rs
+++ b/lib/wallet/mod.rs
@@ -636,18 +636,6 @@ impl Wallet {
             .await
     }
 
-    async fn insert_new_bmm_request(
-        &self,
-        sidechain_number: SidechainNumber,
-        prev_blockhash: bdk_wallet::bitcoin::BlockHash,
-        side_block_hash: BmmCommitment,
-    ) -> Result<bool, rusqlite::Error> {
-        self.inner
-            .db()
-            .insert_new_bmm_request(sidechain_number, prev_blockhash, side_block_hash)
-            .await
-    }
-
     pub async fn sync_task(&self, cancel: CancellationToken) -> Result<(), miette::Report> {
         const SYNC_INTERVAL: Duration = Duration::from_secs(15);
         tracing::debug!(
@@ -1591,7 +1579,27 @@ impl Wallet {
     #[instrument(skip_all, err)]
     async fn sign_transaction(
         &self,
+        psbt: bdk_wallet::bitcoin::psbt::Psbt,
+    ) -> Result<bdk_wallet::bitcoin::Transaction, error::WalletSignTransaction> {
+        self.sign_transaction_inner(psbt, false).await
+    }
+
+    /// [`Self::sign_transaction`], without the PSBT fee-rate sanity limit.
+    /// A BMM bid is paid as the transaction fee, so it may deliberately
+    /// exceed any fee-rate threshold that guards ordinary transactions
+    /// against fat-fingered fees.
+    #[instrument(skip_all, err)]
+    async fn sign_bmm_request_transaction(
+        &self,
+        psbt: bdk_wallet::bitcoin::psbt::Psbt,
+    ) -> Result<bdk_wallet::bitcoin::Transaction, error::WalletSignTransaction> {
+        self.sign_transaction_inner(psbt, true).await
+    }
+
+    async fn sign_transaction_inner(
+        &self,
         mut psbt: bdk_wallet::bitcoin::psbt::Psbt,
+        skip_fee_rate_check: bool,
     ) -> Result<bdk_wallet::bitcoin::Transaction, error::WalletSignTransaction> {
         let mut timestamp = Instant::now();
 
@@ -1609,24 +1617,62 @@ impl Wallet {
         tracing::debug!("Signed transaction in {:?}", timestamp.elapsed());
         timestamp = Instant::now();
 
-        let tx = psbt
-            .extract_tx()
-            .map_err(error::WalletSignTransaction::ExtractTx)?;
+        let tx = if skip_fee_rate_check {
+            psbt.extract_tx_unchecked_fee_rate()
+        } else {
+            psbt.extract_tx()
+                .map_err(error::WalletSignTransaction::ExtractTx)?
+        };
 
         tracing::debug!("Extracted transaction in {:?}", timestamp.elapsed());
         Ok(tx)
     }
 
-    fn bmm_request_message(
-        sidechain_number: SidechainNumber,
-        prev_mainchain_block_hash: bdk_wallet::bitcoin::BlockHash,
-        sidechain_block_hash: BmmCommitment,
-    ) -> Result<bdk_wallet::bitcoin::ScriptBuf, bitcoin::script::PushBytesError> {
-        M8BmmRequest::script_pubkey(
-            sidechain_number,
-            sidechain_block_hash,
-            prev_mainchain_block_hash,
-        )
+    fn build_bmm_psbt(
+        wallet: &mut bdk_wallet::Wallet,
+        message: &PushBytesBuf,
+        bid_amount: bdk_wallet::bitcoin::Amount,
+        locktime: bdk_wallet::bitcoin::absolute::LockTime,
+    ) -> Result<bdk_wallet::bitcoin::psbt::Psbt, bdk_wallet::error::CreateTxError> {
+        let mut builder = wallet.build_tx();
+        // BIP301 requires the M8 OP_RETURN at output zero.
+        builder.ordering(bdk_wallet::TxOrdering::Untouched);
+        builder.nlocktime(locktime);
+        builder.add_data(message);
+        builder.fee_absolute(bid_amount);
+        builder.finish()
+    }
+
+    /// Evict every unconfirmed BMM request whose `prev_mainchain_block_hash`
+    /// is not `mainchain_tip` from the wallet's canonical set, returning the
+    /// evicted txids. Such requests can never confirm (BIP300 rejects an M8
+    /// whose prev hash is not the block's parent), but they linger in Bitcoin
+    /// Core's mempool, where chain-source syncs keep re-adopting them into
+    /// the wallet and locking their inputs. Callers must persist the wallet
+    /// afterwards, or the eviction is lost on restart.
+    fn evict_stale_bmm_requests(
+        wallet: &mut bdk_wallet::Wallet,
+        mainchain_tip: bitcoin::BlockHash,
+    ) -> Vec<bdk_wallet::bitcoin::Txid> {
+        let stale: Vec<bdk_wallet::bitcoin::Txid> = wallet
+            .transactions()
+            .filter(|wallet_tx| !wallet_tx.chain_position.is_confirmed())
+            .filter_map(|wallet_tx| {
+                let output = wallet_tx.tx_node.tx.output.first()?;
+                let script = output.script_pubkey.to_bytes();
+                let (_rest, m8) = M8BmmRequest::parse(&script).ok()?;
+                (m8.prev_mainchain_block_hash != mainchain_tip).then_some(wallet_tx.tx_node.txid)
+            })
+            .collect();
+        if !stale.is_empty() {
+            tracing::info!(stale_bmm_requests = ?stale, "evicting stale BMM requests from wallet");
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs();
+            wallet.apply_evicted_txs(stale.iter().map(|txid| (*txid, now)));
+        }
+        stale
     }
 
     async fn build_bmm_tx(
@@ -1637,48 +1683,26 @@ impl Wallet {
         bid_amount: bdk_wallet::bitcoin::Amount,
         locktime: bdk_wallet::bitcoin::absolute::LockTime,
     ) -> Result<bdk_wallet::bitcoin::psbt::Psbt, error::BuildBmmTx> {
-        tracing::trace!("build_bmm_tx: constructing request message");
-        // https://github.com/LayerTwo-Labs/bip300_bip301_specifications/blob/master/bip301.md#m8-bmm-request
-        let message = Self::bmm_request_message(
+        let message = M8BmmRequest::data(
             sidechain_number,
-            prev_mainchain_block_hash,
             sidechain_block_hash,
+            prev_mainchain_block_hash,
         )?;
 
-        let psbt = {
-            tracing::trace!("build_bmm_tx: acquiring wallet write lock");
-            let mut wallet_write = self.inner.write_wallet().await?;
-            tokio::task::block_in_place(|| {
-                wallet_write.with_mut(|wallet| {
-                    tracing::trace!("build_bmm_tx: creating transaction builder");
-                    let mut builder = wallet.build_tx();
-                    // OP_RETURN message MUST be first output
-                    builder.ordering(bdk_wallet::TxOrdering::Untouched);
-
-                    tracing::trace!("build_bmm_tx: adding locktime {locktime}");
-                    builder.nlocktime(locktime);
-
-                    tracing::trace!("build_bmm_tx: adding recipient");
-                    builder.add_recipient(message, bid_amount);
-
-                    tracing::trace!("build_bmm_tx: finishing transaction builder");
-                    let res = builder.finish();
-
-                    tracing::trace!("build_bmm_tx: built transaction");
-
-                    res
-                })
-            })?
-        };
+        let mut wallet_write = self.inner.write_wallet().await?;
+        let psbt = tokio::task::block_in_place(|| {
+            wallet_write
+                .with_mut(|wallet| Self::build_bmm_psbt(wallet, &message, bid_amount, locktime))
+        })?;
 
         Ok(psbt)
     }
 
-    /// Creates a BMM request transaction. Broadcasts via the p2p whitelist,
-    /// and via RPC to our own node (tolerating rejection due to non-standardness).
-    /// Returns `Some(tx)` if the BMM request was stored, `None` if the BMM
-    /// request was not stored due to pre-existing request with the same
-    /// `sidechain_number` and `prev_mainchain_block_hash`.
+    /// Creates a BMM request transaction and broadcasts it via the p2p
+    /// whitelist and RPC to our own node.
+    /// The bid amount is paid as transaction fee, so miners collect it by
+    /// selecting the request rather than the requester burning it in the M8
+    /// output.
     pub async fn create_bmm_request(
         &self,
         sidechain_number: SidechainNumber,
@@ -1686,7 +1710,7 @@ impl Wallet {
         sidechain_block_hash: BmmCommitment,
         bid_amount: bdk_wallet::bitcoin::Amount,
         locktime: bdk_wallet::bitcoin::absolute::LockTime,
-    ) -> Result<Option<bdk_wallet::bitcoin::Transaction>, error::CreateBmmRequest> {
+    ) -> Result<bdk_wallet::bitcoin::Transaction, error::CreateBmmRequest> {
         tracing::debug!("create_bmm_request: building transaction");
         let psbt = self
             .build_bmm_tx(
@@ -1697,23 +1721,9 @@ impl Wallet {
                 locktime,
             )
             .await?;
-        let tx = self.sign_transaction(psbt).await?;
+        let tx = self.sign_bmm_request_transaction(psbt).await?;
         tracing::info!("BMM request: PSBT signed successfully");
         let txid = tx.compute_txid();
-        let stored = self
-            .insert_new_bmm_request(
-                sidechain_number,
-                prev_mainchain_block_hash,
-                sidechain_block_hash,
-            )
-            .await?;
-        if stored {
-            tracing::info!("BMM request: inserted new bmm request into db");
-        } else {
-            tracing::warn!(
-                "BMM request: Ignored, request exists with same sidechain slot and previous block hash"
-            );
-        }
         let block_height = self
             .inner
             .validator()
@@ -1751,15 +1761,12 @@ impl Wallet {
         }
         // Submit to our own node via RPC as well. This must happen after the
         // p2p broadcast: if a peer received the tx via relay from our node
-        // first, the p2p broadcast to it would time out. Unpatched nodes may
-        // reject the BMM request as non-standard. That is tolerated.
+        // first, the p2p broadcast to it would time out. The bid is paid as
+        // the fee, so broadcast without Bitcoin Core's RPC fee-rate cap.
         tracing::debug!(%txid, "Broadcasting BMM request transaction to own node via RPC...");
-        match crate::rpc_client::broadcast_transaction_tolerate_mempool_rejection(
-            &self.inner.main_client,
-            &tx,
-        )
-        .await
-        .map_err(error::CreateBmmRequestInner::BroadcastTxRpc)?
+        match crate::rpc_client::broadcast_transaction_no_fee_limit(&self.inner.main_client, &tx)
+            .await
+            .map_err(error::CreateBmmRequestInner::BroadcastTxRpc)?
         {
             Some(_) => {
                 tracing::info!(%txid, "Broadcast BMM request transaction via RPC to own node");
@@ -1768,7 +1775,7 @@ impl Wallet {
                 tracing::info!(%txid, "Own node rejected BMM request transaction from its mempool");
             }
         }
-        if stored { Ok(Some(tx)) } else { Ok(None) }
+        Ok(tx)
     }
 
     pub async fn get_wallet_info(&self) -> Result<WalletInfo, error::NotUnlocked> {
@@ -1948,8 +1955,80 @@ mod tests {
         bitcoin::{Amount, ScriptBuf, script::PushBytesBuf},
         test_utils::get_funded_wallet_wpkh,
     };
+    use bitcoin::{BlockHash, hashes::Hash as _};
 
     use super::{CreateTransactionParams, M8BmmRequest, Wallet};
+    use crate::types::{BmmCommitment, SidechainNumber};
+
+    #[test]
+    fn bmm_bid_is_a_fee_not_a_burn() {
+        let (mut wallet, _) = get_funded_wallet_wpkh();
+        let bid = Amount::from_sat(10_000);
+        let message = M8BmmRequest::data(
+            SidechainNumber(13),
+            BmmCommitment([0x11; 32]),
+            BlockHash::from_byte_array([0x22; 32]),
+        )
+        .unwrap();
+
+        let psbt = Wallet::build_bmm_psbt(
+            &mut wallet,
+            &message,
+            bid,
+            bitcoin::absolute::LockTime::ZERO,
+        )
+        .unwrap();
+
+        assert_eq!(wallet.calculate_fee(&psbt.unsigned_tx).unwrap(), bid);
+        assert_eq!(psbt.unsigned_tx.output[0].value, Amount::ZERO);
+        M8BmmRequest::parse(&psbt.unsigned_tx.output[0].script_pubkey.to_bytes())
+            .expect("output zero must contain the M8 request");
+    }
+
+    /// A BMM request that no longer bids on the tip can never confirm, so
+    /// evicting it must free its inputs; a request still bidding on the tip
+    /// must be left alone.
+    #[test]
+    fn stale_bmm_request_is_evicted_and_frees_inputs() {
+        let (mut wallet, _) = get_funded_wallet_wpkh();
+        let tip = BlockHash::from_byte_array([0xAA; 32]);
+        let message =
+            M8BmmRequest::data(SidechainNumber(3), BmmCommitment([0x33; 32]), tip).unwrap();
+        let psbt = Wallet::build_bmm_psbt(
+            &mut wallet,
+            &message,
+            Amount::from_sat(1_000),
+            bitcoin::absolute::LockTime::ZERO,
+        )
+        .unwrap();
+        let tx = psbt.unsigned_tx.clone();
+        let txid = tx.compute_txid();
+        let spent: Vec<_> = tx.input.iter().map(|input| input.previous_output).collect();
+        assert!(!spent.is_empty());
+        wallet.apply_unconfirmed_txs([(tx, 100)]);
+        assert!(
+            wallet
+                .list_unspent()
+                .all(|utxo| !spent.contains(&utxo.outpoint)),
+            "an unconfirmed bid must spend its inputs"
+        );
+
+        assert!(
+            Wallet::evict_stale_bmm_requests(&mut wallet, tip).is_empty(),
+            "a bid on the current tip must not be evicted"
+        );
+        let moved_tip = BlockHash::from_byte_array([0xBB; 32]);
+        assert_eq!(
+            Wallet::evict_stale_bmm_requests(&mut wallet, moved_tip),
+            vec![txid]
+        );
+        assert!(
+            spent
+                .iter()
+                .all(|outpoint| wallet.list_unspent().any(|utxo| utxo.outpoint == *outpoint)),
+            "evicting the stale bid must free its inputs"
+        );
+    }
 
     /// A BMM request only counts as an M8 when its OP_RETURN sits at output 0,
     /// and a shuffle lands it there half the time, so one build proves nothing.

--- a/lib/wallet/sync.rs
+++ b/lib/wallet/sync.rs
@@ -241,6 +241,13 @@ impl WalletInner {
         // Upgrade wallet lock
         let mut wallet_write = RwLockUpgradableReadGuardSome::upgrade(wallet_read).await;
         wallet_write.with_mut(|wallet| wallet.apply_update(update))?;
+        // The update re-adopts any stale BMM request that still sits in the
+        // chain source's mempool view, re-locking its inputs. Evict again
+        // before the update is committed.
+        if let Ok(mainchain_tip) = self.validator().get_mainchain_tip() {
+            let _stale = wallet_write
+                .with_mut(|wallet| super::Wallet::evict_stale_bmm_requests(wallet, mainchain_tip));
+        }
         tracing::debug!(
             "wallet sync complete in {:?}",
             start.elapsed().unwrap_or_default(),
@@ -368,11 +375,17 @@ impl WalletInner {
         let mut wallet_write = RwLockUpgradableReadGuardSome::upgrade(wallet_read).await;
         let mut bdk_db = self.bdk_db.lock().await;
 
+        // A full scan re-adopts stale BMM requests still in the chain
+        // source's mempool view. Evict them again before persisting.
+        let mainchain_tip = self.validator().try_get_mainchain_tip().ok().flatten();
         wallet_write
             .with_mut(|wallet| {
-                wallet
-                    .apply_update(update)
-                    .map(|_| wallet.persist_async(&mut bdk_db))
+                wallet.apply_update(update).map(|_| {
+                    if let Some(mainchain_tip) = mainchain_tip {
+                        let _stale = super::Wallet::evict_stale_bmm_requests(wallet, mainchain_tip);
+                    }
+                    wallet.persist_async(&mut bdk_db)
+                })
             })
             .map_err(error::FullScan::CannotConnect)?
             .await


### PR DESCRIPTION
There are currently a lot of edge cases we don't cover here related to wallet handling of chained bids, RBFs, idempotent retries, concurrent bids and other race conditions, reorgs for BMM bids, isolation between simultaneous sidechain bids, descendant handling of losing bids, and probably more as well.