### PR TITLE
fix: Stop an uncountable M2 from suppressing a valid M2 for the same slot

### DIFF
--- a/integration_tests/test_invalid_block.rs
+++ b/integration_tests/test_invalid_block.rs
@@ -3,14 +3,14 @@ use std::{str::FromStr as _, time::Duration};
 use bip300301_enforcer_lib::{
     bins::CommandExt as _,
     messages::{M1ProposeSidechain, M2AckSidechain, M4AckBundles, M7BmmAccept, M8BmmRequest},
-    types::{BmmCommitment, SidechainDescription, op_drivechain_script},
+    types::{BmmCommitment, SidechainDescription, SidechainNumber, op_drivechain_script},
 };
 use bitcoin::{
     Amount, Block, BlockHash, CompactTarget, OutPoint, ScriptBuf, Sequence, Transaction, TxIn,
     TxMerkleNode, TxOut, Txid, Witness,
     block::Header,
     consensus::encode::{deserialize_hex, serialize_hex},
-    hashes::{Hash as _, sha256d},
+    hashes::Hash as _,
     script::{Builder as ScriptBuilder, PushBytesBuf},
     transaction::Version,
 };
@@ -41,11 +41,6 @@ pub(crate) const DUPLICATE_M1: BadBlockCase = BadBlockCase {
 const CASES: &[BadBlockCase] = &[
     DUPLICATE_M1,
     BadBlockCase {
-        name: "duplicate_m2",
-        extra_coinbase_outputs: duplicate_m2_outputs,
-        expected_log_contains: "rejecting block: M2 that acks proposal for slot",
-    },
-    BadBlockCase {
         name: "duplicate_m4",
         extra_coinbase_outputs: duplicate_m4_outputs,
         expected_log_contains: "rejecting block: M4 already included at index",
@@ -68,20 +63,6 @@ fn duplicate_m1_outputs() -> anyhow::Result<Vec<TxOut>> {
     })?;
     let m1_b: ScriptBuf = proposal.try_into()?;
     Ok(vec![zero_value(m1_a), zero_value(m1_b)])
-}
-
-fn duplicate_m2_outputs() -> anyhow::Result<Vec<TxOut>> {
-    let m2_a: ScriptBuf = M2AckSidechain {
-        sidechain_number: DummySidechain::SIDECHAIN_NUMBER,
-        description_hash: sha256d::Hash::from_byte_array([0xAA; 32]),
-    }
-    .try_into()?;
-    let m2_b: ScriptBuf = M2AckSidechain {
-        sidechain_number: DummySidechain::SIDECHAIN_NUMBER,
-        description_hash: sha256d::Hash::from_byte_array([0xBB; 32]),
-    }
-    .try_into()?;
-    Ok(vec![zero_value(m2_a), zero_value(m2_b)])
 }
 
 fn duplicate_m4_outputs() -> anyhow::Result<Vec<TxOut>> {
@@ -128,6 +109,18 @@ pub async fn test_invalid_block(mut post_setup: PostSetup) -> anyhow::Result<()>
                 tracing::error!(case = case.name, "case failed: {err:#}");
                 failures.push(format!("{}: {err:#}", case.name));
             }
+        }
+    }
+
+    // A duplicate M2 needs a live proposal from an *earlier* block to ack, so
+    // it spans two blocks rather than the single self-contained one every
+    // `CASES` entry is built from.
+    const M2_CASE: &str = "duplicate_m2";
+    match run_duplicate_m2_case(&mut post_setup).await {
+        Ok(()) => tracing::info!(case = M2_CASE, "case passed"),
+        Err(err) => {
+            tracing::error!(case = M2_CASE, "case failed: {err:#}");
+            failures.push(format!("{M2_CASE}: {err:#}"));
         }
     }
 
@@ -178,6 +171,54 @@ async fn run_case(post_setup: &mut PostSetup, case: &BadBlockCase) -> anyhow::Re
         bad_block_hash,
         Expect::Rejected {
             log_contains: case.expected_log_contains,
+        },
+        Duration::from_secs(10),
+    )
+    .await
+}
+
+/// An unused slot, so the proposal below cannot disturb the active
+/// [`DummySidechain`] in slot 0.
+const DUPLICATE_M2_SLOT: SidechainNumber = SidechainNumber(7);
+
+/// BIP 300: "only one M2 per sidechain slot per block". The rule is about acks
+/// that are actually counted -- an M2 whose description hash matches no live
+/// proposal is an ordinary script, and an M2 in the same block as its M1 is
+/// ignored too -- so the duplicate has to ack a proposal made in an earlier
+/// block. Two blocks: one proposing, one acking it twice.
+async fn run_duplicate_m2_case(post_setup: &mut PostSetup) -> anyhow::Result<()> {
+    let description = SidechainDescription(b"duplicate-m2 test".to_vec());
+    let m1: ScriptBuf = M1ProposeSidechain {
+        sidechain_number: DUPLICATE_M2_SLOT,
+        description: description.clone(),
+    }
+    .try_into()?;
+    let proposal_block_hash =
+        submit_block_with_coinbase_outputs(post_setup, vec![zero_value(m1)]).await?;
+    tracing::info!(%proposal_block_hash, "submitted proposal for the duplicate M2 to ack");
+    let () = assert_enforcer_verdict(
+        post_setup,
+        proposal_block_hash,
+        Expect::Accepted,
+        Duration::from_secs(10),
+    )
+    .await?;
+
+    let m2: ScriptBuf = M2AckSidechain {
+        sidechain_number: DUPLICATE_M2_SLOT,
+        description_hash: description.sha256d_hash(),
+    }
+    .try_into()?;
+    let m2_output = zero_value(m2);
+    let bad_block_hash =
+        submit_block_with_coinbase_outputs(post_setup, vec![m2_output.clone(), m2_output]).await?;
+    tracing::info!(%bad_block_hash, "submitted bad block");
+
+    assert_enforcer_verdict(
+        post_setup,
+        bad_block_hash,
+        Expect::Rejected {
+            log_contains: "rejecting block: M2 that acks proposal for slot",
         },
         Duration::from_secs(10),
     )
@@ -475,6 +516,15 @@ pub(crate) async fn submit_invalid_block(
     post_setup: &PostSetup,
     case: &BadBlockCase,
 ) -> anyhow::Result<BlockHash> {
+    submit_block_with_coinbase_outputs(post_setup, (case.extra_coinbase_outputs)()?).await
+}
+
+/// Mine and submit a block whose coinbase carries `extra_coinbase_outputs` on
+/// top of the payout and witness commitment.
+async fn submit_block_with_coinbase_outputs(
+    post_setup: &PostSetup,
+    extra_coinbase_outputs: Vec<TxOut>,
+) -> anyhow::Result<BlockHash> {
     let template_json = post_setup
         .bitcoin_cli
         // We craft the BIP300/BIP301 coinbase commitments below, so we ack the
@@ -526,7 +576,7 @@ pub(crate) async fn submit_invalid_block(
             value: Amount::ZERO,
         },
     ];
-    outputs.extend((case.extra_coinbase_outputs)()?);
+    outputs.extend(extra_coinbase_outputs);
     let coinbase = Transaction {
         version: Version::TWO,
         lock_time: bitcoin::locktime::absolute::LockTime::ZERO,

--- a/lib/validator/task/mod.rs
+++ b/lib/validator/task/mod.rs
@@ -1142,6 +1142,37 @@ impl BlockHandler<'_> {
                     .entry((*sidechain_number, description_hash))
                     .or_insert(vout as u32);
             }
+            // BIP 300: an M2 that `handle_m2_ack_sidechain` would ignore is an
+            // ordinary script, so it must not claim the slot's single M2 entry
+            // in `coinbase_messages` -- otherwise it suppresses a later valid
+            // M2 for the same slot with `DuplicateM2`, rejecting the block. No
+            // M1 from this block has been applied yet, so a proposal made in
+            // this same block is absent here, matching the `proposal_height ==
+            // height` case that handler also ignores.
+            if let CoinbaseMessage::M2AckSidechain(M2AckSidechain {
+                sidechain_number,
+                description_hash,
+            }) = &message
+            {
+                let proposal_id = SidechainProposalId {
+                    sidechain_number: *sidechain_number,
+                    description_hash: *description_hash,
+                };
+                if dbs
+                    .proposal_id_to_sidechain
+                    .try_get(rwtxn, &proposal_id)?
+                    .is_none()
+                {
+                    tracing::debug!(
+                        %sidechain_number,
+                        %description_hash,
+                        "ignoring M2 ack: no matching M1 proposal from an ancestor block"
+                    );
+                    continue;
+                }
+            }
+            // Only M2s that can actually be counted get this far, so a repeat
+            // here is a second *valid* ack for the slot.
             coinbase_messages.push(message, vout)?;
         }
         let mut accepted_bmm_requests = BmmCommitments::new();
@@ -3543,6 +3574,76 @@ mod tests {
                      not reject the block: {e:#}"
                 )
             })?;
+        Ok(())
+    }
+
+    /// BIP 300 M2: an ignored M2 is an ordinary script, so it must not occupy
+    /// the slot's single M2 entry and turn a later *valid* M2 for the same
+    /// slot into a duplicate.
+    #[test]
+    fn connect_block_accepts_valid_m2_after_ignored_m2_for_same_slot() -> Result<()> {
+        let (_dir, dbs) = create_test_dbs()?;
+        let mut rwtxn = dbs.write_txn().into_diagnostic()?;
+        let prev_hash = BlockHash::all_zeros();
+
+        // Proposal from an ancestor block, so an ack at height 1 counts.
+        let sidechain = test_sidechain(1, 0);
+        let proposal_id = sidechain.proposal.compute_id();
+        dbs.proposal_id_to_sidechain
+            .put(&mut rwtxn, &proposal_id, &sidechain)
+            .into_diagnostic()?;
+
+        let ignored_m2: ScriptBuf = M2AckSidechain {
+            sidechain_number: proposal_id.sidechain_number,
+            description_hash: bitcoin::hashes::sha256d::Hash::all_zeros(),
+        }
+        .try_into()
+        .into_diagnostic()?;
+        let valid_m2: ScriptBuf = M2AckSidechain {
+            sidechain_number: proposal_id.sidechain_number,
+            description_hash: proposal_id.description_hash,
+        }
+        .try_into()
+        .into_diagnostic()?;
+        let block = build_test_block(
+            prev_hash,
+            TestBlockParts {
+                extra_coinbase_outputs: vec![
+                    TxOut {
+                        script_pubkey: ignored_m2,
+                        value: Amount::ZERO,
+                    },
+                    TxOut {
+                        script_pubkey: valid_m2,
+                        value: Amount::ZERO,
+                    },
+                ],
+                ..Default::default()
+            },
+        );
+
+        dbs.block_hashes
+            .put_headers(&mut rwtxn, &[(block.header, 1)])
+            .into_diagnostic()?;
+
+        test_handler(&dbs)
+            .connect_block(&mut rwtxn, &block)
+            .into_diagnostic()
+            .map_err(|e| {
+                miette::miette!(
+                    "M2 referencing unknown proposal must not suppress a later \
+                     valid M2 for the same slot: {e:#}"
+                )
+            })?;
+
+        let sidechain = dbs
+            .proposal_id_to_sidechain
+            .get(&rwtxn, &proposal_id)
+            .into_diagnostic()?;
+        assert_eq!(
+            sidechain.status.vote_count, 1,
+            "the valid M2 for the slot must still be counted"
+        );
         Ok(())
     }
 


### PR DESCRIPTION
When `connect_block` in `lib/validator/task/mod.rs` collects coinbase messages, it pushed every M2 ack into `coinbase_messages`, including one whose description hash matches no live M1 proposal — an ack that `handle_m2_ack_sidechain` later ignores as an ordinary script. That uncountable M2 still claimed the slot's single M2 entry, so a later *valid* M2 for the same slot in the same block tripped `DuplicateM2` and the whole block was rejected.

The fix checks `proposal_id_to_sidechain` before pushing an M2: an ack with no matching proposal from an ancestor block is skipped, exactly as the handler already treats it, so only countable acks occupy the slot and a genuine duplicate is still rejected.

This narrows an existing over-rejection to match how M2 acks are already counted; it adds no new invalidation rule.

Tests: a unit test, `connect_block_accepts_valid_m2_after_ignored_m2_for_same_slot`, plus a two-block integration case, `run_duplicate_m2_case`, that still rejects a genuine duplicate M2 against a real proposal.