### PR TITLE
fix: Bail out of header sync when the targeted tip has left the active chain

### DIFF
--- a/app/error.rs
+++ b/app/error.rs
@@ -76,7 +76,7 @@ where
                 is_transport_error(err)
             }
             SyncTaskError::InitialSyncEnforcer(InitialSyncError::CusfEnforcer(err)) => {
-                is_block_not_found_on_disk(err)
+                is_block_not_found_on_disk(err) || is_stale_main_tip(err)
             }
             // The crate does not export this variant's error type, so its
             // `ClientError` is only reachable through the source chain.
@@ -95,6 +95,20 @@ where
     ErrorChain::new(err)
         .to_string()
         .contains("Block not found on disk")
+}
+
+// A sync targets a tip read before it started, and the node can reorg onto a
+// chain that does not contain that tip while the sync is running. The sync
+// gives up in that case, since only a sync against the node's current tip can
+// finish. Matched by message, as the enforcer's error type does not survive
+// the crate boundary. See `validator::task::error::Sync::MainTipReorged`.
+fn is_stale_main_tip<E>(err: &E) -> bool
+where
+    E: std::error::Error,
+{
+    ErrorChain::new(err)
+        .to_string()
+        .contains("left the active chain during header sync")
 }
 
 /// Whether a node RPC call failed at the transport layer rather than being
@@ -128,7 +142,7 @@ where
             is_transport_error(err)
         }
         TaskError::InitialSync(InitialSyncError::CusfEnforcer(err)) => {
-            is_block_not_found_on_disk(err)
+            is_block_not_found_on_disk(err) || is_stale_main_tip(err)
         }
         _ => false,
     }

--- a/lib/validator/task/error.rs
+++ b/lib/validator/task/error.rs
@@ -499,6 +499,13 @@ pub(in crate::validator) enum Sync {
     #[error(transparent)]
     #[fatal(true)]
     LastCommonAncestor(#[from] dbs::block_hash_dbs_error::LastCommonAncestor),
+    /// The tip a sync was targeting is no longer reachable, because the node
+    /// reorged onto a chain that does not contain it. Only a fresh sync
+    /// against the node's current tip clears this, so `app::error` classifies
+    /// it as re-syncable by matching this message. Keep the two in sync.
+    #[error("Mainchain tip `{block_hash}` left the active chain during header sync")]
+    #[fatal(false)]
+    MainTipReorged { block_hash: bitcoin::BlockHash },
     #[error(transparent)]
     #[fatal(true)]
     ParseBlockFiles(#[from] parse_block_files::ParseBlockFileError),

--- a/lib/validator/task/mod.rs
+++ b/lib/validator/task/mod.rs
@@ -1635,6 +1635,20 @@ where
 
         match headers.last() {
             Some((_, last_block_hash, last_block_height)) => {
+                // The requested header is always the first entry in the batch,
+                // so a batch that ends where it started made no progress. That
+                // happens when the active chain has reorged onto a shorter
+                // chain whose tip is the block we're currently at: every
+                // further request returns that same single header. The batch is
+                // never empty and the cursor never reaches the captured tip, so
+                // neither of the checks below would ever fire. The tip we were
+                // given is gone, and only a sync against the node's current tip
+                // can make progress, so bail out and let the caller re-sync.
+                if *last_block_height <= current_height && *last_block_hash != main_tip {
+                    return Err(error::Sync::MainTipReorged {
+                        block_hash: main_tip,
+                    });
+                }
                 // Update the block_hash to the latest header fetched in this
                 // batch to continue the loop
                 current_block_hash = *last_block_hash;
@@ -2414,6 +2428,22 @@ mod tests {
         )
         .expect_err("a header that does not deserialize must be rejected");
         assert!(matches!(err, error::Sync::DeserializeHex(_)));
+    }
+
+    #[test]
+    fn a_reorged_main_tip_is_retryable() {
+        let err = error::Sync::MainTipReorged {
+            block_hash: dummy_block_hash(0x42),
+        };
+        assert!(
+            !err.is_fatal(),
+            "a tip that left the active chain clears on a sync against the current tip"
+        );
+        assert!(
+            err.to_string()
+                .contains("left the active chain during header sync"),
+            "`app::error::is_stale_main_tip` classifies this error by its message"
+        );
     }
 
     // ── handle_m8 ──


### PR DESCRIPTION
`sync_headers` in `lib/validator/task/mod.rs` loops fetching header batches until it reaches the tip captured when the sync began. If the node reorgs onto a shorter chain whose tip is the block the sync is currently at, every further batch returns that same single header: the batch is never empty and the cursor never reaches the captured tip, so neither loop-exit check fires and the sync spins forever.

The fix detects a batch that ends at or below the current height with a hash other than the captured tip and returns a new non-fatal `Sync::MainTipReorged`. `app/error.rs` classifies that error as re-syncable (matched by message, since the enforcer's error type does not cross the crate boundary), so the sync task restarts against the node's current tip instead of livelocking.

Tests: adds `a_reorged_main_tip_is_retryable`, asserting the error is non-fatal and carries the message the classifier matches. This is sync-loop robustness only; it changes nothing about block validation.