### PR TITLE
fix: list_headers: walk back from the tip so each height appears once

### DIFF
--- a/integration_tests/integration_test.rs
+++ b/integration_tests/integration_test.rs
@@ -330,6 +330,54 @@ pub async fn wait_for_wallet_sync(post_setup: &mut PostSetup) -> anyhow::Result<
     }
 }
 
+/// Block until electrs has indexed up to bitcoind's tip.
+///
+/// The test harness runs the enforcer with `--wallet-skip-periodic-sync`, so
+/// each full scan runs exactly once, at the point the test drives it, with no
+/// later retry to paper over a chain source that was still catching up. Every
+/// scan must therefore be sequenced after this wait.
+pub async fn wait_for_electrs_tip(post_setup: &PostSetup) -> anyhow::Result<()> {
+    const POLL_INTERVAL: Duration = Duration::from_millis(500);
+    const TIMEOUT: Duration = Duration::from_secs(180);
+
+    let target_height: u32 = post_setup
+        .bitcoin_cli
+        .command::<String, _, String, _, _>([], "getblockcount", [])
+        .run_utf8()
+        .await?
+        .trim()
+        .parse()?;
+    let url = format!(
+        "http://127.0.0.1:{}/blocks/tip/height",
+        post_setup.reserved_ports.electrs_electrum_http.port()
+    );
+    tracing::debug!("waiting for electrs to index up to block {target_height}");
+
+    let client = reqwest::Client::new();
+    let deadline = std::time::Instant::now() + TIMEOUT;
+    loop {
+        // electrs returns 5xx while it is still opening its index, so a
+        // failed request here is expected rather than fatal.
+        let indexed_height: Option<u32> = match client.get(&url).send().await {
+            Ok(response) => response
+                .text()
+                .await
+                .ok()
+                .and_then(|body| body.trim().parse().ok()),
+            Err(_) => None,
+        };
+        if indexed_height.is_some_and(|height| height >= target_height) {
+            return Ok(());
+        }
+        anyhow::ensure!(
+            std::time::Instant::now() < deadline,
+            "electrs did not index up to block {target_height} within {TIMEOUT:?} \
+             (stuck at {indexed_height:?})"
+        );
+        sleep(POLL_INTERVAL).await;
+    }
+}
+
 /// Block until the validator's reported chain tip reaches bitcoind's height.
 pub async fn wait_for_validator_tip(post_setup: &PostSetup) -> anyhow::Result<()> {
     let target_height: u32 = post_setup

--- a/integration_tests/test_wallet_large_gap_sync.rs
+++ b/integration_tests/test_wallet_large_gap_sync.rs
@@ -60,7 +60,7 @@
 //! cover -- as an RPC, without a restart. The obligation is the same one the
 //! gap crossings carry: money at an index the wallet never revealed.
 
-use std::{str::FromStr as _, time::Duration};
+use std::str::FromStr as _;
 
 use bdk_wallet::miniscript::{Descriptor, DescriptorPublicKey};
 use bip300301_enforcer_lib::{
@@ -75,10 +75,11 @@ use bip300301_enforcer_lib::{
 };
 use bitcoin::{BlockHash, secp256k1::Secp256k1};
 use futures::channel::mpsc;
-use tokio::time::sleep;
 
 use crate::{
-    integration_test::{fund_enforcer, wait_for_validator_tip, wait_for_wallet_sync},
+    integration_test::{
+        fund_enforcer, wait_for_electrs_tip, wait_for_validator_tip, wait_for_wallet_sync,
+    },
     setup::{
         DummySidechain, Mode, Network, PostSetup, PreSetup, SetupOpts, read_enforcer_log,
         wait_for_enforcer_log,
@@ -172,54 +173,6 @@ fn enforcer_args() -> Vec<String> {
     vec![format!(
         "--wallet-max-block-by-block-replay={MAX_BLOCK_BY_BLOCK_REPLAY}"
     )]
-}
-
-/// Block until electrs has indexed up to bitcoind's tip.
-///
-/// The test harness runs the enforcer with `--wallet-skip-periodic-sync`, so
-/// each full scan runs exactly once, at the point the test drives it, with no
-/// later retry to paper over a chain source that was still catching up. Every
-/// scan must therefore be sequenced after this wait.
-async fn wait_for_electrs_tip(post_setup: &PostSetup) -> anyhow::Result<()> {
-    const POLL_INTERVAL: Duration = Duration::from_millis(500);
-    const TIMEOUT: Duration = Duration::from_secs(180);
-
-    let target_height: u32 = post_setup
-        .bitcoin_cli
-        .command::<String, _, String, _, _>([], "getblockcount", [])
-        .run_utf8()
-        .await?
-        .trim()
-        .parse()?;
-    let url = format!(
-        "http://127.0.0.1:{}/blocks/tip/height",
-        post_setup.reserved_ports.electrs_electrum_http.port()
-    );
-    tracing::debug!("waiting for electrs to index up to block {target_height}");
-
-    let client = reqwest::Client::new();
-    let deadline = std::time::Instant::now() + TIMEOUT;
-    loop {
-        // electrs returns 5xx while it is still opening its index, so a
-        // failed request here is expected rather than fatal.
-        let indexed_height: Option<u32> = match client.get(&url).send().await {
-            Ok(response) => response
-                .text()
-                .await
-                .ok()
-                .and_then(|body| body.trim().parse().ok()),
-            Err(_) => None,
-        };
-        if indexed_height.is_some_and(|height| height >= target_height) {
-            return Ok(());
-        }
-        anyhow::ensure!(
-            std::time::Instant::now() < deadline,
-            "electrs did not index up to block {target_height} within {TIMEOUT:?} \
-             (stuck at {indexed_height:?})"
-        );
-        sleep(POLL_INTERVAL).await;
-    }
 }
 
 /// Number of confirmed wallet UTXOs paying `address`.

--- a/integration_tests/test_wallet_reorg_multi_block.rs
+++ b/integration_tests/test_wallet_reorg_multi_block.rs
@@ -3,9 +3,10 @@
 //! streams block connects/disconnects one at a time, so several catch-up
 //! code paths only ever run after a restart with a real gap to cross.
 //!
-//! The rejected-block scenario must run last: it deliberately leaves the
-//! enforcer's validated tip stuck behind bitcoind's tip, a terminal state
-//! nothing else can sync past.
+//! The rejected-block scenario deliberately stops the enforcer's validated
+//! tip at a chain it rejects, a state nothing can sync past until that chain
+//! is reorged away. The stale-branch scenario is built on that state, so it
+//! runs last.
 
 use std::str::FromStr as _;
 
@@ -23,14 +24,26 @@ use futures::channel::mpsc;
 use serde::Deserialize;
 
 use crate::{
-    integration_test::{fund_enforcer, wait_for_wallet_sync},
-    setup::{DummySidechain, Mode, Network, PostSetup, PreSetup, SetupOpts, Sidechain, wait_until},
+    integration_test::{fund_enforcer, wait_for_electrs_tip, wait_for_wallet_sync},
+    setup::{
+        DummySidechain, Mode, Network, PostSetup, PreSetup, SetupOpts, Sidechain,
+        read_enforcer_log, wait_until,
+    },
     util::BinPaths,
 };
 
 pub const TEST_NAME: &str = "wallet_reorg_multi_block";
 
 const FORK_DEPTH: u32 = 15;
+
+/// `--wallet-max-block-by-block-replay` for the stale-branch scenario's
+/// restart; past this many blocks the wallet checkpoints from headers.
+const STALE_BRANCH_MAX_BLOCK_BY_BLOCK_REPLAY: u32 = 50;
+
+const STALE_BRANCH_REPLACEMENT_BLOCKS: u32 = STALE_BRANCH_MAX_BLOCK_BY_BLOCK_REPLAY + 10;
+
+/// Emitted by `sync_wallet_to_tip` when it takes the checkpoint path.
+const CHECKPOINT_LOG: &str = "checkpointing chain forward and running a full scan";
 
 pub async fn test_wallet_reorg_multi_block(bin_paths: BinPaths) -> anyhow::Result<()> {
     let (res_tx, _res_rx) = mpsc::unbounded();
@@ -70,7 +83,11 @@ pub async fn test_wallet_reorg_multi_block(bin_paths: BinPaths) -> anyhow::Resul
     wallet_reorg_scenario(&mut post_setup, &bin_paths, &res_tx).await?;
 
     tracing::info!("starting scenario: rejected_block");
-    rejected_block_scenario(&mut post_setup, &bin_paths, &res_tx).await?;
+    let last_valid_height = rejected_block_scenario(&mut post_setup, &bin_paths, &res_tx).await?;
+
+    tracing::info!("starting scenario: stale_branch_full_scan");
+    stale_branch_full_scan_scenario(&mut post_setup, &bin_paths, &res_tx, last_valid_height)
+        .await?;
 
     Ok(())
 }
@@ -379,11 +396,13 @@ async fn broadcast_raw_bid(
 /// No sidechain needs to be proposed or activated for any of this: M8
 /// parsing and rejection never consult activation state -- acceptance is
 /// judged purely against M7 accepts in the containing block's own coinbase.
+///
+/// Returns the height the enforcer's validated tip came to rest at.
 async fn rejected_block_scenario(
     post_setup: &mut PostSetup,
     bin_paths: &BinPaths,
     res_tx: &mpsc::UnboundedSender<anyhow::Result<()>>,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<u32> {
     // Kill the enforcer *before* touching the chain: everything below must
     // happen while it's down, so the only way it can learn about any of it
     // is by catching up across the whole gap in one bulk jump on restart.
@@ -524,6 +543,87 @@ async fn rejected_block_scenario(
     tracing::info!(
         last_valid_height,
         "enforcer survived the restart and caught up to its last accepted block"
+    );
+
+    Ok(last_valid_height)
+}
+
+/// Regression scenario for `Validator::list_headers` returning stale-branch
+/// headers, which left the wallet's full scan with duplicate heights to build
+/// its checkpoint from (a `debug_assert!` panic in debug builds, a failed scan
+/// in release builds).
+///
+/// Stale headers only matter above the wallet's tip. The rejected-block
+/// scenario leaves exactly that: `sync_headers` stored the rejected chain's
+/// headers past the validated tip, where the wallet stopped too. Reorging
+/// that chain away while the enforcer is down, past a lowered replay limit,
+/// forces the wallet to checkpoint from those headers on restart.
+async fn stale_branch_full_scan_scenario(
+    post_setup: &mut PostSetup,
+    bin_paths: &BinPaths,
+    res_tx: &mpsc::UnboundedSender<anyhow::Result<()>>,
+    last_valid_height: u32,
+) -> anyhow::Result<()> {
+    post_setup.kill_enforcer().await?;
+
+    // The enforcer already invalidated the poisoned block on its last restart,
+    // so bitcoind's tip is the last accepted block. Empty blocks: the stale bid
+    // is back in the mempool and `generatetoaddress` would mine it again.
+    let replacement_address = post_setup
+        .bitcoin_cli
+        .command::<String, _, String, _, _>([], "getnewaddress", [])
+        .run_utf8()
+        .await?
+        .trim()
+        .to_string();
+    for _ in 0..STALE_BRANCH_REPLACEMENT_BLOCKS {
+        post_setup
+            .bitcoin_cli
+            .command::<String, _, _, _, _>(
+                [],
+                "generateblock",
+                [replacement_address.clone(), "[]".to_owned()],
+            )
+            .run_utf8()
+            .await?;
+    }
+    let new_tip_height: u32 = post_setup
+        .bitcoin_cli
+        .command::<String, _, String, _, _>([], "getblockcount", [])
+        .run_utf8()
+        .await?
+        .trim()
+        .parse()?;
+    anyhow::ensure!(
+        new_tip_height == last_valid_height + STALE_BRANCH_REPLACEMENT_BLOCKS,
+        "expected the replacement chain to build on the last accepted block \
+         ({last_valid_height}), got height {new_tip_height}"
+    );
+
+    // electrs may not survive the reorg, and must be at the tip before the scan.
+    post_setup
+        .restart_electrs(bin_paths, res_tx.clone())
+        .await?;
+    wait_for_electrs_tip(post_setup).await?;
+
+    post_setup
+        .restart_enforcer(
+            bin_paths,
+            [format!(
+                "--wallet-max-block-by-block-replay={STALE_BRANCH_MAX_BLOCK_BY_BLOCK_REPLAY}"
+            )],
+            res_tx.clone(),
+        )
+        .await?;
+    // Pre-fix the enforcer went down in the full scan here.
+    wait_for_wallet_sync(post_setup).await?;
+
+    // Prove the checkpoint path ran, not a block-by-block replay.
+    let enforcer_log = read_enforcer_log(&post_setup.directories.enforcer_dir)?;
+    anyhow::ensure!(
+        enforcer_log.contains(CHECKPOINT_LOG),
+        "expected the wallet to close a {STALE_BRANCH_REPLACEMENT_BLOCKS}-block gap with a \
+         checkpoint and full scan, but {CHECKPOINT_LOG:?} never appeared in the enforcer log"
     );
 
     Ok(())

--- a/lib/validator/mod.rs
+++ b/lib/validator/mod.rs
@@ -284,7 +284,9 @@ where
 #[derive(Debug, Error)]
 pub enum ListHeadersError {
     #[error(transparent)]
-    Iter(#[from] db::error::Iter),
+    DbGet(#[from] db::error::Get),
+    #[error(transparent)]
+    DbTryGet(#[from] db::error::TryGet),
     #[error(transparent)]
     ReadTxn(#[from] env::error::ReadTxn),
 }
@@ -683,36 +685,37 @@ impl Validator {
         }
     }
 
-    // Lists known block heights and their corresponding header hashes in ascending order.
+    // Lists active chain block heights and their corresponding header hashes
+    // in ascending order.
     pub fn list_headers(
         &self,
         start_height: u32,
     ) -> Result<Vec<(u32, BlockHash)>, ListHeadersError> {
         let rotxn = self.dbs.read_txn()?;
-        let mut res: Vec<(u32, BlockHash)> = self
-            .dbs
-            .block_hashes
-            .height()
-            .iter(&rotxn)
-            .map_err(db::error::Iter::from)?
-            .filter_map(|(block_hash, height)| {
-                if height >= start_height {
-                    Ok(Some((height, block_hash)))
-                } else {
-                    Ok(None)
-                }
-            })
-            .collect()
-            .map_err(db::error::Iter::from)?;
+        // Not synced yet, so there is no active chain to list.
+        let Some(tip) = self.dbs.current_chain_tip.try_get(&rotxn, &())? else {
+            return Ok(Vec::new());
+        };
+        // Headers on stale branches are never removed, so once a fork has been
+        // seen, the height DB holds several hashes at the same height. Walk
+        // back from the tip instead of iterating that DB, so that exactly one
+        // header is listed per height, as consumers (the wallet checkpoint)
+        // require strictly increasing heights.
+        let heights = self.dbs.block_hashes.height();
+        let mut ancestors = self.dbs.block_hashes.ancestor_headers(&rotxn, tip);
+        let mut res = Vec::new();
+        while let Some((block_hash, _header)) = ancestors.next()? {
+            let height = heights.get(&rotxn, &block_hash)?;
+            if height < start_height {
+                break;
+            }
+            res.push((height, block_hash));
+        }
+        res.reverse();
 
-        res.sort_by_key(|(height, _)| *height);
-
-        debug_assert!(
-            res.clone()
-                .is_sorted_by(|(first_height, _), (second_height, _)| {
-                    first_height < second_height
-                })
-        );
+        debug_assert!(res.is_sorted_by(|(first_height, _), (second_height, _)| {
+            first_height < second_height
+        }));
         Ok(res)
     }
 
@@ -820,24 +823,7 @@ mod ctip_sequence_number_tests {
     use bitcoin::{Amount, OutPoint, Txid, hashes::Hash as _};
 
     use super::*;
-    use crate::types::Ctip;
-
-    fn dummy_validator(dir: &std::path::Path) -> Validator {
-        let mainchain_client = jsonrpsee::http_client::HttpClientBuilder::default()
-            .build("http://127.0.0.1:1")
-            .expect("build dummy rpc client");
-        let mainchain_rest_client =
-            MainRestClient::new(url::Url::parse("http://127.0.0.1:1").expect("valid url"));
-        Validator::new(
-            mainchain_client,
-            Some(mainchain_rest_client),
-            None,
-            dir,
-            bitcoin::Network::Regtest,
-            NetworkParams::for_network(bitcoin::Network::Regtest),
-        )
-        .expect("construct validator")
-    }
+    use crate::{types::Ctip, validator::test_utils::dummy_validator};
 
     #[tokio::test]
     async fn get_ctip_sequence_number_after_disconnecting_last_ctip_is_none() {
@@ -869,5 +855,66 @@ mod ctip_sequence_number_tests {
         rwtxn.commit().unwrap();
 
         assert_eq!(validator.get_ctip_sequence_number(sc).unwrap(), None);
+    }
+}
+
+#[cfg(test)]
+mod list_headers_tests {
+    use bitcoin::hashes::Hash as _;
+
+    use super::*;
+    use crate::validator::test_utils::{dummy_validator, test_block_header};
+
+    /// Headers on stale branches are never removed, so a fork leaves two
+    /// headers at one height. Only the active chain may be listed: the wallet
+    /// builds a checkpoint out of the result, which needs strictly increasing
+    /// heights.
+    #[test]
+    fn list_headers_lists_active_chain_only() {
+        let dir = temp_dir::TempDir::new().unwrap();
+        let validator = dummy_validator(dir.path());
+        let header0 = test_block_header(BlockHash::all_zeros());
+        let header1a = test_block_header(header0.block_hash());
+        // Sibling of `header1a`, on the branch that lost.
+        let mut header1b = test_block_header(header0.block_hash());
+        header1b.nonce = 1;
+        let header2 = test_block_header(header1a.block_hash());
+
+        let mut rwtxn = validator.dbs.write_txn().unwrap();
+        validator
+            .dbs
+            .block_hashes
+            .put_headers(
+                &mut rwtxn,
+                &[(header0, 0), (header1a, 1), (header1b, 1), (header2, 2)],
+            )
+            .unwrap();
+        rwtxn.commit().unwrap();
+        assert!(
+            validator.list_headers(0).unwrap().is_empty(),
+            "no chain tip, so no active chain to list"
+        );
+
+        let mut rwtxn = validator.dbs.write_txn().unwrap();
+        validator
+            .dbs
+            .current_chain_tip
+            .put(&mut rwtxn, &(), &header2.block_hash())
+            .unwrap();
+        rwtxn.commit().unwrap();
+        assert_eq!(
+            validator.list_headers(0).unwrap(),
+            vec![
+                (0, header0.block_hash()),
+                (1, header1a.block_hash()),
+                (2, header2.block_hash()),
+            ],
+            "the stale header at height 1 must not be listed"
+        );
+        assert_eq!(
+            validator.list_headers(2).unwrap(),
+            vec![(2, header2.block_hash())],
+            "headers below `start_height` must not be listed"
+        );
     }
 }

--- a/lib/validator/test_utils.rs
+++ b/lib/validator/test_utils.rs
@@ -2,11 +2,12 @@
 //! This module is gated behind `#[cfg(test)]` in the parent module.
 
 use bitcoin::{BlockHash, Txid, hashes::Hash as _};
+use bitcoin_jsonrpsee::jsonrpsee;
 use miette::IntoDiagnostic;
 
-use super::dbs::Dbs;
+use super::{Validator, dbs::Dbs, main_rest_client::MainRestClient};
 use crate::types::{
-    M6id, Sidechain, SidechainDescription, SidechainNumber, SidechainProposal,
+    M6id, NetworkParams, Sidechain, SidechainDescription, SidechainNumber, SidechainProposal,
     SidechainProposalStatus,
 };
 
@@ -14,6 +15,25 @@ pub fn create_test_dbs() -> miette::Result<(temp_dir::TempDir, Dbs)> {
     let dir = temp_dir::TempDir::new().into_diagnostic()?;
     let dbs = Dbs::new(dir.path(), bitcoin::Network::Regtest).into_diagnostic()?;
     Ok((dir, dbs))
+}
+
+/// Validator with a fresh DB in `dir`, and mainchain clients that point at
+/// nothing. For tests that only exercise DB-backed methods.
+pub fn dummy_validator(dir: &std::path::Path) -> Validator {
+    let mainchain_client = jsonrpsee::http_client::HttpClientBuilder::default()
+        .build("http://127.0.0.1:1")
+        .expect("build dummy rpc client");
+    let mainchain_rest_client =
+        MainRestClient::new(url::Url::parse("http://127.0.0.1:1").expect("valid url"));
+    Validator::new(
+        mainchain_client,
+        Some(mainchain_rest_client),
+        None,
+        dir,
+        bitcoin::Network::Regtest,
+        NetworkParams::for_network(bitcoin::Network::Regtest),
+    )
+    .expect("construct validator")
 }
 
 pub fn test_sidechain(sidechain_number: u8, proposal_height: u32) -> Sidechain {


### PR DESCRIPTION
`Validator::list_headers` (`lib/validator/mod.rs`) iterated the height DB and sorted by height. Headers on stale branches are never pruned, so once a fork has been seen that DB holds several hashes at the same height, and the result contained duplicate-height entries. The wallet feeds this list into `CreateCheckPointFromHeaders`, which requires strictly increasing heights: in debug builds the `is_sorted_by` assertion panics, and in release the checkpoint build errors, breaking the wallet full-scan.

The fix walks back from the current chain tip via `ancestor_headers`, emitting exactly one header per height and stopping at `start_height`, then reverses into ascending order. If the validator is not yet synced (no `current_chain_tip`), it returns an empty list rather than iterating the height DB.

This changes only what the `list_headers` query returns; it does not affect block validation.

Tests: unit tests assert that a fork's stale height-1 header is excluded from the active-chain listing, that headers below `start_height` are omitted, and that a validator without a chain tip returns empty. A shared `dummy_validator` helper is moved into `test_utils`.