### PR TITLE
Build the withdrawal-payout suffix against post-block CTIPs

### DIFF
--- a/lib/block_producer/error.rs
+++ b/lib/block_producer/error.rs
@@ -184,11 +184,7 @@ impl ToStatus for GetBlockTemplate {
 #[derive(Debug, Diagnostic, Error)]
 pub enum SelectBlockTxs {
     #[error(transparent)]
-    GenerateSuffixTxs(#[from] GetBundleProposals),
-    #[error(transparent)]
     GetBlockTemplate(#[from] GetBlockTemplate),
-    #[error(transparent)]
-    GetCtips(#[from] crate::validator::GetCtipsError),
     #[error("failed to decode transaction `{txid}` from the block template")]
     DecodeTemplateTransaction {
         txid: bitcoin::Txid,
@@ -215,9 +211,7 @@ pub enum SelectBlockTxs {
 impl ToStatus for SelectBlockTxs {
     fn builder(&self) -> StatusBuilder<'_> {
         match self {
-            Self::GenerateSuffixTxs(err) => err.builder(),
             Self::GetBlockTemplate(err) => err.builder(),
-            Self::GetCtips(err) => err.builder(),
             Self::DecodeTemplateTransaction { .. }
             | Self::NegativeTemplateTransactionFee { .. } => {
                 StatusBuilder::new(self).code(connectrpc::ErrorCode::Internal)
@@ -250,6 +244,58 @@ impl ToStatus for FinalizeBlock {
             Self::Script(err) => StatusBuilder::new(err),
             Self::SystemTime(err) => StatusBuilder::new(err),
         }
+    }
+}
+
+#[derive(Debug, Error)]
+pub(in crate::block_producer) enum GenerateSuffixTxsInner {
+    #[error(transparent)]
+    FinalizeBlock(#[from] FinalizeBlock),
+    #[error(transparent)]
+    GetBundleProposals(#[from] GetBundleProposals),
+    #[error(transparent)]
+    GetCtipsAfter(#[from] crate::validator::cusf_enforcer::GetCtipsAfterError),
+    /// The validator rejects the template's transactions on top of its own
+    /// tip. Mining them anyway produces a block that Bitcoin Core accepts and
+    /// this enforcer then rejects, so bail out instead.
+    #[error("block template transactions rejected by the validator: {reason}")]
+    TemplateRejected { reason: String },
+}
+
+impl ToStatus for GenerateSuffixTxsInner {
+    fn builder(&self) -> StatusBuilder<'_> {
+        match self {
+            Self::FinalizeBlock(err) => err.builder(),
+            Self::GetBundleProposals(err) => err.builder(),
+            Self::GetCtipsAfter(err) => StatusBuilder::new(err),
+            // Retryable: the offending transaction has to leave the node's
+            // mempool before a block can be produced.
+            Self::TemplateRejected { .. } => {
+                StatusBuilder::new(self).code(connectrpc::ErrorCode::FailedPrecondition)
+            }
+        }
+    }
+}
+
+/// Generating the withdrawal-payout suffix for a block template that does not
+/// come with one.
+#[derive(Debug, Diagnostic, Error)]
+#[error(transparent)]
+#[repr(transparent)]
+pub struct GenerateSuffixTxs(GenerateSuffixTxsInner);
+
+impl<Err> From<Err> for GenerateSuffixTxs
+where
+    GenerateSuffixTxsInner: From<Err>,
+{
+    fn from(err: Err) -> Self {
+        Self(err.into())
+    }
+}
+
+impl ToStatus for GenerateSuffixTxs {
+    fn builder(&self) -> StatusBuilder<'_> {
+        self.0.builder()
     }
 }
 
@@ -434,6 +480,8 @@ pub enum GenerateBlock {
     #[error(transparent)]
     GenerateSignetBlock(#[from] GenerateSignetBlock),
     #[error(transparent)]
+    GenerateSuffixTxs(#[from] GenerateSuffixTxs),
+    #[error(transparent)]
     Mine(#[from] Mine),
     #[error(transparent)]
     PushBytesBuf(#[from] bitcoin::script::PushBytesError),
@@ -451,6 +499,7 @@ impl ToStatus for GenerateBlock {
             Self::CoinbaseBuilder(err) => err.builder(),
             Self::GenerateCoinbaseTxouts(err) => err.builder(),
             Self::GenerateSignetBlock(err) => err.builder(),
+            Self::GenerateSuffixTxs(err) => err.builder(),
             Self::Mine(err) => err.builder(),
             Self::SelectBlockTxs(err) => err.builder(),
             Self::TryGetMainchainTip(err) => err.builder(),

--- a/lib/block_producer/mine.rs
+++ b/lib/block_producer/mine.rs
@@ -98,6 +98,15 @@ fn get_block_value(height: u32, fees: Amount, network: Network) -> Amount {
 
 const WITNESS_RESERVED_VALUE: [u8; 32] = [0; 32];
 
+/// The transactions a block template contributes to a new block, before the
+/// withdrawal-payout suffix is appended.
+struct SelectedBlockTxs {
+    txs: Vec<(Transaction, Amount)>,
+    /// Set when the template does not already end with the withdrawal-payout
+    /// suffix txs, so they have to be generated locally.
+    needs_suffix_txs: bool,
+}
+
 impl BlockProducer {
     async fn fetch_block_template(
         &self,
@@ -121,7 +130,7 @@ impl BlockProducer {
     async fn select_block_txs(
         &self,
         mainchain_tip: BlockHash,
-    ) -> Result<Vec<(Transaction, Amount)>, error::SelectBlockTxs> {
+    ) -> Result<SelectedBlockTxs, error::SelectBlockTxs> {
         let template = self
             .fetch_block_template(vec![
                 "segwit".to_string(),
@@ -145,19 +154,13 @@ impl BlockProducer {
         // respects the enforcer's mempool rules and already ends with the
         // withdrawal-payout suffix txs. A `coinbasevalue` template comes from
         // Bitcoin Core, which knows nothing of drivechain rules, so the suffix
-        // txs must be generated locally.
-        let mut res = match template.coinbase_txn_or_value {
-            CoinbaseTxnOrValue::Txn(_) => Vec::new(),
-            CoinbaseTxnOrValue::ValueSats(_) => {
-                let ctips = self.validator().get_ctips()?;
-                self.generate_suffix_txs(&ctips)
-                    .await?
-                    .into_iter()
-                    .map(|tx| (tx, Amount::ZERO))
-                    .collect()
-            }
-        };
+        // txs must be generated locally, once the template's own txs are known.
+        let needs_suffix_txs = matches!(
+            template.coinbase_txn_or_value,
+            CoinbaseTxnOrValue::ValueSats(_)
+        );
 
+        let mut txs = Vec::with_capacity(template.transactions.len());
         for template_tx in template.transactions {
             let txid = template_tx.txid;
             let transaction: Transaction =
@@ -170,10 +173,35 @@ impl BlockProducer {
                     fee: template_tx.fee,
                 }
             })?;
-            res.push((transaction, fee));
+            txs.push((transaction, fee));
         }
 
-        Ok(res)
+        Ok(SelectedBlockTxs {
+            txs,
+            needs_suffix_txs,
+        })
+    }
+
+    /// The withdrawal-payout suffix for a block that pays out to `coinbase_spk`
+    /// with `coinbase_outputs`, and whose transactions are `transactions`.
+    ///
+    /// An M6 must spend the CTIP as it stands *after* the block's own
+    /// transactions: an M5 deposit in the tx set spends the current CTIP and
+    /// creates its successor, so a suffix built against the pre-block CTIPs
+    /// would spend an outpoint the deposit already spent, and the block would
+    /// be rejected as a double spend.
+    async fn generate_block_suffix_txs(
+        &self,
+        coinbase_spk: ScriptBuf,
+        coinbase_outputs: &[TxOut],
+        transactions: &[Transaction],
+        fees: Amount,
+    ) -> Result<Vec<Transaction>, error::GenerateSuffixTxs> {
+        let block =
+            self.finalize_block(coinbase_spk, coinbase_outputs, transactions.to_vec(), fees)?;
+        let ctips = crate::validator::cusf_enforcer::get_ctips_after(self.validator(), &block)?
+            .map_err(|reason| error::GenerateSuffixTxsInner::TemplateRejected { reason })?;
+        Ok(self.generate_suffix_txs(&ctips).await?)
     }
 
     /// Construct a coinbase tx paying out to `coinbase_spk`.
@@ -668,7 +696,7 @@ impl BlockProducer {
             .extend_coinbase_txouts(ack_all_proposals, mainchain_tip, &mut coinbase_outputs)
             .await?;
         let selected = self.select_block_txs(mainchain_tip).await?;
-        let winners = bmm_auction_winners(selected.iter().filter_map(|(tx, fee)| {
+        let winners = bmm_auction_winners(selected.txs.iter().filter_map(|(tx, fee)| {
             let request = crate::messages::parse_m8_tx(tx)?;
             (request.prev_mainchain_block_hash == mainchain_tip).then(|| {
                 (
@@ -681,8 +709,8 @@ impl BlockProducer {
         }));
         let mut coinbase_builder = CoinbaseBuilder::new(&mut coinbase_outputs)?;
         let mut fees = Amount::ZERO;
-        let mut transactions = Vec::with_capacity(selected.len());
-        for (tx, fee) in selected {
+        let mut transactions = Vec::with_capacity(selected.txs.len());
+        for (tx, fee) in selected.txs {
             if let Some(request) = crate::messages::parse_m8_tx(&tx) {
                 let txid = tx.compute_txid();
                 if winners
@@ -698,6 +726,21 @@ impl BlockProducer {
             transactions.push(tx);
         }
         let () = coinbase_builder.build()?;
+
+        // The suffix goes *after* the template's own txs, and is built against
+        // the treasury state they leave behind, so that an approved bundle
+        // chains onto the CTIP a deposit in the same block created.
+        if selected.needs_suffix_txs {
+            let suffix_txs = self
+                .generate_block_suffix_txs(
+                    coinbase_spk.clone(),
+                    &coinbase_outputs,
+                    &transactions,
+                    fees,
+                )
+                .await?;
+            transactions.extend(suffix_txs);
+        }
 
         tracing::info!(
             coinbase_outputs = %coinbase_outputs.len(),


### PR DESCRIPTION
When a block template comes from Bitcoin Core as a `coinbasevalue` (Core knows nothing of drivechain rules), `select_block_txs` in `lib/block_producer/mine.rs` generated the withdrawal-payout suffix against the CTIPs as they stood *before* the block. If the template's transactions include an M5 deposit, that deposit spends the current CTIP and creates its successor, so an M6 in the suffix spends an outpoint the deposit already spent. The result is a block Bitcoin Core accepts but this enforcer then rejects as a double spend.

The fix defers suffix generation until the template's own transactions are known: `generate_block_suffix_txs` finalizes the block, reads the CTIPs left behind via `get_ctips_after`, and builds the suffix against those. If the validator rejects the template transactions on top of its own tip, a retryable `TemplateRejected` (FailedPrecondition) is returned instead of mining an invalid block. `select_block_txs` now returns `SelectedBlockTxs { txs, needs_suffix_txs }`.

This only changes the blocks the node produces, not what it validates.