### PR TITLE
rpc_client: ack the enforcer in getblocktemplate

### DIFF
--- a/app/main.rs
+++ b/app/main.rs
@@ -85,26 +85,6 @@ fn enforcer_wallet(enforcer: &Enforcer) -> Option<&Wallet> {
     }
 }
 
-async fn get_block_template<RpcClient>(
-    rpc_client: &RpcClient,
-    network: bitcoin::Network,
-) -> Result<bitcoin_jsonrpsee::client::BlockTemplate, wallet::error::BitcoinCoreRPC>
-where
-    RpcClient: MainClient + Sync,
-{
-    let mut request = bitcoin_jsonrpsee::client::BlockTemplateRequest::default();
-    if network == bitcoin::Network::Signet {
-        request.rules.push("signet".to_owned())
-    }
-    rpc_client
-        .get_block_template(request)
-        .await
-        .map_err(|err| wallet::error::BitcoinCoreRPC {
-            method: "getblocktemplate".to_string(),
-            error: err,
-        })
-}
-
 /// Resolve the message-start bytes used by Bitcoin Core's block files.
 ///
 /// An explicit CLI override remains the escape hatch for rebranded node
@@ -937,7 +917,7 @@ where
     // current Core tip. However, Core can still be stuck in IBD, hence the need for this loop
     // https://github.com/bitcoin/bitcoin/blob/6c4fe401e908cff1b67d80035b117aae15fe7db6/src/rpc/mining.cpp#L771-L773
     let sample_block_template = loop {
-        match get_block_template(&mainchain_client, network).await {
+        match rpc_client::get_block_template(&mainchain_client, network).await {
             Ok(block_template) => break block_template,
             Err(wallet::error::BitcoinCoreRPC {
                 method: _,
@@ -1547,7 +1527,7 @@ async fn main() -> Result<()> {
     }
 
     let signet_challenge = if info.chain == bitcoin::Network::Signet {
-        let block_template = get_block_template(&mainchain_client, info.chain).await?;
+        let block_template = rpc_client::get_block_template(&mainchain_client, info.chain).await?;
         let Some(signet_challenge) = block_template.signet_challenge else {
             return Err(miette!("signet challenge not found in block template"));
         };

--- a/lib/rpc_client.rs
+++ b/lib/rpc_client.rs
@@ -1,10 +1,13 @@
 use bitcoin_jsonrpsee::{
     MainClient,
+    client::{BlockTemplate, BlockTemplateRequest},
     jsonrpsee::{core::ClientError, http_client::HttpClient},
 };
+use jsonrpsee::{core::client::ClientT, rpc_params};
 use miette::Diagnostic;
+use serde::Serialize;
 
-use crate::{cli::NodeRpcConfig, errors::ErrorChain};
+use crate::{block_producer::error::BitcoinCoreRPC, cli::NodeRpcConfig, errors::ErrorChain};
 
 #[derive(Debug, Diagnostic, thiserror::Error)]
 pub enum Error {
@@ -203,4 +206,66 @@ where
         code == BITCOIN_CORE_RPC_TRANSACTION_REJECTED
     })
     .await
+}
+
+/// A `getblocktemplate` request that acknowledges the enforcer. Bitcoin Core
+/// serves a plain layer 1 template, so the caller adds the BIP300/BIP301
+/// commitments itself.
+#[derive(Debug, Serialize)]
+struct EnforcerBlockTemplateRequest {
+    #[serde(flatten)]
+    request: BlockTemplateRequest,
+    bip300301_enforcer: bool,
+}
+
+fn block_template_request(network: bitcoin::Network) -> EnforcerBlockTemplateRequest {
+    let mut request = BlockTemplateRequest::default();
+    if network == bitcoin::Network::Signet {
+        request.rules.push("signet".to_owned());
+    }
+    EnforcerBlockTemplateRequest {
+        request,
+        bip300301_enforcer: true,
+    }
+}
+
+/// Fetches a block template from Bitcoin Core.
+pub async fn get_block_template<RpcClient>(
+    rpc_client: &RpcClient,
+    network: bitcoin::Network,
+) -> Result<BlockTemplate, BitcoinCoreRPC>
+where
+    RpcClient: ClientT + Sync,
+{
+    rpc_client
+        .request(
+            "getblocktemplate",
+            rpc_params![block_template_request(network)],
+        )
+        .await
+        .map_err(|error| BitcoinCoreRPC {
+            method: "getblocktemplate".to_string(),
+            error,
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::block_template_request;
+
+    #[test]
+    fn signet_template_request_acks_the_enforcer() {
+        let request = serde_json::to_value(block_template_request(bitcoin::Network::Signet))
+            .expect("failed to serialize block template request");
+        assert_eq!(request["bip300301_enforcer"], serde_json::json!(true));
+        assert_eq!(request["rules"], serde_json::json!(["segwit", "signet"]));
+    }
+
+    #[test]
+    fn regtest_template_request_drops_the_signet_rule() {
+        let request = serde_json::to_value(block_template_request(bitcoin::Network::Regtest))
+            .expect("failed to serialize block template request");
+        assert_eq!(request["bip300301_enforcer"], serde_json::json!(true));
+        assert_eq!(request["rules"], serde_json::json!(["segwit"]));
+    }
 }


### PR DESCRIPTION
The patched Bitcoin Core serves `getblocktemplate` only to a caller that sets `bip300301_enforcer: true`. The enforcer did not set it, so it exited at start with "failed to get sample block template".

The template request now carries the ack, and one helper in `rpc_client` holds it for both call sites.