### PR TITLE
fix: Refuse GetCtip until the validator is synced to tip

### DIFF
--- a/lib/server/validator/grpc.rs
+++ b/lib/server/validator/grpc.rs
@@ -278,6 +278,15 @@ impl ValidatorService for Server {
         } = request.to_owned_message();
         let sidechain_number =
             parse_sidechain_id::<GetCtipRequest>(sidechain_number, "sidechain_number")?;
+        // A validator that is still replaying the chain has a Ctip for every
+        // deposit it has connected so far, which is indistinguishable from the
+        // Ctip at the tip -- and no Ctip at all for a slot whose first deposit
+        // it has not reached yet, which is indistinguishable from an unfunded
+        // slot. Callers build M5 deposits out of this, so refuse rather than
+        // answer for a past height.
+        if !self.validator.is_synced_to_tip() {
+            return Err(ConnectError::unavailable("Validator is not synced"));
+        }
         let ctip = self
             .validator
             .try_get_ctip(sidechain_number)

--- a/lib/validator/cusf_enforcer.rs
+++ b/lib/validator/cusf_enforcer.rs
@@ -380,6 +380,9 @@ impl CusfEnforcer for Validator {
             *header_sync_progress_rx_write = Some(header_sync_progress_rx);
             header_sync_progress_tx
         };
+        // Every sync replays the chain, and a resync may disconnect blocks
+        // first, so the databases stop describing a tip until this one lands.
+        self.set_synced_to_tip(false);
         tracing::debug!(block_hash = %tip, "Syncing to tip");
 
         let handler = BlockHandler::new(&self.dbs, self.network, self.network_params);
@@ -399,7 +402,12 @@ impl CusfEnforcer for Validator {
             result = sync_future => {
                 *self.header_sync_progress_rx.write() = None;
                 match result {
-                    Ok(None) => Ok(()),
+                    Ok(None) => {
+                        // The databases now describe a tip rather than a replay
+                        // of the chain, so consensus reads are answerable.
+                        self.set_synced_to_tip(true);
+                        Ok(())
+                    }
                     Ok(Some(invalid_block)) => Err(SyncToTipError::InvalidBlock {
                         block_hash: invalid_block.block_hash,
                         reason: InvalidBlockReason(invalid_block.reason),

--- a/lib/validator/mod.rs
+++ b/lib/validator/mod.rs
@@ -1,7 +1,10 @@
 use std::{
     collections::{HashMap, HashSet},
     path::{Path, PathBuf},
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
 };
 
 use async_broadcast::{InactiveReceiver, Sender as BroadcastSender, broadcast};
@@ -413,6 +416,9 @@ pub struct Validator {
     events_rx: InactiveReceiver<Event>,
     events_tx: BroadcastSender<Event>,
     header_sync_progress_rx: Arc<parking_lot::RwLock<Option<WatchReceiver<HeaderSyncProgress>>>>,
+    /// Shared by every clone, so a reader can tell a replay of the chain apart
+    /// from the state at a tip. See [`Self::is_synced_to_tip`].
+    synced_to_tip: Arc<AtomicBool>,
     mainchain_client: jsonrpsee::http_client::HttpClient,
     mainchain_rest_client: Option<MainRestClient>,
     mainchain_blocks_dir: Option<PathBuf>,
@@ -449,6 +455,7 @@ impl Validator {
             events_rx: events_rx.deactivate(),
             events_tx,
             header_sync_progress_rx: Arc::new(parking_lot::RwLock::new(None)),
+            synced_to_tip: Arc::new(AtomicBool::new(false)),
             mainchain_client,
             mainchain_rest_client,
             mainchain_blocks_dir,
@@ -481,6 +488,21 @@ impl Validator {
     /// Returns `None` if there is not a header sync in progress
     pub fn subscribe_header_sync_progress(&self) -> Option<WatchReceiver<HeaderSyncProgress>> {
         self.header_sync_progress_rx.read().clone()
+    }
+
+    /// `true` once a sync has run to completion, and `false` again for as long
+    /// as the next one runs. While a sync is in progress the databases hold a
+    /// replay of the chain rather than the state at a tip: a tip is stored for
+    /// every block connected so far, so reads such as [`Self::try_get_ctip`]
+    /// answer for a past height, and cannot be told apart from the same read
+    /// against a synced tip. A resync can also disconnect blocks, so this is
+    /// cleared for every sync, not just the first.
+    pub fn is_synced_to_tip(&self) -> bool {
+        self.synced_to_tip.load(Ordering::Acquire)
+    }
+
+    pub(in crate::validator) fn set_synced_to_tip(&self, synced_to_tip: bool) {
+        self.synced_to_tip.store(synced_to_tip, Ordering::Release);
     }
 
     /// Get (possibly unactivated) sidechains
@@ -869,5 +891,26 @@ mod ctip_sequence_number_tests {
         rwtxn.commit().unwrap();
 
         assert_eq!(validator.get_ctip_sequence_number(sc).unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn ctip_reads_are_not_answerable_while_syncing() {
+        let dir = temp_dir::TempDir::new().unwrap();
+        let validator = dummy_validator(dir.path());
+
+        // A validator that has not synced holds a replay of the chain, so a
+        // `None` Ctip does not mean "unfunded slot".
+        assert!(!validator.is_synced_to_tip());
+
+        // The sync runs against one clone while the gRPC server reads another,
+        // so the signal has to be shared between them.
+        let reader = validator.clone();
+        validator.set_synced_to_tip(true);
+        assert!(reader.is_synced_to_tip());
+
+        // A resync can rewind the stored chain, so it must take the signal back
+        // down rather than leave the first sync's `true` standing.
+        validator.set_synced_to_tip(false);
+        assert!(!reader.is_synced_to_tip());
     }
 }


### PR DESCRIPTION
A validator still replaying the chain holds a Ctip for every deposit it has connected so far — indistinguishable from the Ctip at the tip — and no Ctip at all for a slot whose first deposit it has not reached yet — indistinguishable from an unfunded slot. `GetCtip` in `lib/server/validator/grpc.rs` answered from that mid-sync state, and callers build M5 deposits from the answer, so a deposit could be built against a past height or against an empty funded-slot view.

The fix adds a `synced_to_tip` flag on `Validator` (an `AtomicBool` shared across clones), cleared at the start of every sync — including a resync that may disconnect blocks first — and set once a sync completes. `GetCtip` now returns `unavailable("Validator is not synced")` until then, rather than answering for a past height.

A test, `ctip_reads_are_not_answerable_while_syncing`, checks the flag starts false, is visible across clones, and is taken back down by a resync.

This only changes what the node's own RPC answers and the deposits it builds, not what it validates.