### PR TITLE
fix: Redact node RPC credentials from signet miner stderr and errors

### DIFF
--- a/lib/bins.rs
+++ b/lib/bins.rs
@@ -8,8 +8,15 @@ use crate::proto::{StatusBuilder, ToStatus};
 pub enum CommandError {
     #[error(transparent)]
     FromUtf8(#[from] std::string::FromUtf8Error),
+    // Commands are invoked with the node's RPC credentials in their argv (see
+    // `BitcoinCli::default_args`), which a failing child can echo back at us on
+    // stderr, so the message is redacted before it reaches a log or a gRPC
+    // status.
     #[error("{}", match std::str::from_utf8(.0) {
-        Ok(err_msg) => format!("Command failed with error: `{err_msg}`"),
+        Ok(err_msg) => {
+            let err_msg = crate::cli::redact_rpc_credentials(err_msg);
+            format!("Command failed with error: `{err_msg}`")
+        },
         Err(_) => {
             let stderr_hex = hex::encode(.0);
             format!("Command failed with stderr hex: `{stderr_hex}`")
@@ -51,7 +58,7 @@ impl CommandExt for tokio::process::Command {
         if output.status.success() {
             if !output.stderr.is_empty() {
                 let stderr = match String::from_utf8(output.stderr) {
-                    Ok(err_msgs) => err_msgs,
+                    Ok(err_msgs) => crate::cli::redact_rpc_credentials(&err_msgs).into_owned(),
                     Err(err) => hex::encode(err.into_bytes()),
                 };
                 tracing::warn!("Command ran successfully, but stderr was not empty: `{stderr}`")

--- a/lib/block_producer/mine.rs
+++ b/lib/block_producer/mine.rs
@@ -551,7 +551,12 @@ impl BlockProducer {
         // We want to stream stdout/stderr as they come in, for investigating hanging processes.
         command.stdout(std::process::Stdio::piped());
         command.stderr(std::process::Stdio::piped());
-        tracing::debug!("Running signet miner: {:?}", command);
+        // The miner is handed `bitcoin-cli`'s full command line, RPC password
+        // included, so the command cannot be logged verbatim.
+        tracing::debug!(
+            "Running signet miner: {}",
+            crate::cli::redact_rpc_credentials(&format!("{command:?}"))
+        );
 
         let start = std::time::Instant::now();
         let mut child = command.spawn().map_err(bins::CommandError::from)?;
@@ -580,6 +585,11 @@ impl BlockProducer {
             let mut lines = reader.lines();
             let mut collected = String::new();
             while let Ok(Some(line)) = lines.next_line().await {
+                // A failing miner prints a `CalledProcessError` whose repr
+                // contains the `bitcoin-cli` argv, RPC password included, so
+                // the credentials go before the line is logged or collected
+                // into the error returned to the caller.
+                let line = crate::cli::redact_rpc_credentials(&line);
                 tracing::warn!(target: "signet_miner::stderr", "{line}");
                 if !collected.is_empty() {
                     collected.push('\n');

--- a/lib/cli.rs
+++ b/lib/cli.rs
@@ -1,4 +1,5 @@
 use std::{
+    borrow::Cow,
     env,
     net::{Ipv4Addr, SocketAddr, SocketAddrV4, ToSocketAddrs},
     num::NonZeroU64,
@@ -645,6 +646,55 @@ pub(crate) fn redact_embedded_credentials(value: &str) -> Option<String> {
     Some(url.to_string())
 }
 
+/// Command line arguments whose value is a node RPC credential.
+const RPC_CREDENTIAL_ARGS: [&str; 2] = ["-rpcpassword=", "-rpcuser="];
+
+/// Replace the value of every `-rpcpassword=`/`-rpcuser=` argument in `value`
+/// with `[redacted]`.
+///
+/// Subprocesses are invoked with the node's RPC credentials in their argv (see
+/// `bins::BitcoinCli::default_args`), and a failing child echoes its own argv
+/// back at us: the signet miner's Python traceback prints the whole
+/// `bitcoin-cli` command line. Anything carrying a child's command line or
+/// output therefore goes through this before reaching a log or an error
+/// message. Redacting an already redacted value is a no-op, so applying it at
+/// more than one boundary is safe.
+pub(crate) fn redact_rpc_credentials(value: &str) -> Cow<'_, str> {
+    // A credential value runs until the next argument, or until the end of the
+    // string literal quoting it in a traceback.
+    fn value_end(c: char) -> bool {
+        c.is_whitespace() || matches!(c, '\'' | '"' | ',')
+    }
+
+    let mut rest = value;
+    let mut res: Option<String> = None;
+    loop {
+        // Whichever credential argument comes first in what is left.
+        let next = RPC_CREDENTIAL_ARGS
+            .iter()
+            .filter_map(|&arg| rest.find(arg).map(|start| (start, arg)))
+            .min();
+        let Some((arg_start, arg)) = next else {
+            break;
+        };
+        let secret_start = arg_start + arg.len();
+        let secret_end = rest[secret_start..]
+            .find(value_end)
+            .map_or(rest.len(), |offset| secret_start + offset);
+        let redacted = res.get_or_insert_default();
+        redacted.push_str(&rest[..secret_start]);
+        redacted.push_str(REDACTED);
+        rest = &rest[secret_end..];
+    }
+    match res {
+        Some(mut res) => {
+            res.push_str(rest);
+            Cow::Owned(res)
+        }
+        None => Cow::Borrowed(value),
+    }
+}
+
 /// Log the effective value of every argument, one line each, with secrets
 /// masked. This mirrors the configuration dump Bitcoin Core writes at startup:
 /// it makes a log self-describing, so a bug report says exactly what the node
@@ -803,7 +853,7 @@ mod tests {
 
     use super::{
         Config, NetworkPreset, REDACTED, SecretString, UNSET, is_secret_arg,
-        redact_embedded_credentials,
+        redact_embedded_credentials, redact_rpc_credentials,
     };
 
     /// Each preset's `--network-preset` spelling reaches the parameters it
@@ -1049,6 +1099,60 @@ mod tests {
             redact_embedded_credentials("https://SECRETTOKEN@esplora.example/api").as_deref(),
             Some("https://redacted@esplora.example/api"),
         );
+    }
+
+    /// The signet miner dies with a Python traceback whose
+    /// `CalledProcessError` repr is the `bitcoin-cli` argv we handed it, RPC
+    /// password included. That line is logged and returned to gRPC callers, so
+    /// the credentials must not survive it.
+    #[test]
+    fn subprocess_argv_credentials_are_stripped() {
+        assert_eq!(
+            redact_rpc_credentials(
+                "subprocess.CalledProcessError: Command '['bitcoin-cli', \
+                 '-rpcconnect=127.0.0.1', '-rpcuser=alice', '-rpcpassword=hunter2', \
+                 'getblocktemplate']' returned non-zero exit status 1."
+            ),
+            "subprocess.CalledProcessError: Command '['bitcoin-cli', \
+             '-rpcconnect=127.0.0.1', '-rpcuser=[redacted]', '-rpcpassword=[redacted]', \
+             'getblocktemplate']' returned non-zero exit status 1.",
+        );
+
+        // The same credentials as the miner receives them, in a single
+        // whitespace separated `--cli=` argument.
+        assert_eq!(
+            redact_rpc_credentials(
+                "--cli=bitcoin-cli -rpcport=38332 -rpcuser=alice -rpcpassword=hunter2 -rpcwallet=w"
+            ),
+            "--cli=bitcoin-cli -rpcport=38332 -rpcuser=[redacted] \
+             -rpcpassword=[redacted] -rpcwallet=w",
+        );
+
+        // A trailing credential, with nothing to terminate it.
+        assert_eq!(
+            redact_rpc_credentials("bitcoin-cli -rpcpassword=hunter2"),
+            "bitcoin-cli -rpcpassword=[redacted]",
+        );
+
+        // Nothing to strip: the value is passed through untouched.
+        assert_eq!(
+            redact_rpc_credentials("Traceback (most recent call last):"),
+            "Traceback (most recent call last):",
+        );
+    }
+
+    /// Both a log line and the error built from the same output are redacted,
+    /// so a value may pass through twice. The second pass must not eat the
+    /// marker written by the first.
+    #[test]
+    fn rpc_credential_redaction_is_idempotent() {
+        let once = redact_rpc_credentials("bitcoin-cli -rpcpassword=hunter2 getblocktemplate");
+        assert_eq!(
+            redact_rpc_credentials(&once),
+            once,
+            "redacting twice must equal redacting once"
+        );
+        assert!(once.contains(REDACTED));
     }
 
     /// Redaction must not swallow the parts that identify which backend the


### PR DESCRIPTION
When the signet miner subprocess fails, it dies with a Python `CalledProcessError` whose repr is the `bitcoin-cli` argv, including `-rpcpassword=`/`-rpcuser=`. `BlockProducer` streams that stderr to WARN under `target: "signet_miner::stderr"` and also collects it into the error returned to gRPC callers (`lib/block_producer/mine.rs`); `CommandError`'s `Display` and the non-empty-stderr WARN in `lib/bins.rs` echo it too. The node RPC credentials therefore reach logs and error responses.

The fix adds `redact_rpc_credentials` in `lib/cli.rs`, which replaces the value of every `-rpcpassword=`/`-rpcuser=` argument with `[redacted]`, and applies it at each of those boundaries. It is idempotent, so a value that passes through two boundaries stays correctly redacted.

Tests cover a real traceback, the single-argument `--cli=` form, a trailing credential with nothing to terminate it, a pass-through with nothing to strip, and idempotency.

This only changes logged and returned text, not anything the node validates.