### PR TITLE
fix: Sort wallet transactions with a total-order key

### DIFF
--- a/integration_tests/test_wallet_reorg_multi_block.rs
+++ b/integration_tests/test_wallet_reorg_multi_block.rs
@@ -7,16 +7,20 @@
 //! enforcer's validated tip stuck behind bitcoind's tip, a terminal state
 //! nothing else can sync past.
 
-use std::str::FromStr as _;
+use std::{collections::HashSet, str::FromStr as _};
 
 use bip300301_enforcer_lib::{
     bins::CommandExt as _,
     messages::M8BmmRequest,
-    proto::mainchain::{GetBalanceRequest, GetChainTipRequest},
+    proto::mainchain::{
+        CreateNewAddressRequest, GetBalanceRequest, GetChainTipRequest, ListTransactionsRequest,
+        WalletTransaction,
+    },
     types::BmmCommitment,
 };
 use bitcoin::{
-    Amount, BlockHash, OutPoint, Transaction, TxIn, TxOut, Txid, consensus::encode::serialize_hex,
+    Amount, BlockHash, OutPoint, Transaction, TxIn, TxOut, Txid,
+    consensus::encode::{deserialize_hex, serialize_hex},
     transaction::Version,
 };
 use futures::channel::mpsc;
@@ -68,6 +72,9 @@ pub async fn test_wallet_reorg_multi_block(bin_paths: BinPaths) -> anyhow::Resul
 
     tracing::info!("starting scenario: wallet_reorg");
     wallet_reorg_scenario(&mut post_setup, &bin_paths, &res_tx).await?;
+
+    tracing::info!("starting scenario: orphaned_transactions");
+    orphaned_transactions_scenario(&mut post_setup, &bin_paths, &res_tx).await?;
 
     tracing::info!("starting scenario: rejected_block");
     rejected_block_scenario(&mut post_setup, &bin_paths, &res_tx).await?;
@@ -348,6 +355,219 @@ async fn broadcast_raw_bid(
         .run_utf8()
         .await?;
     Ok((Txid::from_str(txid_str.trim())?, signed_hex))
+}
+
+/// Payments the reorg below orphans. Enough that the standard library's sort,
+/// which only checks its comparator opportunistically, panicked on the old
+/// one in nearly every run rather than in one of six.
+const ORPHANED_PAYMENTS: usize = 24;
+
+async fn bitcoin_cli<Arg: AsRef<std::ffi::OsStr>>(
+    post_setup: &PostSetup,
+    method: &str,
+    args: impl IntoIterator<Item = Arg>,
+) -> anyhow::Result<String> {
+    let output = post_setup
+        .bitcoin_cli
+        .command::<String, _, _, _, _>([], method, args)
+        .run_utf8()
+        .await?;
+    Ok(output.trim().to_owned())
+}
+
+#[derive(Deserialize)]
+struct FundResult {
+    hex: String,
+}
+
+/// The height the wallet reports a transaction confirmed at, if any.
+fn listed_height(tx: &WalletTransaction) -> Option<u32> {
+    tx.confirmation_info
+        .clone()
+        .into_option()
+        .filter(|info| info.block_hash.clone().into_option().is_some())
+        .map(|info| info.height)
+}
+
+/// The time the wallet has for a listed transaction: its confirmation time,
+/// else when the wallet last saw it in the mempool, else nothing.
+fn listed_timestamp(tx: &WalletTransaction) -> Option<i64> {
+    tx.confirmation_info
+        .clone()
+        .into_option()
+        .and_then(|info| info.timestamp.into_option())
+        .map(|timestamp| timestamp.seconds)
+}
+
+/// The TXIDs `ListTransactions` reports at `height` (`None` for unconfirmed).
+fn listed_txids_at(listed: &[WalletTransaction], height: Option<u32>) -> HashSet<Txid> {
+    listed
+        .iter()
+        .filter(|tx| listed_height(tx) == height)
+        .filter_map(|tx| {
+            tx.txid
+                .clone()
+                .into_option()?
+                .decode::<WalletTransaction, _>("txid")
+                .ok()
+        })
+        .collect()
+}
+
+/// Regression scenario for `ListTransactions` panicking on a wallet holding
+/// transactions a reorg has orphaned.
+///
+/// `list_wallet_transactions` (`lib/wallet/mod.rs`) sorts the listing
+/// chronologically. A transaction the wallet only ever saw inside a block has
+/// no mempool `last_seen`, and once a reorg drops that block BDK reports it as
+/// unconfirmed with no timestamp at all. The old comparator ordered those by
+/// TXID and everything else by time. Mixing the two relations is not a total
+/// order, and the standard library's sort panics when it catches that,
+/// taking the RPC down with "user-provided comparison function does not
+/// correctly implement a total order".
+///
+/// Every route back to the wallet would give the payments a time, so all are
+/// cut: they are mined straight into a block, never via the mempool; they
+/// are time-locked to be final at that block and no lower, so that after
+/// invalidating from one block below, bitcoind drops them instead of
+/// returning them to its mempool (from where the enforcer's mempool mirror
+/// would feed them to the wallet as freshly seen; standardness is no lever,
+/// since the harness runs stock Bitcoin Core with `-acceptnonstdtxn`); and
+/// electrs stays down until after the listing, since a sync evicts
+/// transactions the chain source no longer knows.
+async fn orphaned_transactions_scenario(
+    post_setup: &mut PostSetup,
+    bin_paths: &BinPaths,
+    res_tx: &mpsc::UnboundedSender<anyhow::Result<()>>,
+) -> anyhow::Result<()> {
+    // Mature enough of bitcoind's coinbases to fund one payment each.
+    let miner_address = bitcoin_cli(post_setup, "getnewaddress", [""; 0]).await?;
+    bitcoin_cli(
+        post_setup,
+        "generatetoaddress",
+        [(ORPHANED_PAYMENTS + 5).to_string(), miner_address.clone()],
+    )
+    .await?;
+    wait_for_wallet_sync(post_setup).await?;
+
+    let enforcer_address = post_setup
+        .wallet_service_client
+        .create_new_address(CreateNewAddressRequest::default())
+        .await?
+        .into_owned()
+        .address;
+    let payment_height: u32 = bitcoin_cli(post_setup, "getblockcount", [""; 0])
+        .await?
+        .parse::<u32>()?
+        + 1;
+    let mut payments = Vec::with_capacity(ORPHANED_PAYMENTS);
+    for _ in 0..ORPHANED_PAYMENTS {
+        // A height lock is final only in blocks above it; bitcoind's wallet
+        // sets the input sequence that makes it count.
+        let unfunded = bitcoin_cli(
+            post_setup,
+            "createrawtransaction",
+            [
+                "[]".to_owned(),
+                format!("{{\"{enforcer_address}\":0.1}}"),
+                (payment_height - 1).to_string(),
+            ],
+        )
+        .await?;
+        let funded: FundResult = serde_json::from_str(
+            &bitcoin_cli(
+                post_setup,
+                "fundrawtransaction",
+                [
+                    unfunded,
+                    r#"{"lockUnspents":true,"fee_rate":10}"#.to_owned(),
+                ],
+            )
+            .await?,
+        )?;
+        let signed: SignResult = serde_json::from_str(
+            &bitcoin_cli(post_setup, "signrawtransactionwithwallet", [funded.hex]).await?,
+        )?;
+        anyhow::ensure!(signed.complete, "signrawtransactionwithwallet incomplete");
+        payments.push(signed.hex);
+    }
+    let payment_txids: HashSet<Txid> = payments
+        .iter()
+        .map(|hex| Ok(deserialize_hex::<Transaction>(hex)?.compute_txid()))
+        .collect::<anyhow::Result<_>>()?;
+
+    // Straight into a block, bypassing the mempool.
+    bitcoin_cli(
+        post_setup,
+        "generateblock",
+        [miner_address, serde_json::to_string(&payments)?],
+    )
+    .await?;
+    wait_for_wallet_sync(post_setup).await?;
+    let listed = list_transactions(post_setup).await?;
+    anyhow::ensure!(
+        listed_txids_at(&listed, Some(payment_height)) == payment_txids,
+        "expected every payment listed as confirmed at height {payment_height} before the reorg"
+    );
+
+    tracing::info!("orphaning the payments with electrs and the enforcer down");
+    post_setup.kill_enforcer().await?;
+    post_setup.kill_electrs().await?;
+    let fork_block_hash = bitcoin_cli(
+        post_setup,
+        "getblockhash",
+        [(payment_height - 1).to_string()],
+    )
+    .await?;
+    bitcoin_cli(post_setup, "invalidateblock", [fork_block_hash]).await?;
+    // Empty replacement blocks, to a fresh address: the first would otherwise
+    // come out byte-identical to the (also empty) block it replaces, which
+    // bitcoind rejects as already invalidated.
+    let replacement_address = bitcoin_cli(post_setup, "getnewaddress", [""; 0]).await?;
+    for _ in 0..3 {
+        bitcoin_cli(
+            post_setup,
+            "generateblock",
+            [replacement_address.clone(), "[]".to_owned()],
+        )
+        .await?;
+    }
+    post_setup
+        .restart_enforcer(bin_paths, Vec::<String>::new(), res_tx.clone())
+        .await?;
+    wait_for_wallet_sync(post_setup).await?;
+
+    // Pre-fix this call is where the RPC panicked (in most runs; in the rest
+    // the listing came back in an order that depended on which pairs the
+    // sort happened to compare).
+    let listed = list_transactions(post_setup).await?;
+    anyhow::ensure!(
+        listed_txids_at(&listed, None) == payment_txids,
+        "expected exactly the payments listed as unconfirmed after the reorg"
+    );
+    // The precondition of the bug: no time at all, not a mempool sighting.
+    anyhow::ensure!(
+        listed
+            .iter()
+            .all(|tx| listed_height(tx).is_some() || listed_timestamp(tx).is_none()),
+        "the wallet should have no timestamp for the orphaned payments"
+    );
+    let timestamps = listed.iter().map(listed_timestamp).collect::<Vec<_>>();
+    anyhow::ensure!(
+        timestamps.is_sorted(),
+        "ListTransactions must be in chronological order, got {timestamps:?}"
+    );
+
+    post_setup.restart_electrs(bin_paths, res_tx.clone()).await
+}
+
+async fn list_transactions(post_setup: &mut PostSetup) -> anyhow::Result<Vec<WalletTransaction>> {
+    Ok(post_setup
+        .wallet_service_client
+        .list_transactions(ListTransactionsRequest::default())
+        .await?
+        .into_owned()
+        .transactions)
 }
 
 /// Regression scenario for the enforcer fatally crashing while catching up,

--- a/lib/wallet/mod.rs
+++ b/lib/wallet/mod.rs
@@ -229,6 +229,24 @@ const fn default_electrum_host_port(network: Network) -> Option<(&'static str, u
     }
 }
 
+/// Chronological sort key for a wallet transaction: the confirmation time if
+/// it is confirmed, otherwise the time it was last seen in the mempool. BDK
+/// reports no `last_seen` for a transaction it has not seen since a reorg
+/// orphaned it, and those sort first. The TXID is only a tie-breaker.
+///
+/// Comparing one key per transaction is a total order, which comparing
+/// timestamps for some pairs and TXIDs for the rest is not: those two
+/// relations disagree, so mixing them yields cycles, and the sort panics with
+/// "user-provided comparison function does not correctly implement a total
+/// order" when it notices.
+fn wallet_transaction_sort_key(tx: &BDKWalletTransaction) -> (Option<u64>, Txid) {
+    let timestamp = match tx.chain_position {
+        ChainPosition::Confirmed { anchor, .. } => Some(anchor.confirmation_time),
+        ChainPosition::Unconfirmed { last_seen, .. } => last_seen,
+    };
+    (timestamp, tx.txid)
+}
+
 struct WalletInner {
     main_client: HttpClient,
     producer: BlockProducer,
@@ -1431,43 +1449,7 @@ impl Wallet {
         }
 
         // Make sure that the transaction list is in chronological order.
-        txs.sort_by(|a, b| match (a.chain_position, b.chain_position) {
-            (
-                ChainPosition::Confirmed {
-                    anchor: a_anchor, ..
-                },
-                ChainPosition::Confirmed {
-                    anchor: b_anchor, ..
-                },
-            ) => a_anchor.confirmation_time.cmp(&b_anchor.confirmation_time),
-            (
-                ChainPosition::Confirmed { anchor, .. },
-                ChainPosition::Unconfirmed {
-                    last_seen: Some(last_seen),
-                    first_seen: _,
-                },
-            ) => anchor.confirmation_time.cmp(&last_seen),
-            (
-                ChainPosition::Unconfirmed {
-                    last_seen: Some(last_seen),
-                    first_seen: _,
-                },
-                ChainPosition::Confirmed { anchor, .. },
-            ) => last_seen.cmp(&anchor.confirmation_time),
-            (
-                ChainPosition::Unconfirmed {
-                    last_seen: Some(a_last_seen),
-                    first_seen: _,
-                },
-                ChainPosition::Unconfirmed {
-                    last_seen: Some(b_last_seen),
-                    first_seen: _,
-                },
-            ) => a_last_seen.cmp(&b_last_seen),
-
-            // Fallback to comparing TXIDs
-            (_, _) => a.txid.cmp(&b.txid),
-        });
+        txs.sort_by_key(wallet_transaction_sort_key);
         Ok(txs)
     }
 
@@ -2016,8 +1998,9 @@ impl Wallet {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use std::{collections::HashMap, sync::Arc};
 
+    use bdk_chain::{BlockId, ConfirmationBlockTime};
     use bdk_wallet::{
         bip39::Language,
         bitcoin::{Amount, ScriptBuf, script::PushBytesBuf},
@@ -2026,9 +2009,9 @@ mod tests {
     use bitcoin::{BlockHash, hashes::Hash as _};
 
     use super::{
-        BdkWallet, CreateTransactionParams, KeychainKind, LEGACY_COIN_TYPE, M8BmmRequest, Mnemonic,
-        Network, Persistence, Wallet, WalletConfig, WalletInner, WalletSyncSource, error,
-        slip44_coin_type,
+        BDKWalletTransaction, BdkWallet, ChainPosition, CreateTransactionParams, KeychainKind,
+        LEGACY_COIN_TYPE, M8BmmRequest, Mnemonic, Network, Persistence, Txid, Wallet, WalletConfig,
+        WalletInner, WalletSyncSource, error, slip44_coin_type,
     };
     use crate::{
         errors::ErrorChain,
@@ -2462,6 +2445,112 @@ mod tests {
         assert_eq!(
             super::sync_backend_endpoint(&config, Network::Regtest),
             None
+        );
+    }
+
+    fn wallet_tx(
+        txid_byte: u8,
+        chain_position: ChainPosition<ConfirmationBlockTime>,
+    ) -> BDKWalletTransaction {
+        let tx = bitcoin::Transaction {
+            version: bitcoin::transaction::Version::TWO,
+            lock_time: bitcoin::absolute::LockTime::ZERO,
+            input: Vec::new(),
+            output: Vec::new(),
+        };
+        BDKWalletTransaction {
+            txid: Txid::from_byte_array([txid_byte; 32]),
+            tx: Arc::new(tx),
+            chain_position,
+            fee: Amount::ZERO,
+            received: Amount::ZERO,
+            sent: Amount::ZERO,
+        }
+    }
+
+    /// A position confirmed at `timestamp`. Only the time matters here, not
+    /// the block the transaction is anchored to.
+    fn confirmed_at(timestamp: u64) -> ChainPosition<ConfirmationBlockTime> {
+        let block_id = BlockId {
+            height: 1,
+            hash: BlockHash::from_byte_array([0xAA; 32]),
+        };
+        ChainPosition::Confirmed {
+            anchor: ConfirmationBlockTime {
+                block_id,
+                confirmation_time: timestamp,
+            },
+            transitively: None,
+        }
+    }
+
+    /// An unconfirmed position. BDK reports no `last_seen` for a transaction
+    /// it has not seen since a reorg orphaned it.
+    fn unconfirmed(last_seen: Option<u64>) -> ChainPosition<ConfirmationBlockTime> {
+        ChainPosition::Unconfirmed {
+            first_seen: last_seen,
+            last_seen,
+        }
+    }
+
+    fn txids(txs: &[BDKWalletTransaction]) -> Vec<Txid> {
+        txs.iter().map(|tx| tx.txid).collect()
+    }
+
+    /// The three positions `list_wallet_transactions` sees, arranged so that
+    /// comparing timestamps for some pairs and TXIDs for the rest is cyclic:
+    /// the confirmed transaction precedes the unconfirmed one by time, which
+    /// precedes the orphaned one by TXID, which precedes the confirmed one by
+    /// TXID.
+    fn intransitive_arrangement() -> [BDKWalletTransaction; 3] {
+        let confirmed = wallet_tx(0x03, confirmed_at(10));
+        let seen = wallet_tx(0x01, unconfirmed(Some(20)));
+        let orphaned = wallet_tx(0x02, unconfirmed(None));
+        [confirmed, seen, orphaned]
+    }
+
+    /// Sorting must be a total order. Switching relation per pair is not one,
+    /// so the answer depended on the order the transactions arrived in.
+    #[test]
+    fn wallet_transactions_sort_in_a_total_order() {
+        let [confirmed, seen, orphaned] = intransitive_arrangement();
+        // Chronological, with the transaction carrying no timestamp first.
+        let expected = [orphaned.txid, confirmed.txid, seen.txid];
+
+        let mut forwards = [confirmed.clone(), seen.clone(), orphaned.clone()];
+        forwards.sort_by_key(super::wallet_transaction_sort_key);
+        let mut backwards = [orphaned, seen, confirmed];
+        backwards.sort_by_key(super::wallet_transaction_sort_key);
+
+        assert_eq!(txids(&forwards), expected);
+        assert_eq!(txids(&backwards), expected);
+    }
+
+    /// The same mix, at a size where the standard library's sort checks the
+    /// comparator it was handed and panics on one that is not a total order.
+    #[test]
+    fn many_wallet_transactions_sort_without_panicking() {
+        const COUNT: u8 = 64;
+
+        // A tiny LCG, so that the timestamps are shuffled with respect to the
+        // TXIDs while the case stays reproducible.
+        let mut seed = 1u64;
+        let mut txs = Vec::with_capacity(COUNT as usize);
+        for i in 0..COUNT {
+            seed = seed.wrapping_mul(2862933555777941757).wrapping_add(1);
+            let chain_position = match i % 3 {
+                0 => confirmed_at(seed >> 58),
+                1 => unconfirmed(Some(seed >> 58)),
+                _ => unconfirmed(None),
+            };
+            txs.push(wallet_tx(i, chain_position));
+        }
+
+        txs.sort_by_key(super::wallet_transaction_sort_key);
+
+        assert!(
+            txs.is_sorted_by_key(super::wallet_transaction_sort_key),
+            "the sorted list must be ordered by its own sort key"
         );
     }
 }


### PR DESCRIPTION
`list_wallet_transactions` sorted with a `sort_by` closure that compared confirmation/last-seen timestamps for some pairs of transactions but fell back to comparing TXIDs for the rest (`lib/wallet/mod.rs`). Those two relations disagree, so the comparator is not a total order: it admits cycles, and on a list large enough for the standard library's sort to check the comparator it panics with "user-provided comparison function does not correctly implement a total order", taking down the transaction-listing RPC.

The fix replaces it with `sort_by_key(wallet_transaction_sort_key)`, deriving one `(Option<u64>, Txid)` key per transaction — the confirmation time if confirmed, else the mempool last-seen time (absent for a transaction a reorg orphaned, which sorts first), with the TXID only as a tie-breaker. Comparing one key per element is a total order.

Tests check a hand-built intransitive arrangement sorts deterministically regardless of input order, and that 64 shuffled transactions sort without panicking.

This only changes how the wallet orders its own listing, not any validation rule.