### PR TITLE
Tolerate legacy coin types for derivation paths

### DIFF
--- a/integration_tests/integration_test.rs
+++ b/integration_tests/integration_test.rs
@@ -1191,6 +1191,22 @@ pub fn tests(
     ));
 
     async_trials.push(new_bespoke_trial(
+        crate::test_wallet_descriptor_fallback::LEGACY_TEST_NAME,
+        bin_paths,
+        &file_registry,
+        &failure_collector,
+        crate::test_wallet_descriptor_fallback::test_wallet_legacy_descriptor,
+    ));
+
+    async_trials.push(new_bespoke_trial(
+        crate::test_wallet_descriptor_fallback::FOREIGN_TEST_NAME,
+        bin_paths,
+        &file_registry,
+        &failure_collector,
+        crate::test_wallet_descriptor_fallback::test_wallet_foreign_descriptor,
+    ));
+
+    async_trials.push(new_bespoke_trial(
         crate::test_wallet_large_gap_sync::TEST_NAME,
         bin_paths,
         &file_registry,

--- a/integration_tests/lib.rs
+++ b/integration_tests/lib.rs
@@ -21,6 +21,7 @@ mod test_rest_disabled;
 mod test_seed_migration;
 mod test_sidechain_ack_policy;
 mod test_unconfirmed_transactions;
+mod test_wallet_descriptor_fallback;
 mod test_wallet_large_gap_sync;
 mod test_wallet_less_block_template;
 mod test_wallet_reorg_multi_block;

--- a/integration_tests/test_wallet_descriptor_fallback.rs
+++ b/integration_tests/test_wallet_descriptor_fallback.rs
@@ -1,0 +1,226 @@
+//! Starting on a wallet whose persisted descriptor is not the one this build
+//! derives.
+//!
+//! The BIP 84 coin type used to be the test-network `1'` on every network,
+//! mainnet included. Making it network-aware changed what a mainnet enforcer
+//! derives, and BDK will not open a wallet under a descriptor other than the
+//! one it was persisted with, so every mainnet wallet from an older build
+//! stopped loading. One test per obligation that follows: a wallet on the
+//! legacy derivation must still open and keep deriving where its funds are,
+//! and one on neither derivation must still be refused -- saying what
+//! differs, not just that a load failed.
+//!
+//! Neither is reachable on the networks the harness runs, where the coin type
+//! never changed, so both enforcers here are started with the hidden
+//! `--wallet-derivation-coin-type`. It decides which descriptor the enforcer
+//! asks for, which is the whole of what the upgrade changed.
+
+use anyhow::Context as _;
+use bip300301_enforcer_lib::proto::mainchain::{GetBalanceRequest, GetInfoRequest};
+use futures::channel::mpsc;
+
+use crate::{
+    integration_test::{fund_enforcer, wait_for_wallet_sync},
+    setup::{DummySidechain, Mode, Network, PostSetup, PreSetup, SetupOpts, read_enforcer_log},
+    util::BinPaths,
+};
+
+pub const LEGACY_TEST_NAME: &str = "wallet_legacy_descriptor";
+pub const FOREIGN_TEST_NAME: &str = "wallet_foreign_descriptor";
+
+/// Emitted (warn) when the wallet only opens under the legacy descriptor.
+/// Nothing else tells the fallback apart from an ordinary load.
+const LEGACY_FALLBACK_LOG: &str = "Loaded existing BDK wallet under the legacy coin type";
+
+/// What a mainnet build derives under. Regtest's own is the legacy one, so
+/// starting with this against an ordinary regtest wallet is the upgrade.
+const MAINNET_COIN_TYPE: u32 = 0;
+
+/// Neither what a network implies nor the legacy value: a wallet under it
+/// belongs to no build the fallback knows about.
+const FOREIGN_COIN_TYPE: u32 = 7;
+
+/// The account paths as they appear in the public descriptors the enforcer
+/// reports, where the path is the key's origin and `/0/*` follows the xpub.
+const LEGACY_ORIGIN: &str = "/84'/1'/0']";
+const FOREIGN_ORIGIN: &str = "/84'/7'/0']";
+
+fn coin_type_args(coin_type: u32) -> Vec<String> {
+    vec![format!("--wallet-derivation-coin-type={coin_type}")]
+}
+
+/// What must survive the restart: the descriptor, and the coins it sees.
+#[derive(Debug, Eq, PartialEq)]
+struct WalletState {
+    external_descriptor: String,
+    unspent_output_count: u32,
+    confirmed_sats: u64,
+}
+
+async fn wallet_state(post_setup: &mut PostSetup) -> anyhow::Result<WalletState> {
+    let info = post_setup
+        .wallet_service_client
+        .get_info(GetInfoRequest::default())
+        .await?
+        .into_owned();
+    let external_descriptor = info
+        .descriptors
+        .get("external")
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "wallet reported no external descriptor, only: {:?}",
+                info.descriptors
+            )
+        })?
+        .clone();
+    let balance = post_setup
+        .wallet_service_client
+        .get_balance(GetBalanceRequest::default())
+        .await?
+        .into_owned();
+    Ok(WalletState {
+        external_descriptor,
+        unspent_output_count: info.unspent_output_count,
+        confirmed_sats: balance.confirmed_sats,
+    })
+}
+
+/// A miette report is a box-drawn tree wrapped to a fixed width, and it wraps
+/// *inside* long tokens, so a descriptor arrives in pieces. Two views of it,
+/// so that no match depends on where the wrapping landed.
+struct Report {
+    /// Words in order, tree markers dropped. For matching prose.
+    words: String,
+    /// The same with spaces removed, for a token wrapping may have broken.
+    packed: String,
+}
+
+fn parse_report(raw: &str) -> Report {
+    let words = raw
+        .split_whitespace()
+        .filter(|token| token.chars().any(char::is_alphanumeric))
+        .collect::<Vec<_>>()
+        .join(" ");
+    let packed = words.split_whitespace().collect();
+    Report { words, packed }
+}
+
+/// A wallet on the legacy derivation must open under a build that derives a
+/// different one, and go on deriving where its coins are.
+pub async fn test_wallet_legacy_descriptor(bin_paths: BinPaths) -> anyhow::Result<()> {
+    let (res_tx, _res_rx) = mpsc::unbounded();
+    let pre_setup = PreSetup::new(bin_paths.clone(), Network::Regtest)?;
+    let setup_opts: SetupOpts = SetupOpts::default();
+    let mut post_setup = pre_setup
+        .setup(Mode::Mempool, setup_opts, res_tx.clone())
+        .await?;
+
+    // Regtest's coin type is the legacy one, so an ordinary boot leaves
+    // exactly the wallet an old build would have.
+    let () = fund_enforcer::<DummySidechain>(&mut post_setup).await?;
+    let () = wait_for_wallet_sync(&mut post_setup).await?;
+    let before = wallet_state(&mut post_setup).await?;
+    anyhow::ensure!(
+        before.external_descriptor.contains(LEGACY_ORIGIN),
+        "the wallet to be migrated must sit on the legacy derivation, got: {}",
+        before.external_descriptor,
+    );
+    anyhow::ensure!(
+        before.confirmed_sats > 0 && before.unspent_output_count > 0,
+        "the wallet must hold coins, or losing sight of them would not show up here: {before:?}",
+    );
+
+    // The upgrade: same data dir, under a build asking for a descriptor the
+    // database does not hold.
+    tracing::info!("restarting enforcer under the mainnet coin type");
+    post_setup
+        .restart_enforcer(
+            &bin_paths,
+            coin_type_args(MAINNET_COIN_TYPE),
+            res_tx.clone(),
+        )
+        .await
+        .context(
+            "the enforcer must start on a wallet persisted under the legacy \
+             coin type, not exit with a descriptor mismatch",
+        )?;
+    let () = wait_for_wallet_sync(&mut post_setup).await?;
+
+    let after = wallet_state(&mut post_setup).await?;
+    anyhow::ensure!(
+        after == before,
+        "the wallet must be unchanged across the upgrade.\n before: {before:?}\n after:  {after:?}",
+    );
+
+    // Prove the fallback is what got us here, not an override the restart
+    // quietly ignored.
+    let enforcer_log = read_enforcer_log(&post_setup.directories.enforcer_dir)?;
+    anyhow::ensure!(
+        enforcer_log.contains(LEGACY_FALLBACK_LOG),
+        "expected the wallet to report opening under the legacy coin type, but \
+         {LEGACY_FALLBACK_LOG:?} never appeared in the enforcer log. Did the \
+         enforcer come up without --wallet-derivation-coin-type={MAINNET_COIN_TYPE}, \
+         leaving it deriving what was already persisted?",
+    );
+
+    drop(post_setup);
+    Ok(())
+}
+
+/// A wallet on neither derivation must still stop the enforcer, reporting
+/// what differs rather than just that a load failed.
+pub async fn test_wallet_foreign_descriptor(bin_paths: BinPaths) -> anyhow::Result<()> {
+    let (res_tx, _res_rx) = mpsc::unbounded();
+    let pre_setup = PreSetup::new(bin_paths.clone(), Network::Regtest)?;
+    let setup_opts: SetupOpts = SetupOpts {
+        enforcer_args: coin_type_args(FOREIGN_COIN_TYPE),
+        ..Default::default()
+    };
+    let mut post_setup = pre_setup
+        .setup(Mode::Mempool, setup_opts, res_tx.clone())
+        .await?;
+    let foreign = wallet_state(&mut post_setup).await?;
+    anyhow::ensure!(
+        foreign.external_descriptor.contains(FOREIGN_ORIGIN),
+        "this wallet must sit on a derivation no build knows, or the fallback \
+         would rightly adopt it: {}",
+        foreign.external_descriptor,
+    );
+
+    // Restart without the override: regtest wants the legacy descriptor, so
+    // the fallback has nowhere else to look.
+    tracing::info!("restarting enforcer against a foreign wallet");
+    let restarted = post_setup
+        .restart_enforcer(&bin_paths, Vec::<String>::new(), res_tx.clone())
+        .await;
+    anyhow::ensure!(
+        restarted.is_err(),
+        "the enforcer must not start on a wallet it cannot account for",
+    );
+
+    // The failure is a startup error, so it is on stderr rather than in the
+    // rolling log: `main` returns it before anything logs it.
+    let stderr_path = post_setup.directories.enforcer_dir.join("stderr.txt");
+    let raw = std::fs::read_to_string(&stderr_path)
+        .with_context(|| format!("reading {}", stderr_path.display()))?;
+    let report = parse_report(&raw);
+    // The actionable diagnosis, not the opaque "failed to load wallet" this
+    // used to report, and what actually differs.
+    for expected in ["wallet data mismatch", "Descriptor mismatch"] {
+        anyhow::ensure!(
+            report.words.contains(expected),
+            "the startup failure must mention {expected:?}, got: {raw}",
+        );
+    }
+    // Both paths: which wallet would open under this build, and which one is
+    // actually there.
+    for expected in [LEGACY_ORIGIN, FOREIGN_ORIGIN] {
+        anyhow::ensure!(
+            report.packed.contains(expected),
+            "the startup failure must name the {expected:?} account path, got: {raw}",
+        );
+    }
+
+    drop(post_setup);
+    Ok(())
+}

--- a/integration_tests/util.rs
+++ b/integration_tests/util.rs
@@ -569,14 +569,14 @@ impl<T> From<JoinHandle<T>> for AbortOnDrop<T> {
     }
 }
 
+/// A writable handle to `path`, appending to what is already there. Reopened
+/// whenever a process is respawned into the same directory, where this
+/// previously opened read-only and silently dropped the new process's output.
 fn open_file_or_create_new(path: &std::path::Path) -> Result<std::fs::File, std::io::Error> {
-    std::fs::File::create_new(path).or_else(|err| {
-        if err.kind() == std::io::ErrorKind::AlreadyExists {
-            std::fs::File::open(path)
-        } else {
-            Err(err)
-        }
-    })
+    std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
 }
 
 /// Run command with args, dumping stderr/stdout to `dir` on exit

--- a/lib/cli.rs
+++ b/lib/cli.rs
@@ -396,6 +396,14 @@ pub struct WalletConfig {
     )]
     pub max_block_by_block_replay: u32,
 
+    /// SLIP-44 coin type for the BIP 84 account path, overriding the one the
+    /// network implies. Drives a descriptor mismatch on a network where the
+    /// coin type never changed and one could not otherwise arise.
+    ///
+    /// Hidden: for testing purposes only
+    #[arg(long = "wallet-derivation-coin-type", hide = true)]
+    pub derivation_coin_type: Option<u32>,
+
     /// Path to a file containing exactly 12 space-separated BIP39 mnemonic words.
     #[arg(long = "wallet-seed-file", conflicts_with = "auto_create")]
     pub mnemonic_path: Option<PathBuf>,
@@ -883,6 +891,23 @@ mod tests {
         };
         assert_eq!(parse(&[]), 2_000);
         assert_eq!(parse(&["--wallet-max-block-by-block-replay=50"]), 50);
+    }
+
+    /// The integration tests persist a wallet under one coin type and start
+    /// the enforcer under another, which only works while the flag keeps
+    /// this spelling.
+    #[test]
+    fn derivation_coin_type_is_overridable() {
+        let parse = |args: &[&str]| {
+            let mut argv = vec!["bip300301_enforcer"];
+            argv.extend_from_slice(args);
+            Config::try_parse_from(argv)
+                .expect("should parse")
+                .wallet_opts
+                .derivation_coin_type
+        };
+        assert_eq!(parse(&[]), None);
+        assert_eq!(parse(&["--wallet-derivation-coin-type=0"]), Some(0));
     }
 
     /// The annotation itself: typing a field `SecretString` is what makes the

--- a/lib/wallet/error.rs
+++ b/lib/wallet/error.rs
@@ -70,13 +70,16 @@ impl ToStatus for NotUnlocked {
     }
 }
 
-/// Wallet data mismatch
+/// Wallet data mismatch. The field is BDK's account of what differs, without
+/// which the report cannot say whether the fix is a different data dir or a
+/// different build.
 #[derive(Debug, Diagnostic, Error)]
 #[diagnostic(code(wallet_data_mismatch))]
 #[error(
-    "enforcer wallet data mismatch, data directory content does not line up with wallet descriptor"
+    "enforcer wallet data mismatch, data directory content does not line up \
+     with wallet descriptor: {0}"
 )]
-pub struct DataMismatch;
+pub struct DataMismatch(String);
 
 impl ToStatus for DataMismatch {
     fn builder(&self) -> StatusBuilder<'_> {
@@ -458,10 +461,14 @@ impl From<bdk_wallet::CreateWithPersistError<Persistence>> for InitWalletFromMne
 
 impl From<bdk_wallet::LoadWithPersistError<Persistence>> for InitWalletFromMnemonic {
     fn from(err: bdk_wallet::LoadWithPersistError<Persistence>) -> Self {
-        if err.to_string().contains("data mismatch") {
-            Self::DataMismatch(DataMismatch)
-        } else {
-            Self::LoadWallet(Box::new(err))
+        // Matched on the variant, not the rendered message: BDK has no one
+        // phrase common to its mismatches, so a substring test recognizes
+        // none of them.
+        match &err {
+            bdk_wallet::LoadWithPersistError::InvalidChangeSet(
+                bdk_wallet::LoadError::Mismatch(mismatch),
+            ) => Self::DataMismatch(DataMismatch(mismatch.to_string())),
+            _ => Self::LoadWallet(Box::new(err)),
         }
     }
 }
@@ -541,8 +548,10 @@ pub enum InitWallet {
     InitSeedStore(#[from] InitSeedStore),
     #[error(transparent)]
     InitChainSourceClient(#[from] InitChainSourceClient),
+    // `#[source]`: a bare `Box<_>` is not a source to thiserror, and without
+    // it the report says initialization failed and not a word of why.
     #[error("failed to initialize wallet from mnemonic")]
-    InitFromMnemonic(Box<InitWalletFromMnemonic>),
+    InitFromMnemonic(#[source] Box<InitWalletFromMnemonic>),
     #[error("no signet challenge found")]
     NoSignetChallengeFound,
     #[error("failed to open connection to wallet DB")]

--- a/lib/wallet/mod.rs
+++ b/lib/wallet/mod.rs
@@ -64,6 +64,7 @@ mod thread_safe_connection;
 mod util;
 
 pub(crate) type Persistence = thread_safe_connection::ThreadSafeConnection;
+type PersistenceError = <Persistence as bdk_wallet::AsyncWalletPersister>::Error;
 type BdkWallet = bdk_wallet::PersistedWallet<Persistence>;
 
 type ElectrumClient = BdkElectrumClient<bdk_electrum::electrum_client::Client>;
@@ -76,6 +77,27 @@ const fn slip44_coin_type(network: Network) -> u32 {
         Network::Bitcoin => 0,
         _ => 1,
     }
+}
+
+/// The coin type every wallet derived under before [`slip44_coin_type`] made
+/// the choice network-aware. On mainnet it is not what this build derives, so
+/// wallets persisted by those builds need
+/// [`WalletInner::initialize_wallet_from_mnemonic`]'s fallback.
+const LEGACY_COIN_TYPE: u32 = 1;
+
+fn descriptor_coin_type(config: &WalletConfig, network: Network) -> u32 {
+    config
+        .derivation_coin_type
+        .unwrap_or_else(|| slip44_coin_type(network))
+}
+
+fn is_descriptor_mismatch(err: &bdk_wallet::LoadWithPersistError<PersistenceError>) -> bool {
+    matches!(
+        err,
+        bdk_wallet::LoadWithPersistError::InvalidChangeSet(bdk_wallet::LoadError::Mismatch(
+            bdk_wallet::LoadMismatch::Descriptor { .. }
+        ))
+    )
 }
 
 #[non_exhaustive]
@@ -371,6 +393,7 @@ impl WalletInner {
     fn bip84_descriptors(
         mnemonic: &Mnemonic,
         network: bdk_wallet::bitcoin::Network,
+        coin_type: u32,
     ) -> Result<(String, String), error::InitWalletFromMnemonic> {
         let extended_key: ExtendedKey = mnemonic.clone().into_extended_key()?;
 
@@ -378,43 +401,89 @@ impl WalletInner {
             .into_xprv(network.into())
             .ok_or(error::InitWalletFromMnemonic::DeriveXpriv)?;
 
-        let coin_type = slip44_coin_type(network);
         Ok((
             format!("wpkh({xpriv}/84'/{coin_type}'/0'/0/*)"),
             format!("wpkh({xpriv}/84'/{coin_type}'/0'/1/*)"),
         ))
     }
 
-    async fn initialize_wallet_from_mnemonic(
-        mnemonic: &Mnemonic,
+    /// Insists on exactly these descriptors. `Ok(None)` if the database holds
+    /// no wallet yet.
+    async fn load_bdk_wallet(
+        external_desc: &str,
+        internal_desc: &str,
         network: bdk_wallet::bitcoin::Network,
         wallet_database: &mut Persistence,
-    ) -> Result<BdkWallet, error::InitWalletFromMnemonic> {
-        let (external_desc, internal_desc) = Self::bip84_descriptors(mnemonic, network)?;
-
-        tracing::debug!("Attempting load of existing BDK wallet");
-        let bitcoin_wallet = bdk_wallet::Wallet::load()
-            .descriptor(KeychainKind::External, Some(external_desc.clone()))
-            .descriptor(KeychainKind::Internal, Some(internal_desc.clone()))
+    ) -> Result<Option<BdkWallet>, bdk_wallet::LoadWithPersistError<PersistenceError>> {
+        bdk_wallet::Wallet::load()
+            .descriptor(KeychainKind::External, Some(external_desc.to_owned()))
+            .descriptor(KeychainKind::Internal, Some(internal_desc.to_owned()))
             .extract_keys()
             .check_network(network)
             .load_wallet_async(wallet_database)
-            .await?;
+            .await
+    }
 
-        let bitcoin_wallet = match bitcoin_wallet {
-            Some(wallet) => {
+    async fn initialize_wallet_from_mnemonic(
+        mnemonic: &Mnemonic,
+        network: bdk_wallet::bitcoin::Network,
+        config: &WalletConfig,
+        wallet_database: &mut Persistence,
+    ) -> Result<BdkWallet, error::InitWalletFromMnemonic> {
+        let coin_type = descriptor_coin_type(config, network);
+        let (external_desc, internal_desc) = Self::bip84_descriptors(mnemonic, network, coin_type)?;
+
+        tracing::debug!(%coin_type, "Attempting load of existing BDK wallet");
+        let loaded =
+            Self::load_bdk_wallet(&external_desc, &internal_desc, network, wallet_database).await;
+
+        let bitcoin_wallet = match loaded {
+            Ok(Some(wallet)) => {
                 tracing::info!("Loaded existing BDK wallet");
                 wallet
             }
 
-            None => {
-                tracing::info!("Creating new BDK wallet");
+            Ok(None) => {
+                tracing::info!(%coin_type, "Creating new BDK wallet");
 
                 bdk_wallet::Wallet::create(external_desc, internal_desc)
                     .network(network)
                     .create_wallet_async(wallet_database)
                     .await?
             }
+
+            // A wallet persisted before the coin type became network-aware
+            // sits at `LEGACY_COIN_TYPE` on every network. Adopt it rather
+            // than refusing to start: this node's funds are on those
+            // addresses, and re-deriving would lose sight of them.
+            Err(err) if is_descriptor_mismatch(&err) && coin_type != LEGACY_COIN_TYPE => {
+                let (legacy_external, legacy_internal) =
+                    Self::bip84_descriptors(mnemonic, network, LEGACY_COIN_TYPE)?;
+                match Self::load_bdk_wallet(
+                    &legacy_external,
+                    &legacy_internal,
+                    network,
+                    wallet_database,
+                )
+                .await
+                {
+                    Ok(Some(wallet)) => {
+                        tracing::warn!(
+                            %coin_type,
+                            legacy_coin_type = %LEGACY_COIN_TYPE,
+                            "Loaded existing BDK wallet under the legacy coin type. It was \
+                             created before the derivation path became network-aware, and \
+                             keeps deriving addresses under the path it was created with.",
+                        );
+                        wallet
+                    }
+                    // Not a legacy wallet either. Report the original
+                    // mismatch, against the descriptor this build wanted.
+                    _ => return Err(err.into()),
+                }
+            }
+
+            Err(err) => return Err(err.into()),
         };
 
         Ok(bitcoin_wallet)
@@ -465,6 +534,7 @@ impl WalletInner {
                 let initialized = WalletInner::initialize_wallet_from_mnemonic(
                     &mnemonic,
                     network,
+                    &config.wallet_opts,
                     &mut wallet_database,
                 )
                 .await?;
@@ -584,8 +654,13 @@ impl WalletInner {
         let mut write_guard = self.locks.write_slot().await;
         let mut database = self.locks.db(&write_guard).await;
         let network = self.validator().network();
-        let wallet =
-            WalletInner::initialize_wallet_from_mnemonic(&mnemonic, network, &mut database).await?;
+        let wallet = WalletInner::initialize_wallet_from_mnemonic(
+            &mnemonic,
+            network,
+            &self.config.wallet_opts,
+            &mut database,
+        )
+        .await?;
         drop(database);
         *write_guard = Some(wallet);
         drop(write_guard);
@@ -629,8 +704,13 @@ impl WalletInner {
         let network = self.validator().network();
 
         tracing::debug!("unlock wallet: initializing BDK wallet struct");
-        let wallet =
-            WalletInner::initialize_wallet_from_mnemonic(&mnemonic, network, &mut database).await?;
+        let wallet = WalletInner::initialize_wallet_from_mnemonic(
+            &mnemonic,
+            network,
+            &self.config.wallet_opts,
+            &mut database,
+        )
+        .await?;
         drop(database);
         *write_guard = Some(wallet);
         drop(write_guard);
@@ -1946,10 +2026,14 @@ mod tests {
     use bitcoin::{BlockHash, hashes::Hash as _};
 
     use super::{
-        CreateTransactionParams, KeychainKind, M8BmmRequest, Mnemonic, Network, Wallet,
-        WalletConfig, WalletInner, WalletSyncSource, slip44_coin_type,
+        BdkWallet, CreateTransactionParams, KeychainKind, LEGACY_COIN_TYPE, M8BmmRequest, Mnemonic,
+        Network, Persistence, Wallet, WalletConfig, WalletInner, WalletSyncSource, error,
+        slip44_coin_type,
     };
-    use crate::types::{BmmCommitment, SidechainNumber};
+    use crate::{
+        errors::ErrorChain,
+        types::{BmmCommitment, SidechainNumber},
+    };
 
     /// The BIP 39 test mnemonic that BIP 84's published vectors derive from.
     const TEST_MNEMONIC: &str = "abandon abandon abandon abandon abandon abandon \
@@ -1970,9 +2054,13 @@ mod tests {
         }
     }
 
+    fn test_mnemonic() -> Mnemonic {
+        Mnemonic::parse_in_normalized(Language::English, TEST_MNEMONIC).unwrap()
+    }
+
     fn descriptors(network: Network) -> (String, String) {
-        let mnemonic = Mnemonic::parse_in_normalized(Language::English, TEST_MNEMONIC).unwrap();
-        WalletInner::bip84_descriptors(&mnemonic, network).unwrap()
+        WalletInner::bip84_descriptors(&test_mnemonic(), network, slip44_coin_type(network))
+            .unwrap()
     }
 
     #[test]
@@ -2037,6 +2125,164 @@ mod tests {
         assert!(signet.starts_with("tb1"), "{signet}");
         assert!(regtest.starts_with("bcrt1"), "{regtest}");
         assert_ne!(mainnet, signet);
+    }
+
+    fn wallet_config(derivation_coin_type: Option<u32>) -> WalletConfig {
+        WalletConfig {
+            auto_create: false,
+            esplora_url: None,
+            electrum_host: None,
+            electrum_port: None,
+            skip_periodic_sync: false,
+            sync_source: WalletSyncSource::Disabled,
+            max_block_by_block_replay: 2_000,
+            derivation_coin_type,
+            mnemonic_path: None,
+        }
+    }
+
+    /// Open the wallet the way the enforcer does.
+    async fn open_wallet(
+        database: &mut Persistence,
+        network: Network,
+        coin_type: Option<u32>,
+    ) -> Result<BdkWallet, error::InitWalletFromMnemonic> {
+        WalletInner::initialize_wallet_from_mnemonic(
+            &test_mnemonic(),
+            network,
+            &wallet_config(coin_type),
+            database,
+        )
+        .await
+    }
+
+    /// Leave `database` holding a wallet persisted under `coin_type`, and
+    /// return its first receive address.
+    async fn persist_wallet_under(
+        database: &mut Persistence,
+        network: Network,
+        coin_type: u32,
+    ) -> String {
+        let wallet = open_wallet(database, network, Some(coin_type))
+            .await
+            .expect("an empty database must yield a freshly created wallet");
+        wallet.peek_address(KeychainKind::External, 0).to_string()
+    }
+
+    async fn empty_database(dir: &temp_dir::TempDir) -> Persistence {
+        Persistence::open(dir.path().join("wallet.sqlite.db"))
+            .await
+            .expect("must open a wallet database")
+    }
+
+    /// The upgrade the fallback exists for: a mainnet wallet persisted under
+    /// [`LEGACY_COIN_TYPE`] has to open under a build that derives `0`, and
+    /// keep deriving where its funds are.
+    #[tokio::test]
+    async fn a_legacy_mainnet_wallet_still_loads() {
+        let dir = temp_dir::TempDir::new().unwrap();
+        let mut database = empty_database(&dir).await;
+        let legacy_address =
+            persist_wallet_under(&mut database, Network::Bitcoin, LEGACY_COIN_TYPE).await;
+
+        let wallet = open_wallet(&mut database, Network::Bitcoin, None)
+            .await
+            .expect("a legacy mainnet wallet must still load");
+
+        assert_eq!(
+            wallet.peek_address(KeychainKind::External, 0).to_string(),
+            legacy_address,
+            "the wallet must keep deriving under the path it was created with",
+        );
+        // Guard the premise: the two derivations must genuinely differ.
+        assert_ne!(
+            legacy_address, "bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu",
+            "the legacy derivation must not coincide with the BIP 84 one",
+        );
+    }
+
+    /// An empty database is unaffected by the fallback.
+    #[tokio::test]
+    async fn a_fresh_mainnet_wallet_is_created_under_the_network_coin_type() {
+        let dir = temp_dir::TempDir::new().unwrap();
+        let mut database = empty_database(&dir).await;
+
+        let wallet = open_wallet(&mut database, Network::Bitcoin, None)
+            .await
+            .expect("an empty database must yield a freshly created wallet");
+
+        assert_eq!(
+            wallet.peek_address(KeychainKind::External, 0).to_string(),
+            "bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu",
+        );
+    }
+
+    /// Neither this build's descriptor nor the legacy one: a foreign wallet,
+    /// which must fail as a data mismatch rather than an opaque load failure.
+    #[tokio::test]
+    async fn an_unrecognized_descriptor_is_a_data_mismatch() {
+        let dir = temp_dir::TempDir::new().unwrap();
+        let mut database = empty_database(&dir).await;
+        let _foreign_address = persist_wallet_under(&mut database, Network::Bitcoin, 7).await;
+
+        let err = open_wallet(&mut database, Network::Bitcoin, None)
+            .await
+            .expect_err("a foreign descriptor must not load");
+
+        assert!(
+            matches!(err, error::InitWalletFromMnemonic::DataMismatch(_)),
+            "expected a data mismatch, got: {err:#}",
+        );
+        // The report has to name what differs; not doing so is what left the
+        // original bug report with nothing to go on.
+        let rendered = format!("{:#}", ErrorChain::new(&err));
+        assert!(
+            rendered.contains("Descriptor mismatch"),
+            "the mismatch BDK reported must survive into the error: {rendered}",
+        );
+    }
+
+    /// The mapping used to be a substring test for "data mismatch", a phrase
+    /// BDK never emits, so every mismatch fell through to the opaque
+    /// `LoadWallet` variant. Pins why the mapping must stay on the variant.
+    #[tokio::test]
+    async fn bdk_does_not_call_a_mismatch_a_data_mismatch() {
+        let dir = temp_dir::TempDir::new().unwrap();
+        let mut database = empty_database(&dir).await;
+        let _foreign_address = persist_wallet_under(&mut database, Network::Bitcoin, 7).await;
+
+        let (external, internal) = descriptors(Network::Bitcoin);
+        let err =
+            WalletInner::load_bdk_wallet(&external, &internal, Network::Bitcoin, &mut database)
+                .await
+                .expect_err("a foreign descriptor must not load");
+
+        assert!(
+            !err.to_string().contains("data mismatch"),
+            "BDK renders its mismatch as `{err}`. If it now says `data \
+             mismatch`, the old substring test would work again -- but the \
+             mapping is matched on the variant, so only this pin is stale.",
+        );
+    }
+
+    /// The test networks' coin type never changed, so there is nothing to
+    /// fall back to and a mismatch is exactly that.
+    #[tokio::test]
+    async fn a_test_network_has_no_legacy_descriptor_to_fall_back_to() {
+        let dir = temp_dir::TempDir::new().unwrap();
+        let mut database = empty_database(&dir).await;
+        assert_eq!(slip44_coin_type(Network::Regtest), LEGACY_COIN_TYPE);
+        // The mainnet coin type, on a regtest wallet.
+        let _foreign_address = persist_wallet_under(&mut database, Network::Regtest, 0).await;
+
+        let err = open_wallet(&mut database, Network::Regtest, None)
+            .await
+            .expect_err("a foreign descriptor must not load");
+
+        assert!(
+            matches!(err, error::InitWalletFromMnemonic::DataMismatch(_)),
+            "expected a data mismatch, got: {err:#}",
+        );
     }
 
     #[test]
@@ -2162,6 +2408,7 @@ mod tests {
             skip_periodic_sync: false,
             sync_source: WalletSyncSource::Esplora,
             max_block_by_block_replay: 2_000,
+            derivation_coin_type: None,
             mnemonic_path: None,
         };
 
@@ -2186,6 +2433,7 @@ mod tests {
             skip_periodic_sync: false,
             sync_source: WalletSyncSource::Electrum,
             max_block_by_block_replay: 2_000,
+            derivation_coin_type: None,
             mnemonic_path: None,
         };
 
@@ -2207,6 +2455,7 @@ mod tests {
             skip_periodic_sync: false,
             sync_source: WalletSyncSource::Disabled,
             max_block_by_block_replay: 2_000,
+            derivation_coin_type: None,
             mnemonic_path: None,
         };
 


### PR DESCRIPTION
PR560 did a breaking backwards change without adding any compatability mechanisms. Add one here, such that old wallets can continue to work.