### PR TITLE
fix: Drop descendants of losing BMM bids when self-mining a block

### DIFF
--- a/integration_tests/test_bmm_bid_auction.rs
+++ b/integration_tests/test_bmm_bid_auction.rs
@@ -1,6 +1,7 @@
 //! Competing BMM bids must resolve to one M7 accept per slot, with the
-//! highest bid winning, losers excluded from the block, stale requests kept
-//! out of later blocks, and losing bids evicted from the enforcer wallet.
+//! highest bid winning, losers excluded from the block together with their
+//! descendants, stale requests kept out of later blocks, and losing bids
+//! evicted from the enforcer wallet.
 //!
 //! The enforcer wallet places at most one bid per tip: a second unconfirmed
 //! bid from the same BDK wallet either chains onto or conflicts with the
@@ -56,6 +57,9 @@ const BIG_LOW_FEERATE_BID: u64 = 30_000;
 /// Inflates the big bid to roughly 10x the small bid's size, putting its fee
 /// rate well below the small bid's.
 const BIG_BID_PAD_OUTPUTS: usize = 40;
+/// The absolute fee of the transaction spending the losing bid's change. If it
+/// were mined, the coinbase would collect it.
+const CHILD_FEE: u64 = 1_000;
 
 fn h_star(label: &str) -> [u8; 32] {
     bitcoin::hashes::sha256::Hash::hash(label.as_bytes()).to_byte_array()
@@ -220,6 +224,57 @@ async fn craft_core_bid(
     Ok(txid)
 }
 
+/// Spend `parent`'s change output — output one, as [`craft_core_bid`] lays it
+/// out — through Bitcoin Core's wallet, returning the child's txid. A losing
+/// bid must leave the block together with its descendants: keeping a child
+/// whose parent was dropped would submit a block with a missing input.
+async fn craft_child_spend(post_setup: &PostSetup, parent: Txid) -> anyhow::Result<Txid> {
+    let parent_tx = get_raw_transaction(post_setup, &parent).await?;
+    let change = parent_tx
+        .output
+        .get(1)
+        .ok_or_else(|| anyhow::anyhow!("crafted bid {parent} has no change output"))?
+        .value;
+    let address = post_setup
+        .bitcoin_cli
+        .command::<String, _, String, _, _>([], "getnewaddress", [])
+        .run_utf8()
+        .await?
+        .trim()
+        .to_owned();
+    let inputs = serde_json::json!([{"txid": parent.to_string(), "vout": 1}]).to_string();
+    let amount = format!("{:.8}", (change - Amount::from_sat(CHILD_FEE)).to_btc());
+    let mut output = serde_json::Map::new();
+    output.insert(address, serde_json::Value::String(amount));
+    let outputs = serde_json::Value::Array(vec![serde_json::Value::Object(output)]).to_string();
+    let raw = post_setup
+        .bitcoin_cli
+        .command::<String, _, _, _, _>([], "createrawtransaction", [inputs, outputs])
+        .run_utf8()
+        .await?;
+    let signed_json = post_setup
+        .bitcoin_cli
+        .command::<String, _, _, _, _>([], "signrawtransactionwithwallet", [raw.trim().to_owned()])
+        .run_utf8()
+        .await?;
+    let signed: serde_json::Value = serde_json::from_str(&signed_json)?;
+    anyhow::ensure!(
+        signed["complete"].as_bool() == Some(true),
+        "failed to sign the child of {parent}: {signed}"
+    );
+    let signed_hex = signed["hex"]
+        .as_str()
+        .ok_or_else(|| anyhow::anyhow!("signrawtransactionwithwallet returned no hex"))?;
+    let txid = post_setup
+        .bitcoin_cli
+        .command::<String, _, _, _, _>([], "sendrawtransaction", [signed_hex.to_owned()])
+        .run_utf8()
+        .await?
+        .trim()
+        .parse::<Txid>()?;
+    Ok(txid)
+}
+
 async fn get_raw_transaction(
     post_setup: &PostSetup,
     txid: &Txid,
@@ -367,7 +422,8 @@ fn coinbase_value(block: &bitcoin::Block) -> Amount {
 
 /// * Round 1: the enforcer outbids a crafted bid on slot 0 while a lone
 ///   crafted bid takes slot 1; one block settles both slots, excludes the
-///   loser, and (self-mining mode) collects the winning bids as fees
+///   loser and the transaction spending its change, and (self-mining mode)
+///   collects the winning bids as fees
 /// * The stale losing bid stays out of the next block
 /// * Round 2: a crafted outside bid outbids the enforcer's own bid, and the
 ///   losing bid's inputs are freed in the wallet
@@ -447,10 +503,18 @@ pub async fn test_bmm_bid_auction(mut post_setup: PostSetup) -> anyhow::Result<(
         0,
     )
     .await?;
-    tracing::info!(%high_txid, %low_txid, %other_txid, "Placed round 1 bids");
+    // A plain transaction spending the losing bid's change. It is a valid
+    // mempool transaction on its own, so generic tx selection offers it
+    // alongside its parent.
+    let low_child_txid = craft_child_spend(&post_setup, low_txid).await?;
+    tracing::info!(%high_txid, %low_txid, %low_child_txid, %other_txid, "Placed round 1 bids");
     if let Mode::GetBlockTemplate = mode {
-        let () =
-            wait_for_template_txs(&post_setup, vec![high_txid, other_txid], vec![low_txid]).await?;
+        let () = wait_for_template_txs(
+            &post_setup,
+            vec![high_txid, other_txid],
+            vec![low_txid, low_child_txid],
+        )
+        .await?;
     }
 
     let (auction_block, auction_height) =
@@ -463,6 +527,10 @@ pub async fn test_bmm_bid_auction(mut post_setup: PostSetup) -> anyhow::Result<(
     anyhow::ensure!(
         !auction_txids.contains(&low_txid),
         "the losing slot 0 bid must not be included in the block"
+    );
+    anyhow::ensure!(
+        !auction_txids.contains(&low_child_txid),
+        "a descendant of the losing bid must be dropped with its parent"
     );
     let m7s = coinbase_m7_accepts(&auction_block)?;
     anyhow::ensure!(
@@ -494,11 +562,13 @@ pub async fn test_bmm_bid_auction(mut post_setup: PostSetup) -> anyhow::Result<(
     }
     tracing::info!("Round 1: auction block settled both slots correctly");
 
-    // The losing bid is now stale, but still sits in Bitcoin Core's mempool.
+    // The losing bid is now stale, but still sits in Bitcoin Core's mempool,
+    // as does the transaction spending its change.
     let (empty_block, _) = mine_and_check_commitment(&mut post_setup, None).await?;
+    let empty_txids = block_txids(&empty_block);
     anyhow::ensure!(
-        !block_txids(&empty_block).contains(&low_txid),
-        "the stale losing bid must not be included in a later block"
+        !empty_txids.contains(&low_txid) && !empty_txids.contains(&low_child_txid),
+        "the stale losing bid and its descendant must not be included in a later block"
     );
     anyhow::ensure!(
         coinbase_m7_accepts(&empty_block)?.is_empty(),

--- a/lib/block_producer/mine.rs
+++ b/lib/block_producer/mine.rs
@@ -34,7 +34,7 @@ use crate::{
     bins::{self, CommandExt as _},
     block_producer::{BlockProducer, error},
     errors::ErrorChain,
-    messages::CoinbaseBuilder,
+    messages::{CoinbaseBuilder, M8BmmRequest},
     types::{BmmCommitment, SidechainNumber},
 };
 
@@ -51,6 +51,45 @@ pub(in crate::block_producer) fn bmm_auction_winners(
         }
     }
     winners
+}
+
+/// Settle the BMM auction over a topologically ordered tx set: drop every
+/// losing bid, and with it every descendant of a losing bid, so that the block
+/// never contains a tx whose parent has been excluded. This mirrors the served
+/// template path, where excluded bids drop together with their descendants when
+/// the template is built.
+///
+/// Returns the retained txs with their fees, and the BMM requests to accept in
+/// the coinbase, both in the input's order.
+fn drop_auction_losers(
+    selected: Vec<(Transaction, Amount)>,
+    winners: &HashMap<SidechainNumber, (BmmCommitment, Txid, Amount)>,
+) -> (Vec<(Transaction, Amount)>, Vec<M8BmmRequest>) {
+    let mut dropped: HashSet<Txid> = HashSet::new();
+    let mut retained = Vec::with_capacity(selected.len());
+    let mut bmm_accepts = Vec::new();
+    for (tx, fee) in selected {
+        let txid = tx.compute_txid();
+        let request = crate::messages::parse_m8_tx(&tx);
+        let is_loser = request.as_ref().is_some_and(|request| {
+            winners
+                .get(&request.sidechain_number)
+                .is_none_or(|(_, winner_txid, _)| *winner_txid != txid)
+        });
+        let spends_dropped = tx
+            .input
+            .iter()
+            .any(|input| dropped.contains(&input.previous_output.txid));
+        if is_loser || spends_dropped {
+            dropped.insert(txid);
+            continue;
+        }
+        if let Some(request) = request {
+            bmm_accepts.push(request);
+        }
+        retained.push((tx, fee));
+    }
+    (retained, bmm_accepts)
 }
 
 /// BMM request cleanup happens after the block has been submitted and observed
@@ -679,21 +718,14 @@ impl BlockProducer {
                 )
             })
         }));
+        let (selected, bmm_accepts) = drop_auction_losers(selected, &winners);
         let mut coinbase_builder = CoinbaseBuilder::new(&mut coinbase_outputs)?;
+        for request in bmm_accepts {
+            coinbase_builder.bmm_accept(request.sidechain_number, request.sidechain_block_hash)?;
+        }
         let mut fees = Amount::ZERO;
         let mut transactions = Vec::with_capacity(selected.len());
         for (tx, fee) in selected {
-            if let Some(request) = crate::messages::parse_m8_tx(&tx) {
-                let txid = tx.compute_txid();
-                if winners
-                    .get(&request.sidechain_number)
-                    .is_none_or(|(_, winner_txid, _)| *winner_txid != txid)
-                {
-                    continue;
-                }
-                coinbase_builder
-                    .bmm_accept(request.sidechain_number, request.sidechain_block_hash)?;
-            }
             fees += fee;
             transactions.push(tx);
         }
@@ -719,10 +751,16 @@ impl BlockProducer {
 
 #[cfg(test)]
 mod tests {
-    use bitcoin::{Amount, BlockHash, Txid, hashes::Hash as _};
+    use bitcoin::{
+        Amount, BlockHash, OutPoint, ScriptBuf, Transaction, TxIn, TxOut, Txid, absolute::LockTime,
+        hashes::Hash as _, transaction::Version as TxVersion,
+    };
 
-    use super::{bmm_auction_winners, finish_bmm_request_cleanup};
-    use crate::types::{BmmCommitment, SidechainNumber};
+    use super::{bmm_auction_winners, drop_auction_losers, finish_bmm_request_cleanup};
+    use crate::{
+        messages::M8BmmRequest,
+        types::{BmmCommitment, SidechainNumber},
+    };
 
     #[test]
     fn highest_bmm_fee_wins_each_sidechain_slot() {
@@ -753,6 +791,73 @@ mod tests {
 
         assert_eq!(winners[&slot].1, high_txid);
         assert_eq!(winners[&SidechainNumber(8)].1, other_txid);
+    }
+
+    /// A tx spending `parents`, with `spk` as its first output.
+    fn tx_spending(parents: &[Txid], spk: ScriptBuf) -> Transaction {
+        Transaction {
+            version: TxVersion::TWO,
+            lock_time: LockTime::ZERO,
+            input: parents
+                .iter()
+                .map(|txid| TxIn {
+                    previous_output: OutPoint {
+                        txid: *txid,
+                        vout: 0,
+                    },
+                    ..TxIn::default()
+                })
+                .collect(),
+            output: vec![TxOut {
+                script_pubkey: spk,
+                value: Amount::ZERO,
+            }],
+        }
+    }
+
+    #[test]
+    fn losing_bid_drops_its_descendants() {
+        let slot = SidechainNumber(7);
+        let tip = BlockHash::from_byte_array([9; 32]);
+        let winner_commitment = BmmCommitment([1; 32]);
+        let loser_commitment = BmmCommitment([2; 32]);
+        let m8_tx = |commitment| {
+            let spk = M8BmmRequest::script_pubkey(slot, commitment, tip).unwrap();
+            tx_spending(&[Txid::from_byte_array([4; 32])], spk)
+        };
+        let winner_tx = m8_tx(winner_commitment);
+        let loser_tx = m8_tx(loser_commitment);
+        let winner_txid = winner_tx.compute_txid();
+        let loser_txid = loser_tx.compute_txid();
+        // A plain tx spending the losing bid's change, and its own child.
+        let child_tx = tx_spending(&[loser_txid], ScriptBuf::new());
+        let grandchild_tx = tx_spending(&[child_tx.compute_txid()], ScriptBuf::new());
+
+        let winner_bid = Amount::from_sat(2_000);
+        let loser_bid = Amount::from_sat(1_000);
+        let winners = bmm_auction_winners([
+            (slot, winner_commitment, winner_txid, winner_bid),
+            (slot, loser_commitment, loser_txid, loser_bid),
+        ]);
+        let (retained, bmm_accepts) = drop_auction_losers(
+            vec![
+                (winner_tx, winner_bid),
+                (loser_tx, loser_bid),
+                (child_tx, Amount::from_sat(500)),
+                (grandchild_tx, Amount::from_sat(250)),
+            ],
+            &winners,
+        );
+
+        let retained_txids: Vec<_> = retained.iter().map(|(tx, _)| tx.compute_txid()).collect();
+        assert_eq!(retained_txids, vec![winner_txid]);
+        let mut fees = Amount::ZERO;
+        for (_, fee) in &retained {
+            fees += *fee;
+        }
+        assert_eq!(fees, winner_bid);
+        assert_eq!(bmm_accepts.len(), 1);
+        assert_eq!(bmm_accepts[0].sidechain_block_hash, winner_commitment);
     }
 
     #[test]


### PR DESCRIPTION
When the enforcer mines its own block (`BlockProducer::mine` in `lib/block_producer/mine.rs`), it settles the BMM auction by dropping each losing M8 bid from the selected transactions. But it dropped only the bid itself, not transactions descending from it. A plain transaction spending a losing bid's change output is a valid mempool transaction on its own, so generic selection offers it alongside its parent; the loop excluded the parent bid but kept the child, producing a block whose child input references a transaction no longer in the block. Bitcoin Core rejects that block (missing input), so self-mining fails.

The fix adds `drop_auction_losers`, which walks the topologically ordered selection once, dropping every losing bid together with anything that transitively spends a dropped transaction, and collects the coinbase M7 accepts for the retained winners. This mirrors the served-template path, where excluded bids already drop with their descendants.

This changes only what the node produces in self-mining mode — its own block — not what it validates.

Tests: a unit test (`losing_bid_drops_its_descendants`) covers the child/grandchild drop, and the BMM auction integration test now crafts a child of the losing bid and asserts it is excluded from the block and from later blocks.