### PR TITLE
ci: avoid requiring passing integration tests for release push

### DIFF
--- a/.github/workflows/check_lint_build_release.yaml
+++ b/.github/workflows/check_lint_build_release.yaml
@@ -581,7 +581,7 @@ jobs:
   upload-releases-to-releases-drivechain-info:
     name: Upload releases to releases.drivechain.info
     runs-on: ubuntu-latest
-    needs: [integration-test, test-build-release]
+    needs: [test-build-release]
     if: github.ref == 'refs/heads/master'
     steps:
       - name: Download artifacts


### PR DESCRIPTION
Flaky integration tests should not prevent us from uploading releases.