### PR TITLE
fix: Snapshot BMM requests before submitblock, not after connection

### DIFF
--- a/integration_tests/integration_test.rs
+++ b/integration_tests/integration_test.rs
@@ -1250,5 +1250,17 @@ pub fn tests(
         crate::test_wallet_reorg_multi_block::test_wallet_reorg_multi_block,
     ));
 
+    async_trials.push(new_trial_with_setup(
+        crate::test_bmm_request_reorg::TEST_NAME.to_string(),
+        TestSetupComponents {
+            bin_paths: bin_paths.clone(),
+            network: Network::Regtest,
+            mode: Mode::Mempool,
+            file_registry: file_registry.clone(),
+            failure_collector: failure_collector.clone(),
+        },
+        crate::test_bmm_request_reorg::test_bmm_request_reorg,
+    ));
+
     async_trials
 }

--- a/integration_tests/lib.rs
+++ b/integration_tests/lib.rs
@@ -7,6 +7,7 @@ pub mod signet_chain_params;
 mod test_activation_height;
 mod test_blinded_m6_roundtrip;
 mod test_bmm_bid_auction;
+mod test_bmm_request_reorg;
 mod test_consecutive_deposits;
 mod test_file_based_block_parser;
 mod test_gbt_during_initial_sync;

--- a/integration_tests/test_bmm_request_reorg.rs
+++ b/integration_tests/test_bmm_request_reorg.rs
@@ -1,0 +1,200 @@
+//! Regression test for the BMM requests a produced block consumes surviving a
+//! reorg of that block.
+//!
+//! Producing a block deletes the `bmm_requests` rows queued against its parent,
+//! first snapshotting them into `bmm_requests_undo` keyed by the produced block
+//! hash, so a disconnect can put them back instead of making the operator
+//! re-queue them against the new tip. That snapshot is taken just before
+//! `submitblock` (`lib/block_producer/mine.rs`), because from the moment
+//! Bitcoin Core has the block the validator may connect *and* disconnect it at
+//! any time: a disconnect processed against an empty undo log restores nothing,
+//! and a snapshot landing after it would then move the still-live rows under a
+//! block hash that is never disconnected again, stranding them there.
+//!
+//! This drives that whole path end to end -- the producer's own `mine()`, a
+//! real `submitblock`, and a real `invalidateblock` -- rather than the
+//! interleaving itself, which is a window of microseconds no external driver
+//! can force. The ordering that closes the window is asserted directly against
+//! `snapshot_and_delete_bmm_requests`/`restore_bmm_requests_from_undo` in
+//! `lib/block_producer/db.rs`.
+
+use std::time::Duration;
+
+use bip300301_enforcer_lib::{
+    bins::CommandExt as _,
+    proto::{
+        self,
+        mainchain::{
+            BlockHeaderInfo, GenerateToAddressRequest, GenerateToAddressResponse,
+            GetChainTipRequest,
+        },
+    },
+};
+use bitcoin::{BlockHash, hashes::Hash as _};
+
+use crate::{
+    block_verdict::wait_for_enforcer_tip_hash,
+    setup::{PostSetup, wait_until},
+};
+
+pub const TEST_NAME: &str = "bmm_request_reorg";
+
+/// Sidechain slot for the queued request. Nothing here validates it: the undo
+/// log is keyed by previous block hash alone, so no sidechain has to be
+/// proposed or active for a request to be queued, consumed, and restored.
+const SIDECHAIN_NUMBER: u8 = 5;
+
+/// Commitment for the queued request, distinctive enough to identify the
+/// restored row as the one that was queued.
+const SIDE_BLOCK_HASH: [u8; 32] = [0xab; 32];
+
+/// The block producer's policy DB. `app/main.rs` puts it at
+/// `<data-dir>/wallet/<chain>/db.sqlite`, with no datadir suffix on plain
+/// regtest.
+fn producer_db(post_setup: &PostSetup) -> anyhow::Result<rusqlite::Connection> {
+    let path = post_setup
+        .directories
+        .enforcer_dir
+        .join("wallet")
+        .join("regtest")
+        .join("db.sqlite");
+    let connection = rusqlite::Connection::open(path)?;
+    // The running enforcer holds the same file open and writes to it as blocks
+    // connect, so wait for its lock rather than failing on `database is locked`.
+    connection.busy_timeout(Duration::from_secs(10))?;
+    Ok(connection)
+}
+
+/// Queue a BMM request against `prev_blockhash`, exactly as
+/// `Db::insert_new_bmm_request` would.
+///
+/// Written into the DB directly because no RPC reaches this table any more:
+/// `CreateBmmCriticalDataTransaction` broadcasts an M8 bid, and the coinbase's
+/// M7 accepts are selected from the validator's own view of seen bids. The
+/// rows are still consumed and restored by block production, which is what
+/// this test covers. Staging `db.sqlite` this way is what `test_seed_migration`
+/// does too.
+fn queue_bmm_request(post_setup: &PostSetup, prev_blockhash: BlockHash) -> anyhow::Result<()> {
+    producer_db(post_setup)?.execute(
+        "INSERT INTO bmm_requests (sidechain_number, prev_block_hash, side_block_hash) \
+         VALUES (?1, ?2, ?3);",
+        (
+            SIDECHAIN_NUMBER,
+            prev_blockhash.to_byte_array(),
+            SIDE_BLOCK_HASH,
+        ),
+    )?;
+    Ok(())
+}
+
+/// The `prev_block_hash` of every live (i.e. not snapshotted away) request
+/// carrying [`SIDE_BLOCK_HASH`].
+fn live_request_prevs(post_setup: &PostSetup) -> anyhow::Result<Vec<BlockHash>> {
+    let connection = producer_db(post_setup)?;
+    let mut statement =
+        connection.prepare("SELECT prev_block_hash FROM bmm_requests WHERE side_block_hash = ?")?;
+    let prevs = statement
+        .query_map([&SIDE_BLOCK_HASH], |row| {
+            row.get::<_, [u8; 32]>(0).map(BlockHash::from_byte_array)
+        })?
+        .collect::<Result<_, _>>()?;
+    Ok(prevs)
+}
+
+/// The produced block hashes that requests carrying [`SIDE_BLOCK_HASH`] are
+/// currently snapshotted under.
+fn undo_block_hashes(post_setup: &PostSetup) -> anyhow::Result<Vec<BlockHash>> {
+    let connection = producer_db(post_setup)?;
+    let mut statement =
+        connection.prepare("SELECT block_hash FROM bmm_requests_undo WHERE side_block_hash = ?")?;
+    let block_hashes = statement
+        .query_map([&SIDE_BLOCK_HASH], |row| {
+            row.get::<_, [u8; 32]>(0).map(BlockHash::from_byte_array)
+        })?
+        .collect::<Result<_, _>>()?;
+    Ok(block_hashes)
+}
+
+pub async fn test_bmm_request_reorg(post_setup: PostSetup) -> anyhow::Result<()> {
+    // The tip the producer will build on. Read from the validator rather than
+    // bitcoind: `generate_block` looks the requests up against its own
+    // validated tip.
+    let tip_before = post_setup
+        .validator_service_client
+        .get_chain_tip(GetChainTipRequest::default())
+        .await?
+        .into_owned()
+        .block_header_info
+        .into_option()
+        .ok_or_else(|| anyhow::anyhow!("get_chain_tip: missing block_header_info"))?
+        .block_hash
+        .into_option()
+        .ok_or_else(|| anyhow::anyhow!("get_chain_tip: missing block_hash"))?
+        .decode::<BlockHeaderInfo, BlockHash>("block_hash")?;
+
+    let () = queue_bmm_request(&post_setup, tip_before)?;
+    anyhow::ensure!(
+        live_request_prevs(&post_setup)? == [tip_before],
+        "the queued BMM request must be live before the block that consumes it is produced"
+    );
+
+    // Produce a block through the enforcer's own block producer, which is what
+    // consumes the request.
+    let response: GenerateToAddressResponse = post_setup
+        .mining_service_client
+        .generate_to_address(GenerateToAddressRequest {
+            blocks: proto::wrap_u32(1),
+            address: post_setup.mining_address.to_string(),
+        })
+        .await?
+        .into_owned();
+    let block_hashes = response
+        .block_hashes
+        .into_iter()
+        .map(|hash| hash.decode::<GenerateToAddressResponse, BlockHash>("block_hashes"))
+        .collect::<Result<Vec<_>, _>>()?;
+    let &[produced_block_hash] = block_hashes.as_slice() else {
+        anyhow::bail!(
+            "expected exactly one block hash from GenerateToAddress, got {}",
+            block_hashes.len()
+        )
+    };
+    tracing::info!(%produced_block_hash, "produced a block consuming the queued BMM request");
+
+    // The request has been consumed into the undo log, keyed by the block that
+    // consumed it -- the snapshot a disconnect of that block restores from.
+    anyhow::ensure!(
+        live_request_prevs(&post_setup)?.is_empty(),
+        "producing a block must consume the BMM requests queued against its parent"
+    );
+    anyhow::ensure!(
+        undo_block_hashes(&post_setup)? == [produced_block_hash],
+        "the consumed BMM request must be snapshotted under the block that consumed it"
+    );
+
+    // Reorg the produced block back out.
+    tracing::info!(%produced_block_hash, "invalidating the block that consumed the BMM request");
+    post_setup
+        .bitcoin_cli
+        .command::<String, _, _, _, _>([], "invalidateblock", [produced_block_hash.to_string()])
+        .run_utf8()
+        .await?;
+    let () = wait_for_enforcer_tip_hash(&post_setup, tip_before).await?;
+
+    // The request is queued again against the block it was queued against
+    // originally -- which is the tip once more -- so the next block produced
+    // can carry it. The restore runs just after the validator's own disconnect,
+    // so it is not necessarily done the moment the tip has rolled back.
+    let () = wait_until(
+        "the disconnected block's BMM request to be restored",
+        || async { Ok(live_request_prevs(&post_setup)? == [tip_before]) },
+    )
+    .await?;
+    anyhow::ensure!(
+        undo_block_hashes(&post_setup)?.is_empty(),
+        "restoring a BMM request must consume its undo snapshot, not leave it behind"
+    );
+
+    drop(post_setup);
+    Ok(())
+}

--- a/lib/block_producer/db.rs
+++ b/lib/block_producer/db.rs
@@ -659,6 +659,37 @@ mod bmm_requests_undo_tests {
         assert_eq!(restored_side, side.as_byte_array().to_vec());
     }
 
+    /// The undo snapshot has to exist before the produced block can be observed
+    /// as connected, which is why the producer takes it before `submitblock`
+    /// rather than after the block has connected: a disconnect processed in
+    /// between finds an empty undo log, and the snapshot landing afterwards
+    /// then consumes a still-live request for a block that is never
+    /// disconnected again.
+    #[test]
+    fn snapshot_before_disconnect_keeps_bmm_request_recoverable() {
+        let prev = block_hash(1);
+        let mined = block_hash(2);
+
+        // The order the producer uses: the disconnect that can follow
+        // submission at any moment finds the undo rows, and restores from them.
+        let mut connection = open_db();
+        insert_request(&connection, 5, &prev);
+        snapshot_and_delete_bmm_requests(&mut connection, &prev, &mined).unwrap();
+        let restored = restore_bmm_requests_from_undo(&mut connection, &mined).unwrap();
+        assert_eq!(restored, 1);
+        assert_eq!(row_count(&connection, "bmm_requests"), 1);
+
+        // Snapshotting only after the disconnect has been processed strands the
+        // request instead: nothing is restored, and the late snapshot then
+        // consumes a row that is still live.
+        let mut connection = open_db();
+        insert_request(&connection, 5, &prev);
+        let restored = restore_bmm_requests_from_undo(&mut connection, &mined).unwrap();
+        assert_eq!(restored, 0);
+        snapshot_and_delete_bmm_requests(&mut connection, &prev, &mined).unwrap();
+        assert_eq!(row_count(&connection, "bmm_requests"), 0);
+    }
+
     /// Blocks that stay on the main chain (never disconnected) must not
     /// accumulate undo rows without bound: only the most recent
     /// `BMM_REQUESTS_UNDO_RETAINED_BLOCKS` producing blocks are retained, and the

--- a/lib/block_producer/mine.rs
+++ b/lib/block_producer/mine.rs
@@ -53,10 +53,10 @@ pub(in crate::block_producer) fn bmm_auction_winners(
     winners
 }
 
-/// BMM request cleanup happens after the block has been submitted and observed
-/// by the validator. Keep the mined block as the operation's result even if the
-/// best-effort cleanup fails, so callers are not invited to retry an operation
-/// that has already happened.
+/// BMM request cleanup happens before the block is submitted, so that its undo
+/// snapshot exists before the validator can observe the block. Keep the mined
+/// block as the operation's result even if that best-effort cleanup failed, so
+/// callers are not invited to retry an operation that has already happened.
 fn finish_bmm_request_cleanup(
     block_hash: BlockHash,
     result: Result<(), rusqlite::Error>,
@@ -272,9 +272,11 @@ impl BlockProducer {
         Ok(block)
     }
 
-    /// Mine a block
+    /// Mine a block on top of `prev_blockhash`, consuming the BMM requests
+    /// queued against it.
     async fn mine(
         &self,
+        prev_blockhash: &BlockHash,
         coinbase_spk: ScriptBuf,
         coinbase_outputs: &[TxOut],
         transactions: Vec<Transaction>,
@@ -293,6 +295,39 @@ impl BlockProducer {
         block
             .consensus_encode(&mut block_bytes)
             .map_err(error::EncodeBlock)?;
+        let block_hash = block.header.block_hash();
+        // Consume the BMM requests *before* handing the block to Bitcoin Core.
+        // From that point on the validator may connect and disconnect the block
+        // at any time, and a disconnect restores the requests from the undo
+        // snapshot keyed by `block_hash`. Snapshotting afterwards would let that
+        // restore find an empty undo log, and the late snapshot would then move
+        // the still-live requests under a block hash that is never disconnected
+        // again, stranding them there.
+        let cleanup_result = self
+            .db()
+            .delete_bmm_requests(prev_blockhash, &block_hash)
+            .await;
+        if let Err(err) = self.submit_mined_block(block_bytes).await {
+            // A block Bitcoin Core never took is never connected, and so never
+            // disconnected either: nothing else will ever put the requests
+            // consumed above back.
+            if let Err(restore_err) = self.db().restore_bmm_requests(&block_hash).await {
+                tracing::error!(
+                    %block_hash,
+                    "failed to restore BMM requests for unsubmitted block: {:#}",
+                    ErrorChain::new(&restore_err),
+                );
+            }
+            return Err(err);
+        }
+        tracing::info!(%block_hash, %transaction_count, "Submitted block");
+        let () = self.await_block_connection(block_hash).await?;
+        Ok(finish_bmm_request_cleanup(block_hash, cleanup_result))
+    }
+
+    /// Hand an encoded block to Bitcoin Core, turning a rejection reason into
+    /// an error.
+    async fn submit_mined_block(&self, block_bytes: Vec<u8>) -> Result<(), error::Mine> {
         if let Some(reason) = self
             .main_client()
             .submit_block(hex::encode(block_bytes))
@@ -304,10 +339,7 @@ impl BlockProducer {
         {
             return Err(error::Mine::BlockRejected { reason });
         }
-        let block_hash = block.header.block_hash();
-        tracing::info!(%block_hash, %transaction_count, "Submitted block");
-        let () = self.await_block_connection(block_hash).await?;
-        Ok(block_hash)
+        Ok(())
     }
 
     /// Wait until the validator has processed `block_hash`. A successful
@@ -707,13 +739,15 @@ impl BlockProducer {
         );
 
         let block_hash = self
-            .mine(coinbase_spk, &coinbase_outputs, transactions, fees)
+            .mine(
+                &mainchain_tip,
+                coinbase_spk,
+                &coinbase_outputs,
+                transactions,
+                fees,
+            )
             .await?;
-        let cleanup_result = self
-            .db()
-            .delete_bmm_requests(&mainchain_tip, &block_hash)
-            .await;
-        Ok(finish_bmm_request_cleanup(block_hash, cleanup_result))
+        Ok(block_hash)
     }
 }
 


### PR DESCRIPTION
Producing a block deletes the `bmm_requests` rows queued against its parent, first snapshotting them into `bmm_requests_undo` keyed by the produced block hash so a disconnect can restore them. That cleanup previously ran after `submitblock` and after the block was observed as connected. But from the moment Bitcoin Core has the block, the validator may connect and disconnect it at any time: a disconnect processed before the snapshot restores nothing, and the snapshot then lands afterward, moving the still-live rows under a block hash that is never disconnected again — stranding the request.

The fix moves the snapshot-and-delete into `BlockProducer::mine` (`lib/block_producer/mine.rs`) so it runs before the block is handed to Core, and restores the rows if `submitblock` itself fails (a block Core never took is never disconnected). `mine` now takes `prev_blockhash`, and submission is split into a `submit_mined_block` helper.

This affects only the producer's own BMM-request bookkeeping, not block validation.

Tests: a unit test asserts the snapshot-before-disconnect ordering keeps the request recoverable, and a new integration test drives queue → produce → `invalidateblock` and checks the request is restored.