### PR TITLE
Serve JSON-RPC during initial wallet sync

### DIFF
--- a/app/main.rs
+++ b/app/main.rs
@@ -486,13 +486,12 @@ async fn run_connect_server(
     res
 }
 
-async fn spawn_gbt_server<BP, RpcClient>(
-    server: cusf_enforcer_mempool::server::Server<BP, RpcClient>,
+async fn spawn_gbt_server<S>(
+    server: S,
     serve_addr: SocketAddr,
 ) -> miette::Result<jsonrpsee::server::ServerHandle>
 where
-    BP: CusfBlockProducer + Send + Sync + 'static,
-    RpcClient: bitcoin_jsonrpsee::MainClient + Send + Sync + 'static,
+    S: cusf_enforcer_mempool::server::RpcServer,
 {
     let rpc_server = server.into_rpc();
 
@@ -514,7 +513,6 @@ where
         .layer(jsonrpsee_tracer!("gbt_server"));
     let rpc_middleware = RpcServiceBuilder::new().rpc_logger(1024);
 
-    use cusf_enforcer_mempool::server::RpcServer;
     let handle = jsonrpsee::server::Server::builder()
         .set_http_middleware(http_middleware)
         .set_rpc_middleware(rpc_middleware)
@@ -811,12 +809,111 @@ struct GbtConfig {
     serve_rpc_addr: SocketAddr,
 }
 
-/// Build the sample block template and bring up the `getblocktemplate` server.
-async fn spawn_block_template_server<BP>(
+type GbtServer<BP> = cusf_enforcer_mempool::server::Server<
+    BP,
+    bitcoin_jsonrpsee::jsonrpsee::http_client::HttpClient,
+>;
+
+// https://github.com/bitcoin/bitcoin/blob/6c4fe401e908cff1b67d80035b117aae15fe7db6/src/rpc/protocol.h#L58
+/// No P2P peers connected
+const RPC_CLIENT_NOT_CONNECTED: i32 = -9;
+
+/// Still syncing, i.e. in IBD
+const RPC_CLIENT_IN_INITIAL_DOWNLOAD: i32 = -10;
+
+/// The JSON-RPC endpoint, bound before the initial sync of the wallet.
+/// `submitblock` only needs the node connection, so it is served immediately.
+/// `getblocktemplate` needs a synced mempool, so until there is one it reports
+/// the same error code Bitcoin Core does.
+struct GbtSlot<BP> {
+    server: Arc<tokio::sync::RwLock<Option<Arc<GbtServer<BP>>>>>,
+    mainchain_client: bitcoin_jsonrpsee::jsonrpsee::http_client::HttpClient,
+}
+
+// Derived `Clone` would demand `BP: Clone`.
+impl<BP> Clone for GbtSlot<BP> {
+    fn clone(&self) -> Self {
+        Self {
+            server: Arc::clone(&self.server),
+            mainchain_client: self.mainchain_client.clone(),
+        }
+    }
+}
+
+impl<BP> GbtSlot<BP> {
+    fn new(mainchain_client: bitcoin_jsonrpsee::jsonrpsee::http_client::HttpClient) -> Self {
+        Self {
+            server: Arc::new(tokio::sync::RwLock::new(None)),
+            mainchain_client,
+        }
+    }
+
+    async fn ready(&self) -> Option<Arc<GbtServer<BP>>> {
+        self.server.read().await.clone()
+    }
+
+    async fn publish(&self, server: GbtServer<BP>) {
+        *self.server.write().await = Some(Arc::new(server));
+        tracing::info!("now serving `getblocktemplate`");
+    }
+
+    async fn clear(&self) {
+        if self.server.write().await.take().is_some() {
+            tracing::info!("no longer serving `getblocktemplate`");
+        }
+    }
+}
+
+#[jsonrpsee::core::async_trait]
+impl<BP> cusf_enforcer_mempool::server::RpcServer for GbtSlot<BP>
+where
+    BP: CusfBlockProducer + Send + Sync + 'static,
+{
+    async fn get_block_template(
+        &self,
+        request: bitcoin_jsonrpsee::client::BlockTemplateRequest,
+    ) -> jsonrpsee::core::RpcResult<bitcoin_jsonrpsee::client::BlockTemplate> {
+        match self.ready().await {
+            Some(server) => server.get_block_template(request).await,
+            None => Err(jsonrpsee::types::ErrorObject::owned(
+                RPC_CLIENT_IN_INITIAL_DOWNLOAD,
+                "enforcer is still syncing, and cannot build block templates yet",
+                None::<()>,
+            )),
+        }
+    }
+
+    async fn submit_block(&self, block_hex: String) -> jsonrpsee::core::RpcResult<Option<String>> {
+        match self.ready().await {
+            Some(server) => server.submit_block(block_hex).await,
+            // What the block template server does with it, too: the node
+            // validates and stores the block, synced enforcer or not.
+            None => self
+                .mainchain_client
+                .submit_block(block_hex)
+                .await
+                .map_err(|err| match err {
+                    Error::Call(err) => err,
+                    err => {
+                        tracing::error!("`submitblock` while syncing: {err:#}");
+                        jsonrpsee::types::ErrorObject::owned(
+                            jsonrpsee::types::ErrorCode::InternalError.code(),
+                            jsonrpsee::types::ErrorCode::InternalError.message(),
+                            Some(format!("{err:#}")),
+                        )
+                    }
+                }),
+        }
+    }
+}
+
+/// Build the sample block template and the `getblocktemplate` server. The
+/// endpoint it is served on is bound separately, by [`GbtSlot`].
+async fn build_block_template_server<BP>(
     gbt: GbtConfig,
     mempool: cusf_enforcer_mempool::mempool::MempoolSync<BP>,
     mainchain_client: bitcoin_jsonrpsee::jsonrpsee::http_client::HttpClient,
-) -> Result<jsonrpsee::server::ServerHandle, miette::Report>
+) -> Result<GbtServer<BP>, miette::Report>
 where
     BP: CusfBlockProducer + Send + Sync + 'static,
 {
@@ -824,7 +921,7 @@ where
         mining_reward_address,
         network,
         cache_lifetime,
-        serve_rpc_addr,
+        serve_rpc_addr: _, // already bound, see `GbtSlot`
     } = gbt;
 
     let network_info = mainchain_client
@@ -840,15 +937,12 @@ where
     // current Core tip. However, Core can still be stuck in IBD, hence the need for this loop
     // https://github.com/bitcoin/bitcoin/blob/6c4fe401e908cff1b67d80035b117aae15fe7db6/src/rpc/mining.cpp#L771-L773
     let sample_block_template = loop {
-        // https://github.com/bitcoin/bitcoin/blob/6c4fe401e908cff1b67d80035b117aae15fe7db6/src/rpc/protocol.h#L58
-        const RPC_CLIENT_NOT_CONNECTED: i32 = -9; // No P2P peers connected, refuses block template requests
-        const RPC_IN_WARMUP: i32 = -10; // In IBD etc, refuses block template requests
         match get_block_template(&mainchain_client, network).await {
             Ok(block_template) => break block_template,
             Err(wallet::error::BitcoinCoreRPC {
                 method: _,
                 error: jsonrpsee::core::client::Error::Call(err),
-            }) if err.code() == RPC_IN_WARMUP => {
+            }) if err.code() == RPC_CLIENT_IN_INITIAL_DOWNLOAD => {
                 tracing::debug!(
                     err = format!("{}: {}", err.code(), err.message()),
                     "Transient Bitcoin Core error, retrying before spawning GBT server...",
@@ -876,7 +970,7 @@ where
         }
     };
 
-    let gbt_server = cusf_enforcer_mempool::server::Server::new(
+    cusf_enforcer_mempool::server::Server::new(
         mining_reward_address.script_pubkey(),
         mempool,
         network,
@@ -885,12 +979,11 @@ where
         cache_lifetime,
         sample_block_template,
     )
-    .into_diagnostic()?;
-    spawn_gbt_server(gbt_server, serve_rpc_addr).await
+    .into_diagnostic()
 }
 
 /// Sync the mempool for any block producer, and, when `gbt` is `Some`, serve
-/// `getblocktemplate` from it.
+/// JSON-RPC from it.
 ///
 /// Serving templates is a niche miner feature, so it is optional: a wallet may
 /// sync the mempool purely to track unconfirmed transactions.
@@ -906,9 +999,19 @@ where
     BP: CusfBlockProducer + Clone + Send + Sync + 'static,
     error::MempoolTask<BP>: Into<miette::Report>,
 {
+    // Bound before syncing anything, see `GbtSlot`.
+    let gbt_server = match gbt {
+        Some(gbt) => {
+            let slot = GbtSlot::<BP>::new(mainchain_client.clone());
+            let handle = spawn_gbt_server(slot.clone(), gbt.serve_rpc_addr).await?;
+            Some((gbt, slot, handle))
+        }
+        None => None,
+    };
+
     // Re-sync rather than exit on a recoverable sync failure. A ZMQ sequence
     // gap blocks the stream permanently, but a fresh sync clears it.
-    loop {
+    let res = loop {
         let sync = sync_mempool(
             producer.clone(),
             mainchain_client.clone(),
@@ -927,44 +1030,56 @@ where
                 tokio::time::sleep(MEMPOOL_RESYNC_DELAY).await;
                 continue;
             }
-            Err(err) => return Err(miette::Report::from_err(err)),
+            Err(err) => break Err(miette::Report::from_err(err)),
         };
 
-        let (server_handle, _mempool) = match gbt.clone() {
-            Some(gbt) => {
-                let handle =
-                    spawn_block_template_server(gbt, mempool, mainchain_client.clone()).await?;
-                (Some(handle), None)
+        // Important: bind the mempool sync handle when it is not moved into a
+        // server. Otherwise it is dropped immediately.
+        let _mempool = match &gbt_server {
+            Some((gbt, slot, _handle)) => {
+                match build_block_template_server(gbt.clone(), mempool, mainchain_client.clone())
+                    .await
+                {
+                    Ok(server) => slot.publish(server).await,
+                    Err(err) => break Err(err),
+                }
+                None
             }
-            None => (None, Some(mempool)),
+            None => Some(mempool),
         };
 
         let err = wait_for_error_or_shutdown(cancel.clone(), err_rx).await;
 
-        // Always stop the server before looping: the next iteration rebinds
-        // the same address
-        if let Some(server_handle) = server_handle {
-            tracing::debug!("stopping `getblocktemplate` JSON-RPC server");
-
-            // This should never fail. The only failure mode is the server
-            // already being stopped, and we have full control over that.
-            if let Err(err) = server_handle.stop() {
-                tracing::error!("error stopping `getblocktemplate` JSON-RPC server: {err:#}");
-            }
+        // Templates must not be served from a mempool that is no longer
+        // being updated.
+        if let Some((_gbt, slot, _handle)) = &gbt_server {
+            slot.clear().await;
         }
 
-        match err? {
-            None => return Ok(()),
-            Some(err) if err.is_resyncable() && !cancel.is_cancelled() => {
+        match err {
+            Err(err) => break Err(err),
+            Ok(None) => break Ok(()),
+            Ok(Some(err)) if err.is_resyncable() && !cancel.is_cancelled() => {
                 tracing::warn!(
                     err = %ErrorChain::new(&err),
                     "mempool sync failed recoverably, re-syncing",
                 );
                 tokio::time::sleep(MEMPOOL_RESYNC_DELAY).await;
             }
-            Some(err) => return Err(miette::Report::from_err(err)),
+            Ok(Some(err)) => break Err(miette::Report::from_err(err)),
+        }
+    };
+
+    if let Some((_gbt, _slot, server_handle)) = gbt_server {
+        tracing::debug!("stopping `getblocktemplate` JSON-RPC server");
+
+        // This should never fail. The only failure mode is the server
+        // already being stopped, and we have full control over that.
+        if let Err(err) = server_handle.stop() {
+            tracing::error!("error stopping `getblocktemplate` JSON-RPC server: {err:#}");
         }
     }
+    res
 }
 
 async fn run_wallet_mempool_task(

--- a/integration_tests/integration_test.rs
+++ b/integration_tests/integration_test.rs
@@ -1199,6 +1199,14 @@ pub fn tests(
     ));
 
     async_trials.push(new_bespoke_trial(
+        crate::test_gbt_during_initial_sync::TEST_NAME,
+        bin_paths,
+        &file_registry,
+        &failure_collector,
+        crate::test_gbt_during_initial_sync::test_gbt_during_initial_sync,
+    ));
+
+    async_trials.push(new_bespoke_trial(
         crate::test_wallet_reorg_multi_block::TEST_NAME,
         bin_paths,
         &file_registry,

--- a/integration_tests/lib.rs
+++ b/integration_tests/lib.rs
@@ -9,6 +9,7 @@ mod test_blinded_m6_roundtrip;
 mod test_bmm_bid_auction;
 mod test_consecutive_deposits;
 mod test_file_based_block_parser;
+mod test_gbt_during_initial_sync;
 mod test_generate_to_address;
 mod test_inactive_drivechain_output;
 mod test_invalid_block;

--- a/integration_tests/setup.rs
+++ b/integration_tests/setup.rs
@@ -616,6 +616,30 @@ pub async fn wait_for_tx_in_mempool(
     .await
 }
 
+/// Reported by the enforcer's `getblocktemplate` while its mempool syncs.
+const RPC_CLIENT_IN_INITIAL_DOWNLOAD: i32 = -10;
+
+/// Block until the enforcer's `getblocktemplate` endpoint serves templates,
+/// rather than reporting that it is still syncing. Any other answer counts as
+/// ready; a transport error is not an answer, and is retried.
+pub async fn wait_for_block_templates(
+    gbt_client: &jsonrpsee::http_client::HttpClient,
+) -> anyhow::Result<()> {
+    use cusf_enforcer_mempool::server::RpcClient as _;
+
+    wait_until("the enforcer to serve block templates", || async {
+        let request = bitcoin_jsonrpsee::client::BlockTemplateRequest::default();
+        match gbt_client.get_block_template(request).await {
+            Ok(_) => Ok(true),
+            Err(jsonrpsee::core::client::Error::Call(err)) => {
+                Ok(err.code() != RPC_CLIENT_IN_INITIAL_DOWNLOAD)
+            }
+            Err(err) => Err(err.into()),
+        }
+    })
+    .await
+}
+
 /// Concatenate the enforcer's rolling log files.
 ///
 /// Not `stdout.txt`: that only holds the run the harness spawned most recently,
@@ -1327,10 +1351,15 @@ impl PostSetup {
         .await
         .map_err(|e| anyhow!("Failed waiting for enforcer gRPC port: {e}"))?;
 
-        // The JSON-RPC (`getblocktemplate`) server comes up after the gRPC one,
-        // and only in the mode that serves block templates. Both the `gbt_client`
-        // below and the signet miner's GBT script talk to it, so wait for it
-        // too rather than racing the first template request against startup.
+        let gbt_client = jsonrpsee::http_client::HttpClient::builder()
+            .build(format!("http://127.0.0.1:{}", enforcer.serve_rpc_port))
+            .map_err(|err| anyhow!("failed to create gbt client: {err:#}"))?;
+
+        // The JSON-RPC (`getblocktemplate`) server only runs in the mode that
+        // serves block templates, and it binds before the enforcer has synced.
+        // Both the `gbt_client` above and the signet miner's GBT script talk to
+        // it, so wait for it to serve a template rather than racing the first
+        // request against startup.
         if enforcer.enable_block_template_server {
             wait_for_port(
                 "127.0.0.1",
@@ -1339,11 +1368,8 @@ impl PostSetup {
             )
             .await
             .map_err(|e| anyhow!("Failed waiting for enforcer JSON-RPC port: {e}"))?;
+            wait_for_block_templates(&gbt_client).await?;
         }
-
-        let gbt_client = jsonrpsee::http_client::HttpClient::builder()
-            .build(format!("http://127.0.0.1:{}", enforcer.serve_rpc_port))
-            .map_err(|err| anyhow!("failed to create gbt client: {err:#}"))?;
         if let Some(signet_miner) = signet_miner.as_mut() {
             let () = SignetSetup::configure_miner(signet_miner, &dirs.base_dir, &enforcer)?;
         }

--- a/integration_tests/test_gbt_during_initial_sync.rs
+++ b/integration_tests/test_gbt_during_initial_sync.rs
@@ -1,0 +1,246 @@
+//! Regression test for the `getblocktemplate` endpoint being absent for the
+//! whole of the enforcer's initial sync, which with `--enable-wallet` covers
+//! the wallet's catch-up over every block it missed. Miners could neither tell
+//! a slow start from a dead enforcer, nor submit blocks they had found.
+//!
+//! `submitblock` only needs the node, so it must work throughout.
+//! `getblocktemplate` needs a synced mempool, so it must say so as a JSON-RPC
+//! error rather than as a refused connection.
+//!
+//! The sync window is held open by killing the enforcer, mining a gap behind
+//! its back, and restarting. Landing inside the window is asserted rather than
+//! assumed, so a window that closed too early fails the test.
+
+use std::time::Duration;
+
+use bip300301_enforcer_lib::bins::CommandExt as _;
+use cusf_enforcer_mempool::server::RpcClient as _;
+use futures::channel::mpsc;
+
+use crate::{
+    integration_test::{wait_for_validator_tip, wait_for_wallet_sync},
+    setup::{
+        Mode, Network, PostSetup, PreSetup, SetupOpts, read_enforcer_log, wait_for_block_templates,
+        wait_for_port, wait_for_port_free,
+    },
+    util::BinPaths,
+};
+
+pub const TEST_NAME: &str = "gbt_during_initial_sync";
+
+/// Bitcoin Core's code for "cannot build a template yet", which the enforcer
+/// reuses.
+const RPC_CLIENT_IN_INITIAL_DOWNLOAD: i32 = -10;
+
+/// Far above [`GAP_BLOCKS`], so the wallet crosses the gap the slow way rather
+/// than checkpointing across it, which is what holds the sync open.
+const MAX_BLOCK_BY_BLOCK_REPLAY: u32 = 1_000_000;
+
+/// Mined while the enforcer is down. The window the probes need is the whole
+/// initial sync, not just this gap, so it only has to be big enough to make
+/// that window comfortable.
+const GAP_BLOCKS: u32 = 200;
+
+/// Emitted once per block by the wallet's block-by-block replay.
+const REPLAY_LOG: &str = "unable to connect block to bdk_chain";
+
+/// Emitted by `spawn_gbt_server` when the JSON-RPC endpoint binds.
+const LISTENING_LOG: &str = "Listening for JSON-RPC on";
+
+/// Emitted by `sync_mempool` once the initial sync is done.
+const SYNCED_LOG: &str = "Initial mempool sync complete";
+
+/// Initial syncs this data dir has seen finish, over every run.
+fn initial_syncs_completed(post_setup: &PostSetup) -> anyhow::Result<usize> {
+    let log = read_enforcer_log(&post_setup.directories.enforcer_dir)?;
+    Ok(log.matches(SYNCED_LOG).count())
+}
+
+fn enforcer_args() -> Vec<String> {
+    vec![format!(
+        "--wallet-max-block-by-block-replay={MAX_BLOCK_BY_BLOCK_REPLAY}"
+    )]
+}
+
+async fn request_block_template(
+    post_setup: &PostSetup,
+) -> Result<bitcoin_jsonrpsee::client::BlockTemplate, jsonrpsee::core::client::Error> {
+    let mut request = bitcoin_jsonrpsee::client::BlockTemplateRequest::default();
+    request.capabilities.insert("coinbasetxn".to_owned());
+    post_setup.gbt_client.get_block_template(request).await
+}
+
+/// Raw hex of the block bitcoind currently has at its tip.
+async fn tip_block_hex(post_setup: &PostSetup) -> anyhow::Result<String> {
+    let block_hash = post_setup
+        .bitcoin_cli
+        .command::<String, _, String, _, _>([], "getbestblockhash", [])
+        .run_utf8()
+        .await?
+        .trim()
+        .to_owned();
+    let block_hex = post_setup
+        .bitcoin_cli
+        .command::<String, _, _, _, _>([], "getblock", [block_hash, "0".to_owned()])
+        .run_utf8()
+        .await?
+        .trim()
+        .to_owned();
+    Ok(block_hex)
+}
+
+pub async fn test_gbt_during_initial_sync(bin_paths: BinPaths) -> anyhow::Result<()> {
+    let (res_tx, _res_rx) = mpsc::unbounded();
+    let pre_setup = PreSetup::new(bin_paths.clone(), Network::Regtest)?;
+    let setup_opts: SetupOpts = SetupOpts {
+        enforcer_args: enforcer_args(),
+        ..Default::default()
+    };
+    let mut post_setup = pre_setup
+        .setup(Mode::GetBlockTemplate, setup_opts, res_tx.clone())
+        .await?;
+    let serve_rpc_port = post_setup.reserved_ports.enforcer_serve_rpc.port();
+
+    // Baseline: a synced enforcer serves templates, so the probes below read a
+    // real difference.
+    let template = request_block_template(&post_setup).await?;
+    tracing::info!(
+        height = template.height,
+        "synced enforcer serves block templates"
+    );
+
+    // Submitted during the sync below. bitcoind already has this block, so
+    // only bitcoind can answer `duplicate`, which is the proof of passthrough.
+    let known_block_hex = tip_block_hex(&post_setup).await?;
+
+    // The restarted enforcer must bind the endpoint before it logs one of
+    // these.
+    let syncs_before_restart = initial_syncs_completed(&post_setup)?;
+
+    tracing::info!("killing enforcer, then mining {GAP_BLOCKS} blocks behind its back");
+    post_setup.kill_enforcer().await?;
+    // The probes must reach the restarted enforcer, not the old one.
+    wait_for_port_free("127.0.0.1", serve_rpc_port, Duration::from_secs(10)).await?;
+    let mining_address = post_setup.mining_address.to_string();
+    post_setup
+        .bitcoin_cli
+        .command::<String, _, _, _, _>(
+            [],
+            "generatetoaddress",
+            [GAP_BLOCKS.to_string(), mining_address],
+        )
+        .run_utf8()
+        .await?;
+
+    tracing::info!("restarting enforcer -- it must serve JSON-RPC while it crosses the gap");
+    post_setup
+        .restart_enforcer(&bin_paths, enforcer_args(), res_tx.clone())
+        .await?;
+
+    // `restart_enforcer` only waits for the gRPC port. This wait used to sit
+    // behind the whole initial sync.
+    wait_for_port("127.0.0.1", serve_rpc_port, Duration::from_secs(30))
+        .await
+        .map_err(|err| {
+            anyhow::anyhow!(
+                "the `getblocktemplate` endpoint must bind before the initial sync \
+                 finishes, but nothing was listening on port {serve_rpc_port}: {err:#}"
+            )
+        })?;
+
+    // The ordering this test exists for, and what makes the probes below
+    // probes of a *syncing* enforcer.
+    let syncs_now = initial_syncs_completed(&post_setup)?;
+    anyhow::ensure!(
+        syncs_now == syncs_before_restart,
+        "the JSON-RPC endpoint only came up once the restarted enforcer had finished \
+         its initial sync ({SYNCED_LOG:?} had already been logged {syncs_now} times, up \
+         from {syncs_before_restart}, by the time port {serve_rpc_port} opened). Miners \
+         are refused for the whole of the sync, templates and `submitblock` alike"
+    );
+
+    // Probe 1: templates.
+    let err = match request_block_template(&post_setup).await {
+        Err(err) => err,
+        Ok(template) => anyhow::bail!(
+            "the enforcer served a block template at height {} while it was still \
+             crossing the {GAP_BLOCKS}-block gap, so it built one from a mempool it had \
+             not finished syncing -- or the gap was crossed in the moments between the \
+             port opening and this request, in which case raise GAP_BLOCKS",
+            template.height
+        ),
+    };
+    let jsonrpsee::core::client::Error::Call(err) = err else {
+        anyhow::bail!(
+            "`getblocktemplate` during the initial sync must fail as a JSON-RPC error, \
+             not at the transport: {err:#}"
+        )
+    };
+    anyhow::ensure!(
+        err.code() == RPC_CLIENT_IN_INITIAL_DOWNLOAD,
+        "`getblocktemplate` during the initial sync must report \
+         {RPC_CLIENT_IN_INITIAL_DOWNLOAD} (`RPC_CLIENT_IN_INITIAL_DOWNLOAD`), the code \
+         Bitcoin Core uses when it cannot build a template yet, but it reported {} ({})",
+        err.code(),
+        err.message()
+    );
+    tracing::info!(
+        "syncing enforcer refused a template with `{}: {}`",
+        err.code(),
+        err.message()
+    );
+
+    // Probe 2: block submission, which is what the outage actually cost.
+    let submit_result = post_setup
+        .gbt_client
+        .submit_block(known_block_hex)
+        .await
+        .map_err(|err| {
+            anyhow::anyhow!(
+                "`submitblock` must reach the node while the enforcer syncs, but the \
+                 call failed: {err:#}"
+            )
+        })?;
+    anyhow::ensure!(
+        submit_result.as_deref() == Some("duplicate"),
+        "bitcoind already has the submitted block, so it must answer `duplicate`; \
+         got {submit_result:?}"
+    );
+    tracing::info!("syncing enforcer passed `submitblock` through to the node");
+
+    // The handover, on the same endpoint, without a rebind.
+    wait_for_validator_tip(&post_setup).await?;
+    wait_for_wallet_sync(&mut post_setup).await?;
+    wait_for_block_templates(&post_setup.gbt_client).await?;
+    let template = request_block_template(&post_setup).await?;
+    tracing::info!(
+        height = template.height,
+        "enforcer serves block templates again once synced"
+    );
+
+    let enforcer_log = read_enforcer_log(&post_setup.directories.enforcer_dir)?;
+    anyhow::ensure!(
+        enforcer_log.contains(REPLAY_LOG),
+        "expected the restarted enforcer to cross the {GAP_BLOCKS}-block gap one block at \
+         a time, but {REPLAY_LOG:?} never appeared in its log. Did it come up without \
+         --wallet-max-block-by-block-replay={MAX_BLOCK_BY_BLOCK_REPLAY}, and checkpoint \
+         across the gap instead?"
+    );
+    // Belt and braces for the probes above, whatever the timing was.
+    let line_of = |needle: &str| {
+        enforcer_log
+            .lines()
+            .position(|line| line.contains(needle))
+            .ok_or_else(|| anyhow::anyhow!("{needle:?} never appeared in the enforcer log"))
+    };
+    let listening = line_of(LISTENING_LOG)?;
+    let synced = line_of(SYNCED_LOG)?;
+    anyhow::ensure!(
+        listening < synced,
+        "the JSON-RPC endpoint must bind before the initial mempool sync completes, but \
+         {LISTENING_LOG:?} was logged at line {listening}, after {SYNCED_LOG:?} at line \
+         {synced}"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
`getblocktemplate` won't be available until the wallet is synced, but `submitblock` is