### PR TITLE
fix: Retain reorgable M8 bids in the mempool mirror on block connect

### DIFF
--- a/lib/block_producer/error.rs
+++ b/lib/block_producer/error.rs
@@ -488,6 +488,8 @@ pub(in crate::block_producer) enum InitialBlockTemplateInner {
     GenerateSuffixTxs(#[from] GetBundleProposals),
     #[error("Failed to read the ACK-all-proposals setting")]
     GetAckAllProposals(#[source] rusqlite::Error),
+    #[error(transparent)]
+    TryGetHeaderInfos(#[from] crate::validator::TryGetHeaderInfosError),
     #[error("the `coinbasetxn` GBT capability is required")]
     NoCoinbaseTxn,
 }

--- a/lib/block_producer/mod.rs
+++ b/lib/block_producer/mod.rs
@@ -402,6 +402,24 @@ impl BlockProducer {
                         }),
                 );
         }
+        // `Validator::connect_block` deliberately leaves the previous
+        // generation of bids in the mempool, so that a one-block reorg can
+        // still mine them. They bid on `parent_block_hash`'s own parent, so
+        // `handle_m8` rejects them as expired in a block built on top of
+        // `parent_block_hash`: exclude them, or the template is unminable.
+        if let Some(header_infos) = self
+            .validator()
+            .try_get_header_infos(parent_block_hash, 0)?
+        {
+            let expired_bmm_requests = self
+                .validator()
+                .get_seen_bmm_requests_for_parent_block(header_infos.head.prev_block_hash)?;
+            template.exclude_mempool_txs.extend(
+                expired_bmm_requests
+                    .into_values()
+                    .flat_map(|requests| requests.into_values().flatten()),
+            );
+        }
         // Reserve suffix txs
         {
             let fake_ctips = HashMap::from_iter((0..=u8::MAX).map(|slot_number| {

--- a/lib/validator/cusf_enforcer.rs
+++ b/lib/validator/cusf_enforcer.rs
@@ -46,6 +46,8 @@ enum ConnectBlockErrorInner {
     #[error(transparent)]
     ConnectBlock(#[from] Box<<task::error::ConnectBlock as Split>::Fatal>),
     #[error(transparent)]
+    Db(#[from] db::Error),
+    #[error(transparent)]
     DbPut(#[from] db::error::Put),
     #[error(transparent)]
     DbTryGet(#[from] db::error::TryGet),
@@ -236,12 +238,30 @@ fn connect_block_no_commit<'validator>(
         .into_nested()?
     {
         Ok(event) => {
+            // BMM requests bidding on `parent` cannot be mined on top of this
+            // block, but they become valid bids again if this block is
+            // disconnected. Bitcoin Core never dropped them from its own
+            // mempool, and nothing re-announces a tx that never left it, so
+            // evicting them here would lose them for good on a one-block
+            // reorg. Keep them for one more block and evict the generation
+            // before instead, which needs a deeper reorg to become minable.
+            // `BlockProducer::initial_block_template` keeps the retained
+            // generation out of block templates.
+            let grandparent = parent_child_rwtxn
+                .with_child(|child_rotxn| {
+                    validator
+                        .dbs
+                        .block_hashes
+                        .try_get_header_info(child_rotxn, &parent)
+                })?
+                .map(|header_info| header_info.prev_block_hash)
+                .unwrap_or_else(BlockHash::all_zeros);
             let remove_mempool_txs = parent_child_rwtxn
                 .with_child(|child_rotxn| {
                     validator
                         .dbs
                         .block_hashes
-                        .get_seen_bmm_requests_for_parent_block(child_rotxn, parent)
+                        .get_seen_bmm_requests_for_parent_block(child_rotxn, grandparent)
                 })?
                 .into_values()
                 .flat_map(|bmm_requests| bmm_requests.into_values().flatten())


### PR DESCRIPTION
`connect_block_no_commit` in `lib/validator/cusf_enforcer.rs` evicts every seen BMM request (M8) that bid on `parent` from the enforcer's mempool mirror when a block connects. Those bids become valid again if that block is disconnected by a one-block reorg, but Bitcoin Core never dropped them from its own mempool, and nothing re-announces a transaction that never left it. Evicting them from the mirror therefore loses them for good: after a one-block reorg the node can no longer select bids that are, in fact, minable again.

The fix keeps the parent generation of bids for one more block and instead evicts the generation before (bids on `grandparent`), which needs a deeper reorg to become minable. Because bids on `parent_block_hash`'s parent are expired for a block built on top of `parent_block_hash`, `initial_block_template_inner` in `lib/block_producer/mod.rs` now excludes the retained generation from the template so it stays minable.

This only changes the enforcer's own mempool mirror and the block templates it produces; it does not change what the node validates.