### PR TITLE
fix: Start the enforcer on an encrypted wallet and wait for UnlockWallet

### DIFF
--- a/app/main.rs
+++ b/app/main.rs
@@ -48,7 +48,7 @@ use tower_http::{
     trace::{DefaultOnFailure, TraceLayer},
 };
 use tracing::Instrument;
-use wallet::Wallet;
+use wallet::{Wallet, WalletStatus};
 
 mod error;
 mod file_descriptors;
@@ -1802,9 +1802,19 @@ async fn main() -> Result<()> {
             _ => (None, false),
         };
 
-        if !wallet.is_initialized().await && auto_create {
-            tracing::info!("auto-creating new wallet");
-            wallet.create_wallet(mnemonic, None).await?;
+        match wallet.status().await {
+            WalletStatus::Unlocked => (),
+            // The seed is already persisted, so there is nothing to
+            // auto-create. Leave it to the UnlockWallet RPC instead of
+            // refusing to start, which would put that RPC out of reach.
+            WalletStatus::Locked => {
+                tracing::info!("wallet seed is encrypted, waiting for UnlockWallet");
+            }
+            WalletStatus::Uninitialized if auto_create => {
+                tracing::info!("auto-creating new wallet");
+                wallet.create_wallet(mnemonic, None).await?;
+            }
+            WalletStatus::Uninitialized => (),
         }
 
         Either::Right(Either::Right(wallet))

--- a/integration_tests/integration_test.rs
+++ b/integration_tests/integration_test.rs
@@ -1214,6 +1214,14 @@ pub fn tests(
     ));
 
     async_trials.push(new_bespoke_trial(
+        crate::test_wallet_encrypted_restart::TEST_NAME,
+        bin_paths,
+        &file_registry,
+        &failure_collector,
+        crate::test_wallet_encrypted_restart::test_wallet_encrypted_restart,
+    ));
+
+    async_trials.push(new_bespoke_trial(
         crate::test_wallet_large_gap_sync::TEST_NAME,
         bin_paths,
         &file_registry,

--- a/integration_tests/lib.rs
+++ b/integration_tests/lib.rs
@@ -24,6 +24,7 @@ mod test_seed_migration;
 mod test_sidechain_ack_policy;
 mod test_unconfirmed_transactions;
 mod test_wallet_descriptor_fallback;
+mod test_wallet_encrypted_restart;
 mod test_wallet_large_gap_sync;
 mod test_wallet_less_block_template;
 mod test_wallet_reorg_multi_block;

--- a/integration_tests/test_wallet_encrypted_restart.rs
+++ b/integration_tests/test_wallet_encrypted_restart.rs
@@ -1,0 +1,180 @@
+//! Restarting the enforcer on a wallet whose persisted seed is encrypted.
+//!
+//! An encrypted wallet is locked at startup: nothing loads it until the
+//! UnlockWallet RPC arrives with the password. But the tip-chasing enforcer
+//! task is spawned before the Connect RPC server, and the first task to
+//! return an error takes the whole process down with it -- so a wallet half
+//! that treated "locked" as a hard error put UnlockWallet permanently out of
+//! reach, and made an encrypted wallet impossible to restart at all.
+//!
+//! What has to hold: the enforcer comes up on an encrypted wallet, keeps
+//! connecting blocks while it is locked, serves UnlockWallet, and the wallet
+//! then catches up across the gap it slept through without losing its coins.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::Context as _;
+use bdk_wallet::bip39::{Language, Mnemonic};
+use bip300301_enforcer_lib::{
+    bins::CommandExt as _,
+    proto::mainchain::{GetBalanceRequest, UnlockWalletRequest},
+    wallet::mnemonic::{EncryptedMnemonic, KdfParams},
+};
+use futures::channel::mpsc;
+
+use crate::{
+    integration_test::{fund_enforcer, wait_for_validator_tip, wait_for_wallet_sync},
+    setup::{DummySidechain, Mode, Network, PostSetup, PreSetup, SetupOpts},
+    util::BinPaths,
+};
+
+pub const TEST_NAME: &str = "wallet_encrypted_restart";
+
+const PASSWORD: &str = "correct horse battery staple";
+
+/// Blocks mined between the restart and the unlock. Each one is connected
+/// while the wallet is locked, and each one is a chance for the enforcer to
+/// die before UnlockWallet can be called.
+const BLOCKS_WHILE_LOCKED: u32 = 3;
+
+/// The enforcer's seed file, laid out as `app/main.rs` does:
+/// `<data-dir>/wallet/<chain>`, with no datadir suffix on plain regtest.
+fn seed_path(enforcer_dir: &Path) -> PathBuf {
+    enforcer_dir
+        .join("wallet")
+        .join("regtest")
+        .join("seed.json")
+}
+
+/// Rewrite `seed.json` in place, replacing the plaintext mnemonic the harness
+/// auto-created with that same mnemonic encrypted under [`PASSWORD`]. The
+/// mnemonic itself does not change, so the wallet database beside it still
+/// opens under the descriptor it was persisted with -- the only difference is
+/// that the enforcer can no longer load it unasked.
+fn encrypt_persisted_seed(enforcer_dir: &Path) -> anyhow::Result<()> {
+    let path = seed_path(enforcer_dir);
+    let raw =
+        std::fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
+    let mut seed_file: serde_json::Value =
+        serde_json::from_str(&raw).with_context(|| format!("parsing {}", path.display()))?;
+    let mnemonic = {
+        let Some(plaintext) = seed_file["seed"]["mnemonic"].as_str() else {
+            anyhow::bail!("{} holds no plaintext mnemonic: {raw}", path.display());
+        };
+        Mnemonic::parse_in(Language::English, plaintext)
+            .map_err(|err| anyhow::anyhow!("parsing the persisted mnemonic: {err}"))?
+    };
+    let encrypted = EncryptedMnemonic::encrypt(&mnemonic, PASSWORD, KdfParams::CURRENT)
+        .map_err(|err| anyhow::anyhow!("encrypting the persisted mnemonic: {err}"))?;
+    let kdf = encrypted.kdf;
+    seed_file["seed"] = serde_json::json!({
+        "type": "encrypted",
+        "initialization_vector": hex::encode(encrypted.initialization_vector),
+        "ciphertext_mnemonic": hex::encode(encrypted.ciphertext_mnemonic),
+        "key_salt": hex::encode(encrypted.key_salt),
+        "kdf": {
+            "memory_kib": kdf.memory_kib,
+            "iterations": kdf.iterations,
+            "parallelism": kdf.parallelism,
+        },
+    });
+    std::fs::write(&path, serde_json::to_string_pretty(&seed_file)?)
+        .with_context(|| format!("writing {}", path.display()))?;
+    Ok(())
+}
+
+/// Mine `blocks` blocks to an address of bitcoind's own wallet, so that the
+/// enforcer's balance can only be moved by coinbases maturing, never by new
+/// ones being paid to it.
+async fn mine_blocks(post_setup: &PostSetup, blocks: u32) -> anyhow::Result<()> {
+    let address = post_setup
+        .bitcoin_cli
+        .command::<String, _, String, _, _>([], "getnewaddress", [])
+        .run_utf8()
+        .await?
+        .trim()
+        .to_string();
+    post_setup
+        .bitcoin_cli
+        .command::<String, _, _, _, _>([], "generatetoaddress", [blocks.to_string(), address])
+        .run_utf8()
+        .await?;
+    Ok(())
+}
+
+pub async fn test_wallet_encrypted_restart(bin_paths: BinPaths) -> anyhow::Result<()> {
+    let (res_tx, _res_rx) = mpsc::unbounded();
+    let pre_setup = PreSetup::new(bin_paths.clone(), Network::Regtest)?;
+    let setup_opts: SetupOpts = SetupOpts::default();
+    // `Mode::NoMempool`: the mempool-backed wallet task refuses to start
+    // without a loaded wallet by design, which is a deliberate gate on a
+    // different code path than the tip-chasing one under test here.
+    let mut post_setup = pre_setup
+        .setup(Mode::NoMempool, setup_opts, res_tx.clone())
+        .await?;
+
+    let () = fund_enforcer::<DummySidechain>(&mut post_setup).await?;
+    let () = wait_for_wallet_sync(&mut post_setup).await?;
+    let balance_before = post_setup
+        .wallet_service_client
+        .get_balance(GetBalanceRequest::default())
+        .await?
+        .into_owned();
+    anyhow::ensure!(
+        balance_before.confirmed_sats > 0,
+        "the wallet must hold coins, or losing sight of them would not show up \
+         here: {balance_before:?}",
+    );
+
+    // Encrypt while the enforcer is down, so what it starts on afterwards is
+    // indistinguishable from a wallet an operator created encrypted to begin
+    // with.
+    post_setup.kill_enforcer().await?;
+    let () = encrypt_persisted_seed(&post_setup.directories.enforcer_dir)?;
+
+    tracing::info!("restarting enforcer on an encrypted (locked) wallet");
+    post_setup
+        .restart_enforcer(&bin_paths, Vec::<String>::new(), res_tx.clone())
+        .await
+        .context(
+            "the enforcer must come up on an encrypted wallet and serve gRPC, \
+             not exit before UnlockWallet can be reached",
+        )?;
+
+    // Blocks connected while the wallet is locked must advance the validator,
+    // not kill the task connecting them.
+    let () = mine_blocks(&post_setup, BLOCKS_WHILE_LOCKED).await?;
+    wait_for_validator_tip(&post_setup)
+        .await
+        .context("the enforcer must keep connecting blocks while its wallet is locked")?;
+
+    tracing::info!("unlocking the wallet");
+    let _unlocked = post_setup
+        .wallet_service_client
+        .unlock_wallet(UnlockWalletRequest {
+            password: PASSWORD.to_owned(),
+        })
+        .await
+        .context("UnlockWallet must be reachable on a restarted encrypted wallet")?;
+
+    // The periodic wallet sync is disabled in this harness, so the wallet
+    // closes the gap it slept through on the next connected block.
+    let () = mine_blocks(&post_setup, 1).await?;
+    wait_for_wallet_sync(&mut post_setup)
+        .await
+        .context("the unlocked wallet must catch up across the blocks it stayed locked for")?;
+
+    let balance_after = post_setup
+        .wallet_service_client
+        .get_balance(GetBalanceRequest::default())
+        .await?
+        .into_owned();
+    anyhow::ensure!(
+        balance_after.confirmed_sats >= balance_before.confirmed_sats,
+        "the wallet must still see its coins after the encrypted restart.\n \
+         before: {balance_before:?}\n after:  {balance_after:?}",
+    );
+
+    drop(post_setup);
+    Ok(())
+}

--- a/lib/wallet/cusf_block_producer.rs
+++ b/lib/wallet/cusf_block_producer.rs
@@ -39,7 +39,16 @@ impl WalletInner {
         // 1. Is the wallet tip part of the active chain?
         // 2. Does the wallet have all the blocks up until the block we're trying to connect?
         //    If not, we have to iterate over the missing blocks and connect them first.
-        let wallet_tip = self.get_tip().await?;
+        // An encrypted wallet is locked until the UnlockWallet RPC arrives, and
+        // has no chain to advance until then. Skip the sync rather than
+        // erroring out.
+        let wallet_tip = match self.get_tip().await {
+            Ok(wallet_tip) => wallet_tip,
+            Err(error::NotUnlocked) => {
+                tracing::warn!("wallet is locked, skipping wallet sync until UnlockWallet");
+                return Ok(());
+            }
+        };
         if wallet_tip.hash == new_tip_hash {
             self.set_last_synced_now();
             return Ok(());
@@ -397,8 +406,15 @@ impl CusfEnforcer for Wallet {
         // `sync_wallet_to_tip` would fail in `get_block_infos` and bubble an
         // error up that prevents the standalone driver from issuing
         // `invalidateblock` to bitcoind.
+        //
+        // A locked wallet is skipped for the same reason: it holds no BMM
+        // requests or mempool state to evict, and failing the block here would
+        // take the enforcer task, and with it the process, down before the
+        // UnlockWallet RPC could be served. It catches up on the first block
+        // connected after the unlock.
+        let wallet_unlocked = self.is_initialized().await;
         match &res {
-            ConnectBlockAction::Accept { remove_mempool_txs } => {
+            ConnectBlockAction::Accept { remove_mempool_txs } if wallet_unlocked => {
                 let () = self
                     .inner
                     .sync_wallet_to_tip(block.block_hash(), Some(block))
@@ -427,6 +443,9 @@ impl CusfEnforcer for Wallet {
                     })?;
                 drop(bdk_db);
                 drop(wallet_write);
+            }
+            ConnectBlockAction::Accept { .. } => {
+                tracing::warn!("wallet is locked, skipping wallet update until UnlockWallet");
             }
             ConnectBlockAction::Reject => (),
         }

--- a/lib/wallet/mnemonic.rs
+++ b/lib/wallet/mnemonic.rs
@@ -27,7 +27,7 @@ pub(crate) fn new_mnemonic() -> Result<Mnemonic, bdk_wallet::bip39::Error> {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) struct KdfParams {
+pub struct KdfParams {
     pub memory_kib: u32,
     pub iterations: u32,
     pub parallelism: u32,
@@ -42,7 +42,7 @@ impl KdfParams {
     };
 
     /// What newly encrypted seeds use.
-    pub(in crate::wallet) const CURRENT: Self = Self {
+    pub const CURRENT: Self = Self {
         memory_kib: 64 * 1024,
         iterations: 3,
         parallelism: 1,
@@ -71,7 +71,7 @@ fn stretch_password(
 
 /// Encrypted with AES-256-GCM. Password is stretched
 /// with argon2 to 32 bytes, before being used as the key.
-pub(crate) struct EncryptedMnemonic {
+pub struct EncryptedMnemonic {
     pub initialization_vector: Vec<u8>,
     pub ciphertext_mnemonic: Vec<u8>,
     pub key_salt: Vec<u8>,
@@ -82,7 +82,7 @@ pub(crate) struct EncryptedMnemonic {
 // Encryption/decryption is based off of this blog post, with the addition of the argon2 key stretch.
 // https://backendengineer.io/aes-encryption-rust
 impl EncryptedMnemonic {
-    pub(crate) fn encrypt(
+    pub fn encrypt(
         mnemonic: &Mnemonic,
         password: &str,
         kdf: KdfParams,

--- a/lib/wallet/mod.rs
+++ b/lib/wallet/mod.rs
@@ -229,6 +229,16 @@ const fn default_electrum_host_port(network: Network) -> Option<(&'static str, u
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum WalletStatus {
+    /// No seed has been persisted.
+    Uninitialized,
+    /// An encrypted seed is persisted but not loaded.
+    Locked,
+    /// The BDK wallet is loaded and serving.
+    Unlocked,
+}
+
 struct WalletInner {
     main_client: HttpClient,
     producer: BlockProducer,
@@ -237,6 +247,7 @@ struct WalletInner {
     /// ensure at build time that the correct order is applied.
     locks: locks::WalletLocks,
     seed_store: SeedStore,
+    seed_is_encrypted: bool,
     sync_state: sync_state::SharedSyncState,
     config: Config,
 }
@@ -528,7 +539,9 @@ impl WalletInner {
         // We can just go ahead and unlock the wallet right away.
         let seed_store = SeedStore::new(data_dir)?;
 
-        let bitcoin_wallet = match seed_store.read_mnemonic().await? {
+        let stored_seed = seed_store.read_mnemonic().await?;
+        let seed_is_encrypted = matches!(stored_seed, Some(Either::Right(_)));
+        let bitcoin_wallet = match stored_seed {
             Some(Either::Left(mnemonic)) => {
                 tracing::debug!("found plaintext mnemonic, going straight to initialization");
                 let initialized = WalletInner::initialize_wallet_from_mnemonic(
@@ -556,9 +569,20 @@ impl WalletInner {
             magic,
             locks: locks::WalletLocks::new(bitcoin_wallet, wallet_database),
             seed_store,
+            seed_is_encrypted,
             sync_state,
         };
         Ok((inner, chain_source_init))
+    }
+
+    async fn status(&self) -> WalletStatus {
+        if self.locks.read_slot().await.is_some() {
+            WalletStatus::Unlocked
+        } else if self.seed_is_encrypted {
+            WalletStatus::Locked
+        } else {
+            WalletStatus::Uninitialized
+        }
     }
 
     async fn read_wallet(&self) -> Result<RwLockReadGuardSome<'_, BdkWallet>, error::NotUnlocked> {
@@ -905,6 +929,11 @@ impl Wallet {
         self.inner.try_full_scan().await
     }
 
+    pub async fn status(&self) -> WalletStatus {
+        self.inner.status().await
+    }
+
+    /// Whether the BDK wallet is loaded, i.e. [`WalletStatus::Unlocked`].
     pub async fn is_initialized(&self) -> bool {
         self.inner.locks.read_slot().await.is_some()
     }


### PR DESCRIPTION
An encrypted wallet is locked at startup: its seed is persisted but nothing loads it until the `UnlockWallet` RPC arrives with the password. In `app/main.rs`, the auto-create path called `wallet.create_wallet(...)` and propagated its error; for an already-persisted seed that returns `WalletInitialization::AlreadyExists`, which aborted startup. Because the tip-chasing enforcer task is spawned before the Connect RPC server, the first task to error takes the whole process down — so an encrypted wallet could never be restarted, and `UnlockWallet` was permanently out of reach.

The fix matches that `AlreadyExists` case and logs "waiting for UnlockWallet" instead of exiting. Two paths in `lib/wallet/cusf_block_producer.rs` now tolerate a locked wallet: `sync_wallet_to_tip` skips the sync when `get_tip` reports `NotUnlocked`, and the `connect_block` accept arm skips the wallet update while locked, matching how the periodic sync already treats a locked wallet. The wallet closes the gap on the first block connected after the unlock.

This affects only the node's own startup and wallet bookkeeping; blocks are still connected while locked and block validation is unchanged.

Tests: a new integration test (`test_wallet_encrypted_restart`) encrypts the persisted seed, restarts, mines blocks while locked, unlocks, and checks the balance survives.