### PR TITLE
fix: Use the resolved network_magic for the wallet's P2P broadcasts

### DIFF
--- a/.github/workflows/check_lint_build_release.yaml
+++ b/.github/workflows/check_lint_build_release.yaml
@@ -449,23 +449,18 @@ jobs:
           # them as artifacts when a test fails.
           export TMPDIR="$RUNNER_TEMP/it-logs"
           mkdir -p "$TMPDIR"
-          # A build with custom P2P magic gets is unable to hand-shake with 
-          # stock Bitcoin Core on any network, so peer_bmm_request is skipped.
+          # A build that rebrands the P2P magic cannot handshake with stock
+          # Bitcoin Core. Tests that pair nodes read this and run every node
+          # on the rebranded build, passing the magic to the enforcer.
           export BITCOIND_REGTEST_MAGIC='${{ matrix.regtest_magic }}'
-          SKIP_ARGS=()
-          if [ -n "$BITCOIND_REGTEST_MAGIC" ]; then
-            echo "skipped: peer_bmm_request (build rebrands the P2P magic)"
-            SKIP_ARGS+=(--skip peer_bmm_request)
-          fi
           if [ -n '${{ matrix.version }}' ]; then
             export BITCOIND_UNPATCHED='../bitcoin-bins/bitcoind'
             export BITCOIND_HAS_DRIVECHAIN=0
-            "$INTEGRATION_TEST_RUNNER" --skip deposit_withdraw_roundtrip \
-              ${SKIP_ARGS[@]+"${SKIP_ARGS[@]}"}
+            "$INTEGRATION_TEST_RUNNER" --skip deposit_withdraw_roundtrip
           else
             export BITCOIND_UNPATCHED='../bitcoin-unpatched-bins/bitcoind'
             export BITCOIND_HAS_DRIVECHAIN=1
-            "$INTEGRATION_TEST_RUNNER" ${SKIP_ARGS[@]+"${SKIP_ARGS[@]}"}
+            "$INTEGRATION_TEST_RUNNER"
           fi
 
       # Did the run end up with a chain worth caching? A run that never needed

--- a/app/main.rs
+++ b/app/main.rs
@@ -1671,10 +1671,12 @@ async fn main() -> Result<()> {
         // TODO: should actually move away from needing txindex, but that's for another day.
         let () = node_checks::check_txindex(&mainchain_client).await?;
 
-        let magic = signet_challenge
-            .as_deref()
-            .map(compute_signet_magic)
-            .unwrap_or_else(|| info.chain.magic());
+        // Make sure to pass custom network magic bytes from the network preset, if present
+        let magic = match network_params.network_magic {
+            Some(magic) => bitcoin::p2p::Magic::from_bytes(magic),
+            None => info.chain.magic(),
+        };
+
         let (wallet, wallet_chain_source_init) = Wallet::new(
             &wallet_data_dir,
             &cli,

--- a/integration_tests/test_peer_bmm_request.rs
+++ b/integration_tests/test_peer_bmm_request.rs
@@ -102,16 +102,32 @@ impl PreSetup {
         self,
         res_tx: mpsc::UnboundedSender<anyhow::Result<()>>,
     ) -> anyhow::Result<PostSetup> {
+        // A bitcoind build that rebrands the P2P magic cannot handshake with
+        // stock Bitcoin Core, so on those flavors the sender runs the same
+        // rebranded build as the miner. Both enforcers are told the magic:
+        // the sender frames its P2P broadcast to the miner node with it, and
+        // the block-file parser expects it as the per-block prefix.
+        let regtest_magic = crate::setup::bitcoind_regtest_magic();
+        let magic_args: Vec<String> = regtest_magic
+            .iter()
+            .map(|magic| format!("--network-magic={magic}"))
+            .collect();
         let sender = {
             // Use a hostname rather than an IP to exercise DNS resolution of
             // p2p broadcast addresses
-            let enforcer_args = vec![format!(
+            let mut enforcer_args = vec![format!(
                 "--p2p-broadcast-addr=localhost:{}",
                 self.miner.reserved_ports.bitcoind_listen.port()
             )];
+            enforcer_args.extend(magic_args.iter().cloned());
+            let bitcoind_kind = if regtest_magic.is_some() {
+                BitcoindKind::Patched
+            } else {
+                BitcoindKind::Unpatched
+            };
             let setup_opts: SetupOpts = SetupOpts {
                 bitcoind_args: Vec::new(),
-                bitcoind_kind: BitcoindKind::Unpatched,
+                bitcoind_kind,
                 enforcer_args,
                 ..Default::default()
             };
@@ -130,7 +146,7 @@ impl PreSetup {
             let setup_opts: SetupOpts<_> = SetupOpts {
                 bitcoind_args,
                 bitcoind_kind: BitcoindKind::Patched,
-                enforcer_args: Vec::new(),
+                enforcer_args: magic_args.clone(),
                 ..Default::default()
             };
             self.miner

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -90,10 +90,6 @@ case "$flavor" in
         # A pinned `drynetN` tag has to be named for setup to fetch that one;
         # `alphanet` is a fixed name that setup always fetches.
         case "$flavor" in drynet*) setup_env=("DRYNET_REVISION=$flavor") ;; esac
-        if [ -n "$("$REPO_ROOT/scripts/setup_integration_tests.sh" \
-            --print-regtest-magic "$flavor")" ]; then
-            skip_patterns=('peer_bmm_request')
-        fi
         ;;
     *)
         echo "unknown --bitcoind flavor '$flavor' (expected bitcoin-patched, unpatched, stock-X.Y, drynetN, alphanet, or all)" >&2


### PR DESCRIPTION
The wallet's P2P message magic in `app/main.rs` was derived from the signet challenge or, failing that, the reported network's stock magic (`info.chain.magic()`). It ignored the resolved `network_magic` override, so a rebranded forknet — a mainnet fork like alphanet that sets its own magic via `--network-magic` or a preset — framed its wallet broadcasts with the stock magic and sent them to peers that drop them.

The fix adds `NetworkParams::p2p_magic` (`lib/types.rs`), which returns the resolved `network_magic` when set and otherwise the reported network's magic, and `main.rs` now uses it — the same magic the validator already reads block files with, which has folded in `--network-magic`, the signet challenge, and the preset.

This affects only how the node frames its own outgoing P2P messages; it does not change block validation.

Tests: a unit test checks that `alphanet` frames with its preset magic over the reported mainnet magic, and that without an override the reported network's magic is used.