### PR TITLE
fix: Redact the node RPC password from the signet miner DEBUG log line

### DIFF
--- a/lib/bins.rs
+++ b/lib/bins.rs
@@ -77,7 +77,11 @@ pub struct BitcoinCli {
 }
 
 impl BitcoinCli {
-    fn default_args(&self) -> Vec<String> {
+    /// `rpc_pass` renders the `-rpcpassword` argument, and is `None` when
+    /// there is no password to pass. Taking it as an argument is what lets a
+    /// redacted rendering be built from the very same code as the argv that
+    /// runs, so the two cannot drift apart.
+    fn default_args_with_rpc_pass(&self, rpc_pass: Option<&str>) -> Vec<String> {
         let mut res = vec![
             format!("-chain={}", self.network.to_core_arg()),
             format!("-rpcport={}", self.rpc_port),
@@ -92,14 +96,24 @@ impl BitcoinCli {
             res.push(format!("-rpcuser={rpc_user}"));
         }
 
-        if let Some(rpc_pass) = &self.rpc_pass {
-            res.push(format!("-rpcpassword={}", rpc_pass.expose()));
+        if let Some(rpc_pass) = rpc_pass {
+            res.push(format!("-rpcpassword={rpc_pass}"));
         }
 
         if let Some(rpc_wallet) = &self.rpc_wallet {
             res.push(format!("-rpcwallet={rpc_wallet}"))
         }
         res
+    }
+
+    fn default_args(&self) -> Vec<String> {
+        self.default_args_with_rpc_pass(self.rpc_pass.as_ref().map(|pass| pass.expose()))
+    }
+
+    /// [`Self::default_args`], with the RPC password replaced by
+    /// `[redacted]`. For logging only: the result is not runnable.
+    fn default_args_redacted(&self) -> Vec<String> {
+        self.default_args_with_rpc_pass(self.rpc_pass.as_ref().map(|_| crate::cli::REDACTED))
     }
 
     pub fn command<CmdArg, Subcommand, SubcommandArg, CmdArgs, SubcommandArgs>(
@@ -134,14 +148,24 @@ impl BitcoinCli {
             .join(" ")
     }
 
-    pub fn display_without_chain(&self) -> String {
+    fn display_without_chain_args(&self, default_args: Vec<String>) -> String {
         let mut command_fragments = vec![format!("{}", self.path.display())];
         command_fragments.extend(
-            self.default_args()
+            default_args
                 .into_iter()
                 .filter(|arg| !arg.starts_with("-chain=")),
         );
         command_fragments.join(" ")
+    }
+
+    pub fn display_without_chain(&self) -> String {
+        self.display_without_chain_args(self.default_args())
+    }
+
+    /// [`Self::display_without_chain`], with the RPC password replaced by
+    /// `[redacted]`. For logging only: the result is not runnable.
+    pub fn display_redacted(&self) -> String {
+        self.display_without_chain_args(self.default_args_redacted())
     }
 }
 
@@ -195,8 +219,12 @@ pub struct SignetMiner {
 }
 
 impl SignetMiner {
-    pub fn command<Subcommand, SubcommandArg, SubcommandArgs>(
+    /// `cli` renders the `--cli` argument. Taking it as an argument is what
+    /// lets [`Self::display_redacted`] build the very same command as
+    /// [`Self::command`], without the node RPC password in it.
+    fn command_with_cli<Subcommand, SubcommandArg, SubcommandArgs>(
         &self,
+        cli: String,
         subcommand: Subcommand,
         subcommand_args: SubcommandArgs,
     ) -> tokio::process::Command
@@ -206,10 +234,7 @@ impl SignetMiner {
         SubcommandArgs: IntoIterator<Item = SubcommandArg>,
     {
         let mut command = tokio::process::Command::new(&self.path);
-        command.arg(format!(
-            "--cli={}",
-            self.bitcoin_cli.display_without_chain()
-        ));
+        command.arg(format!("--cli={cli}"));
 
         // Unless debug is explicitly set, we want to run in quiet mode. Otherwise
         // we'll get lots of error logs about stderr not being empty.
@@ -241,5 +266,117 @@ impl SignetMiner {
         }
         command.args(subcommand_args);
         command
+    }
+
+    pub fn command<Subcommand, SubcommandArg, SubcommandArgs>(
+        &self,
+        subcommand: Subcommand,
+        subcommand_args: SubcommandArgs,
+    ) -> tokio::process::Command
+    where
+        Subcommand: AsRef<OsStr>,
+        SubcommandArg: AsRef<OsStr>,
+        SubcommandArgs: IntoIterator<Item = SubcommandArg>,
+    {
+        self.command_with_cli(
+            self.bitcoin_cli.display_without_chain(),
+            subcommand,
+            subcommand_args,
+        )
+    }
+
+    /// The invocation [`Self::command`] builds, with the node RPC password
+    /// replaced by `[redacted]`. `Debug` on the command itself prints the
+    /// password, so this is what a log line gets.
+    pub fn display_redacted<Subcommand, SubcommandArg, SubcommandArgs>(
+        &self,
+        subcommand: Subcommand,
+        subcommand_args: SubcommandArgs,
+    ) -> String
+    where
+        Subcommand: AsRef<OsStr>,
+        SubcommandArg: AsRef<OsStr>,
+        SubcommandArgs: IntoIterator<Item = SubcommandArg>,
+    {
+        let command = self.command_with_cli(
+            self.bitcoin_cli.display_redacted(),
+            subcommand,
+            subcommand_args,
+        );
+        let command = command.as_std();
+        std::iter::once(command.get_program())
+            .chain(command.get_args())
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{path::PathBuf, time::Duration};
+
+    use super::{BitcoinCli, SignetMiner};
+    use crate::cli::{REDACTED, SecretString};
+
+    const RPC_PASS: &str = "node-rpc-password";
+
+    fn signet_miner() -> SignetMiner {
+        SignetMiner {
+            path: PathBuf::from("/signet/miner"),
+            bitcoin_cli: BitcoinCli {
+                path: PathBuf::from("/bin/bitcoin-cli"),
+                network: bitcoin::Network::Signet,
+                rpc_user: Some("user".to_owned()),
+                rpc_pass: Some(SecretString::new(RPC_PASS)),
+                rpc_cookie_path: None,
+                rpc_port: 38332,
+                rpc_host: "127.0.0.1".to_owned(),
+                rpc_wallet: None,
+            },
+            bitcoin_util: PathBuf::from("/bin/bitcoin-util"),
+            block_interval: Some(Duration::from_secs(60)),
+            nbits: None,
+            coinbase_recipient: None,
+            getblocktemplate_command: Some("bitcoin-cli getblocktemplate".to_owned()),
+            coinbasetxn: true,
+            debug: false,
+        }
+    }
+
+    /// The node RPC password has to reach the mining script through its
+    /// `--cli` argument, but must never reach a log line.
+    #[test]
+    fn signet_miner_display_redacts_rpc_password() {
+        let miner = signet_miner();
+        let subcommand_args = ["--set-block-time=1"];
+
+        let displayed = miner.display_redacted("generate", subcommand_args);
+        assert!(
+            !displayed.contains(RPC_PASS),
+            "the node RPC password leaked into a rendering meant for logs"
+        );
+        assert!(
+            displayed.contains(&format!("-rpcpassword={REDACTED}")),
+            "expected a redacted password, got: {displayed}"
+        );
+
+        // The argv that actually runs still carries the password. Without
+        // this, the assertions above would also pass on a command that never
+        // authenticated at all.
+        let command = miner.command("generate", subcommand_args);
+        let argv = std::iter::once(command.as_std().get_program())
+            .chain(command.as_std().get_args())
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>()
+            .join(" ");
+        assert!(
+            argv.contains(RPC_PASS),
+            "the mining script is invoked without the node RPC password"
+        );
+
+        // Redaction is the only difference: a new argument added to
+        // `command` cannot silently go missing from what gets logged.
+        assert_eq!(displayed.replace(REDACTED, RPC_PASS), argv);
     }
 }

--- a/lib/block_producer/mine.rs
+++ b/lib/block_producer/mine.rs
@@ -544,14 +544,19 @@ impl BlockProducer {
             command_args.push(format!("--set-block-time={next_block_time}"));
         };
 
-        let mut command = miner.command("generate", command_args);
+        let mut command = miner.command("generate", &command_args);
         // Important: avoid lingering mining processes that may loop forever with new requests
         command.kill_on_drop(true);
 
         // We want to stream stdout/stderr as they come in, for investigating hanging processes.
         command.stdout(std::process::Stdio::piped());
         command.stderr(std::process::Stdio::piped());
-        tracing::debug!("Running signet miner: {:?}", command);
+        // The command's own `Debug` would print the node RPC password, which
+        // the `--cli` argument carries.
+        tracing::debug!(
+            "Running signet miner: {}",
+            miner.display_redacted("generate", &command_args)
+        );
 
         let start = std::time::Instant::now();
         let mut child = command.spawn().map_err(bins::CommandError::from)?;

--- a/lib/cli.rs
+++ b/lib/cli.rs
@@ -540,7 +540,7 @@ pub struct Config {
 }
 
 /// Written in place of a sensitive value.
-const REDACTED: &str = "[redacted]";
+pub(crate) const REDACTED: &str = "[redacted]";
 
 /// Written in place of an argument that was neither given nor defaulted.
 const UNSET: &str = "<unset>";


### PR DESCRIPTION
The block producer logs the signet miner invocation at DEBUG with `tracing::debug!("Running signet miner: {:?}", command)` in `lib/block_producer/mine.rs`. The command's `--cli` argument carries the whole `bitcoin-cli` command line, so its `Debug` formatting prints `-rpcpassword=<node RPC password>` straight into the log.

The fix adds `SignetMiner::display_redacted`, which rebuilds the same invocation through a shared `command_with_cli` helper with the password replaced by `[redacted]`, and the DEBUG line now logs that string instead of the raw command. The argv that actually spawns is unchanged and still carries the real credentials, so authentication is unaffected.

A test asserts the logged rendering contains `-rpcpassword=[redacted]` and not the password, that the spawned command still does, and that the two differ only by the redaction — so a newly added argument cannot silently go unredacted.

This only changes what the node writes to its own logs, not anything it validates or produces on the wire.