### PR TITLE
fix: Cap the M1 description so an unminable proposal can't wedge mining

### DIFF
--- a/lib/block_producer/coinbase.rs
+++ b/lib/block_producer/coinbase.rs
@@ -5,7 +5,10 @@ use fallible_iterator::{FallibleIterator as _, IteratorExt as _};
 
 use crate::{
     block_producer::{BlockProducer, BundleProposals, error},
-    messages::{CoinbaseBuilder, CoinbaseMessage, CoinbaseMessages, M4AckBundles},
+    messages::{
+        CoinbaseBuilder, CoinbaseMessage, CoinbaseMessages, M4AckBundles,
+        MAX_SIDECHAIN_DESCRIPTION_SIZE,
+    },
     types::{
         AmountUnderflowError, BlindedM6, Ctip, Sidechain, SidechainAck, SidechainNumber,
         SidechainProposal, SidechainProposalId, Thresholds,
@@ -244,9 +247,24 @@ impl BlockProducer {
             .collect::<HashSet<_>>();
 
         for sidechain_proposal in sidechain_proposals {
-            if !proposed_sidechains.contains(&sidechain_proposal.compute_id()) {
-                coinbase_builder.propose_sidechain(sidechain_proposal)?;
+            if proposed_sidechains.contains(&sidechain_proposal.compute_id()) {
+                continue;
             }
+            // An M1 whose OP_RETURN output does not fit in a block can never be
+            // mined, and a pending proposal is only cleared by the block that
+            // includes it. Skip it rather than wedging block production for
+            // good: rows persisted by a binary predating the RPC-level bound
+            // are otherwise unremovable.
+            if sidechain_proposal.description.0.len() > MAX_SIDECHAIN_DESCRIPTION_SIZE {
+                tracing::warn!(
+                    sidechain_number = %sidechain_proposal.sidechain_number,
+                    description_size = sidechain_proposal.description.0.len(),
+                    max_description_size = MAX_SIDECHAIN_DESCRIPTION_SIZE,
+                    "skipping a pending sidechain proposal too large for a coinbase"
+                );
+                continue;
+            }
+            coinbase_builder.propose_sidechain(sidechain_proposal)?;
         }
 
         let stored_acks = self.db().get_sidechain_acks().await?;

--- a/lib/messages.rs
+++ b/lib/messages.rs
@@ -963,6 +963,18 @@ pub fn compute_m6id(
 
 // ... existing code ...
 
+/// Largest M1 sidechain description this node will propose, in bytes.
+///
+/// BIP300 does not bound the description, but the coinbase carrying the M1 has
+/// to fit in a block. A proposal too large to mine is worse than useless: a
+/// pending proposal is only cleared by the block that includes it, so it stops
+/// this node from producing blocks at all for as long as it is pending. The
+/// M1's `OP_RETURN` output is entirely non-witness data, so each of its bytes
+/// costs four of a block's 4,000,000 weight units. A quarter of that budget is
+/// far more than any real declaration needs, and leaves the rest of the block
+/// usable.
+pub const MAX_SIDECHAIN_DESCRIPTION_SIZE: usize = 250_000;
+
 // Returns the serialized sidechain proposal OP_RETURN output, plus the byte
 // slice encoded into the OP_RETURN output.
 pub fn create_sidechain_proposal(
@@ -1068,6 +1080,26 @@ mod tests {
             (&proposal.description).try_into().expect("Failed to parse");
 
         assert_eq!(parsed, declaration);
+    }
+
+    /// The description cap exists so that the coinbase output carrying the M1
+    /// still fits in a block: an M1 that cannot be mined can never confirm, and
+    /// stops block production for as long as the proposal is pending.
+    #[test]
+    fn maximal_sidechain_proposal_txout_fits_in_a_block() {
+        const MAX_BLOCK_WEIGHT: usize = 4_000_000;
+        let tx_out = TxOut {
+            value: Amount::ZERO,
+            script_pubkey: M1ProposeSidechain {
+                sidechain_number: SidechainNumber(0),
+                description: vec![0u8; MAX_SIDECHAIN_DESCRIPTION_SIZE].into(),
+            }
+            .try_into()
+            .expect("a capped description fits in a single push"),
+        };
+        // The output is entirely non-witness data: four weight units per byte.
+        let weight = bitcoin::consensus::encode::serialize(&tx_out).len() * 4;
+        assert!(weight < MAX_BLOCK_WEIGHT, "{weight} weight units");
     }
 
     // ── M8 script_pubkey roundtrip ──

--- a/lib/server/block_producer.rs
+++ b/lib/server/block_producer.rs
@@ -170,6 +170,17 @@ where
         crate::messages::create_sidechain_proposal(sidechain_id, &declaration).map_err(
             |err: bitcoin::script::PushBytesError| ConnectError::unknown(format!("{err:#}")),
         )?;
+    // The coinbase carrying the M1 has to fit in a block. A proposal too large
+    // to mine can never confirm, and -- since a pending proposal is only
+    // cleared by the block that includes it -- would stop this node from
+    // producing blocks at all for as long as it sits in the DB.
+    if description.0.len() > crate::messages::MAX_SIDECHAIN_DESCRIPTION_SIZE {
+        return Err(ConnectError::invalid_argument(format!(
+            "sidechain declaration serializes to {} bytes; at most {} fit in a coinbase",
+            description.0.len(),
+            crate::messages::MAX_SIDECHAIN_DESCRIPTION_SIZE,
+        )));
+    }
     tracing::info!("Created sidechain proposal TX output: {:?}", proposal_txout);
     let sidechain_proposal = crate::types::SidechainProposal {
         sidechain_number: sidechain_id,


### PR DESCRIPTION
An M1 sidechain proposal whose OP_RETURN description is too large to fit in a block can never be mined, and a pending proposal is only cleared by the block that includes it. Once such a proposal is stored, `generate_coinbase_txouts` in `lib/block_producer/coinbase.rs` keeps trying to place it in every coinbase, and this node produces no blocks for as long as it stays pending.

The fix adds `MAX_SIDECHAIN_DESCRIPTION_SIZE` (250,000 bytes, about a quarter of the block weight budget). `create_sidechain_proposal` handling in `lib/server/block_producer.rs` rejects an over-cap description at the RPC boundary with `invalid_argument`, and coinbase generation skips (with a warning) any already-stored proposal over the cap, so a row persisted by an older binary is no longer unremovable.

Tests: adds a unit test that a maximal capped description's coinbase output fits within a block's weight.

BIP300 does not bound the description; this only validates an RPC argument and changes which proposals this node places in its own coinbase. It introduces no rule about M1s in blocks the node validates.