### PR TITLE
fix: Roll back a rejected block's partial diffs in handle_block_batch

### DIFF
--- a/integration_tests/test_invalid_block.rs
+++ b/integration_tests/test_invalid_block.rs
@@ -3,7 +3,7 @@ use std::{str::FromStr as _, time::Duration};
 use bip300301_enforcer_lib::{
     bins::CommandExt as _,
     messages::{M1ProposeSidechain, M2AckSidechain, M4AckBundles, M7BmmAccept, M8BmmRequest},
-    types::{BmmCommitment, SidechainDescription, op_drivechain_script},
+    types::{BmmCommitment, SidechainDescription, SidechainNumber, op_drivechain_script},
 };
 use bitcoin::{
     Amount, Block, BlockHash, CompactTarget, OutPoint, ScriptBuf, Sequence, Transaction, TxIn,
@@ -38,6 +38,23 @@ pub(crate) const DUPLICATE_M1: BadBlockCase = BadBlockCase {
     expected_log_contains: "rejecting block: M1 sidechain proposal for slot",
 };
 
+/// Slot of the M1 in [`M1_THEN_INVALID_M4`]. Nothing else in the tests
+/// proposes or activates it, so a proposal for it can only come from that
+/// block.
+pub(crate) const PHANTOM_PROPOSAL_SLOT: SidechainNumber = SidechainNumber(4);
+
+/// A block whose coinbase carries a novel M1, followed by an M4 that is
+/// rejected. Unlike the `duplicate_*` cases, whose rejection fires while the
+/// coinbase messages are collected, this one is rejected only after the M1
+/// has been applied to the database. Used by the sync-path test
+/// (`test_invalid_block_during_sync`) to check that the applied M1 does not
+/// survive the rejection.
+pub(crate) const M1_THEN_INVALID_M4: BadBlockCase = BadBlockCase {
+    name: "m1_then_invalid_m4",
+    extra_coinbase_outputs: m1_then_invalid_m4_outputs,
+    expected_log_contains: "Invalid votes: expected 1, but found 2",
+};
+
 const CASES: &[BadBlockCase] = &[
     DUPLICATE_M1,
     BadBlockCase {
@@ -68,6 +85,21 @@ fn duplicate_m1_outputs() -> anyhow::Result<Vec<TxOut>> {
     })?;
     let m1_b: ScriptBuf = proposal.try_into()?;
     Ok(vec![zero_value(m1_a), zero_value(m1_b)])
+}
+
+fn m1_then_invalid_m4_outputs() -> anyhow::Result<Vec<TxOut>> {
+    let m1: ScriptBuf = M1ProposeSidechain {
+        sidechain_number: PHANTOM_PROPOSAL_SLOT,
+        description: SidechainDescription(b"phantom proposal".to_vec()),
+    }
+    .try_into()?;
+    // One vote per active sidechain is required, and only DummySidechain is
+    // active, so two votes are rejected as `InvalidVotes`.
+    let m4: ScriptBuf = M4AckBundles::OneByte {
+        upvotes: vec![M4AckBundles::ABSTAIN_ONE_BYTE; 2],
+    }
+    .try_into()?;
+    Ok(vec![zero_value(m1), zero_value(m4)])
 }
 
 fn duplicate_m2_outputs() -> anyhow::Result<Vec<TxOut>> {

--- a/integration_tests/test_invalid_block_during_sync.rs
+++ b/integration_tests/test_invalid_block_during_sync.rs
@@ -9,10 +9,20 @@
 //! cusf-enforcer-mempool crate must invalidate it on the node and re-sync to
 //! the resulting tip -- instead of the sync erroring out and leaving the
 //! enforcer dead behind a chain it can never accept.
+//!
+//! The bad block is also chosen so that the rejection fires only *after*
+//! part of the block has been applied to the database: its coinbase carries
+//! a novel M1 and then an invalid M4. The batch sync commits its transaction
+//! even when a block is rejected, so the M1 must be applied in a nested
+//! transaction that is rolled back with the block, or the rejected block's
+//! sidechain proposal leaks into the validator's state.
 
 use std::str::FromStr as _;
 
-use bip300301_enforcer_lib::bins::CommandExt as _;
+use bip300301_enforcer_lib::{
+    bins::CommandExt as _,
+    proto::{self, mainchain::GetSidechainProposalsRequest},
+};
 use bitcoin::BlockHash;
 use futures::channel::mpsc;
 
@@ -24,7 +34,7 @@ use crate::{
         DummySidechain, Mode, Network, PostSetup, PreSetup, SetupOpts, Sidechain,
         WAIT_POLL_INTERVAL_SUBPROCESS, read_enforcer_log, wait_until_every,
     },
-    test_invalid_block::{DUPLICATE_M1, submit_invalid_block},
+    test_invalid_block::{M1_THEN_INVALID_M4, PHANTOM_PROPOSAL_SLOT, submit_invalid_block},
     util::BinPaths,
 };
 
@@ -62,7 +72,7 @@ pub async fn test_invalid_block_during_sync(bin_paths: BinPaths) -> anyhow::Resu
 
     tracing::info!("killing enforcer, then mining a consensus-invalid block behind its back");
     post_setup.kill_enforcer().await?;
-    let bad_block_hash = submit_invalid_block(&post_setup, &DUPLICATE_M1).await?;
+    let bad_block_hash = submit_invalid_block(&post_setup, &M1_THEN_INVALID_M4).await?;
     // Bury the bad block under a plain block, so that the catch-up sync meets
     // it mid-chain rather than at the tip, and the reorg must also drop a
     // descendant.
@@ -104,12 +114,34 @@ pub async fn test_invalid_block_during_sync(bin_paths: BinPaths) -> anyhow::Resu
         "the bad block must be caught by the batch sync path, not the live path"
     );
     anyhow::ensure!(
-        log.contains("M1 sidechain proposal for slot"),
+        log.contains("Invalid votes: expected 1, but found 2"),
         "the sync-path rejection must carry the BIP300 reason"
     );
     anyhow::ensure!(
         log.contains("invalidating block that the enforcer reported as invalid during sync"),
         "the invalidation must be driven by the cusf-enforcer-mempool crate"
+    );
+
+    // The M1 was applied before the M4 rejected the block. It must have been
+    // rolled back with the block, not committed along with the rest of the
+    // sync batch.
+    let phantom_proposals = post_setup
+        .validator_service_client
+        .get_sidechain_proposals(GetSidechainProposalsRequest::default())
+        .await?
+        .into_owned()
+        .sidechain_proposals
+        .into_iter()
+        .filter(|proposal| {
+            proto::unwrap_u32(proposal.sidechain_number.clone())
+                == Some(u32::from(PHANTOM_PROPOSAL_SLOT.0))
+        })
+        .count();
+    anyhow::ensure!(
+        phantom_proposals == 0,
+        "the rejected block's M1 for slot {} leaked into the validator's state \
+         ({phantom_proposals} proposal(s) listed for it)",
+        PHANTOM_PROPOSAL_SLOT.0
     );
 
     // The enforcer must be fully live after the recovery: a block mined on the

--- a/lib/validator/task/error.rs
+++ b/lib/validator/task/error.rs
@@ -504,6 +504,9 @@ pub(in crate::validator) enum Sync {
     MissingBackgroundChainstate(#[from] super::chainstates::MissingBackgroundChainstate),
     #[error(transparent)]
     #[fatal(true)]
+    NestedWriteTxn(#[from] env::error::NestedWriteTxn),
+    #[error(transparent)]
+    #[fatal(true)]
     ParseBlockFiles(#[from] parse_block_files::ParseBlockFileError),
     #[error(transparent)]
     #[fatal(true)]

--- a/lib/validator/task/mod.rs
+++ b/lib/validator/task/mod.rs
@@ -1866,8 +1866,26 @@ impl BlockHandler<'_> {
             let start_block = Instant::now();
             // We should not call out to `invalidateblock` in case of failures here,
             // as that is handled by the cusf-enforcer-mempool crate.
+            // Connect within a nested txn, committed only once the whole block
+            // is accepted. A rejected block applies coinbase message and tx
+            // diffs before it fails, and those must not survive in the batch
+            // txn, which is committed even when a block is rejected.
             // FIXME: handle disconnects
-            let event = match self.connect_block(rwtxn, block) {
+            let connect_res = {
+                let mut child_rwtxn = dbs.nested_write_txn(rwtxn)?;
+                match self.connect_block(&mut child_rwtxn, block) {
+                    Ok(event) => {
+                        let () = child_rwtxn.commit()?;
+                        Ok(event)
+                    }
+                    Err(err) => {
+                        child_rwtxn.abort();
+                        Err(err)
+                    }
+                }
+            };
+
+            let event = match connect_res {
                 Ok(event) => event,
                 Err(err) => match err.split() {
                     Ok(jfyi) => {
@@ -2927,6 +2945,77 @@ mod tests {
                 .into_diagnostic()?,
             Some(block_a_hash),
             "the valid prefix must be committed before its event is broadcast"
+        );
+        Ok(())
+    }
+
+    /// A rejected block's partial diffs must not survive. `connect_block`
+    /// applies the coinbase message diffs before the tx loop can reject the
+    /// block, so it must run against a nested txn that is aborted, not against
+    /// the batch txn, which is committed even when a block is rejected.
+    #[test]
+    fn rejected_batch_block_leaves_no_partial_diffs() -> Result<()> {
+        let (_dir, dbs) = create_test_dbs()?;
+        let prev_hash = BlockHash::all_zeros();
+
+        let proposal = SidechainProposal {
+            sidechain_number: SidechainNumber(4),
+            description: SidechainDescription(b"partial-diff".to_vec()),
+        };
+        let proposal_id = proposal.compute_id();
+        let m1_script: ScriptBuf = M1ProposeSidechain {
+            sidechain_number: proposal.sidechain_number,
+            description: proposal.description.clone(),
+        }
+        .try_into()
+        .into_diagnostic()?;
+        // The M1 is applied while handling the coinbase; the M8 has no matching
+        // M7, so the block is rejected as non-fatal only afterwards.
+        let block = build_test_block(
+            prev_hash,
+            TestBlockParts {
+                extra_coinbase_outputs: vec![TxOut {
+                    script_pubkey: m1_script,
+                    value: Amount::ZERO,
+                }],
+                extra_txs: vec![build_m8_tx(SidechainNumber(1), [0x42; 32], prev_hash)],
+            },
+        );
+        let block_hash = block.block_hash();
+        {
+            let mut rwtxn = dbs.write_txn().into_diagnostic()?;
+            dbs.block_hashes
+                .put_headers(&mut rwtxn, &[(block.header, 0)])
+                .into_diagnostic()?;
+            rwtxn.commit().into_diagnostic()?;
+        }
+
+        let (event_tx, mut event_rx) = async_broadcast::broadcast(16);
+        let rwtxn = dbs.write_txn().into_diagnostic()?;
+        let invalid_block = test_handler(&dbs)
+            .handle_block_batch_and_commit(rwtxn, &[block], &event_tx)
+            .into_diagnostic()?
+            .expect("the block must be reported as invalid");
+
+        assert_eq!(invalid_block.block_hash, block_hash);
+        assert!(
+            event_rx.try_recv().is_err(),
+            "a rejected block must not emit events"
+        );
+        let rotxn = dbs.read_txn().into_diagnostic()?;
+        assert!(
+            dbs.proposal_id_to_sidechain
+                .try_get(&rotxn, &proposal_id)
+                .into_diagnostic()?
+                .is_none(),
+            "the rejected block's coinbase diffs must be rolled back"
+        );
+        assert!(
+            dbs.current_chain_tip
+                .try_get(&rotxn, &())
+                .into_diagnostic()?
+                .is_none(),
+            "a rejected block must not become the chain tip"
         );
         Ok(())
     }


### PR DESCRIPTION
`handle_block_batch` in `lib/validator/task/mod.rs` connects each block directly against the batch write transaction (`rwtxn`), which is committed even when a block is rejected. `connect_block` applies coinbase-message diffs (for example, an M1 proposal registration) before its transaction loop can reject the block, so a rejected block's partial coinbase and transaction diffs survive in the committed batch transaction and corrupt validator state — a sidechain proposal from a rejected block ends up stored.

The fix runs `connect_block` inside a nested write transaction that is committed only once the whole block is accepted and aborted on any error, so a rejected block leaves nothing behind. A new fatal `NestedWriteTxn` variant surfaces a failure to open that child transaction.

A test, `rejected_batch_block_leaves_no_partial_diffs`, mines a block whose coinbase carries an M1 and whose body carries an unmatched M8, then asserts the block is reported invalid, emits no events, and leaves neither the proposal nor a chain tip in the database.

This does not change which blocks the validator accepts or rejects; it only ensures a rejected block leaves no partial state behind.