### PR TITLE
fix: Pass node RPC credentials to bitcoin-cli via a cookie file, not argv

### DIFF
--- a/.github/workflows/check_lint_build_release.yaml
+++ b/.github/workflows/check_lint_build_release.yaml
@@ -452,9 +452,9 @@ jobs:
             "$INTEGRATION_TEST_RUNNER" ${SKIP_ARGS[@]+"${SKIP_ARGS[@]}"}
           fi
 
-      # Did the run end up with a chain worth caching? A run that never needed
-      # one (the stock matrix skips the only signet test) leaves nothing to
-      # save, and `cache/save` would warn about the missing path.
+      # Did the run end up with a chain worth caching? A run that skipped every
+      # signet test leaves nothing to save, and `cache/save` would warn about
+      # the missing path.
       #
       # This is a shell test rather than `hashFiles` in the save step's `if`,
       # because `hashFiles` only sees paths inside GITHUB_WORKSPACE — the chain

--- a/integration_tests/integration_test.rs
+++ b/integration_tests/integration_test.rs
@@ -1078,6 +1078,19 @@ pub fn tests(
             move |setup| crate::test_generate_to_address::test_generate_to_address(setup, mode),
         )
     }));
+    // Uses `new_trial`: it needs custom `SetupOpts`. Signet, since only there
+    // does `GenerateToAddress` shell out to the miner.
+    async_trials.push(new_trial(
+        "signet_miner_rpc_cookie".to_string(),
+        TestSetupComponents {
+            bin_paths: bin_paths.clone(),
+            network: Network::Signet,
+            mode: Mode::GetBlockTemplate,
+            file_registry: file_registry.clone(),
+            failure_collector: failure_collector.clone(),
+        },
+        crate::test_signet_miner_rpc_cookie::test_signet_miner_rpc_cookie,
+    ));
     // Uses `new_trial` rather than `new_trial_with_setup`: it needs custom
     // `SetupOpts` to start the enforcer without a wallet.
     async_trials.push(new_trial(

--- a/integration_tests/lib.rs
+++ b/integration_tests/lib.rs
@@ -22,6 +22,7 @@ mod test_peer_bmm_request;
 mod test_rest_disabled;
 mod test_seed_migration;
 mod test_sidechain_ack_policy;
+mod test_signet_miner_rpc_cookie;
 mod test_unconfirmed_transactions;
 mod test_wallet_descriptor_fallback;
 mod test_wallet_large_gap_sync;

--- a/integration_tests/setup.rs
+++ b/integration_tests/setup.rs
@@ -78,14 +78,8 @@ impl SignetSetup {
             &bitcoin::secp256k1::Secp256k1::new(),
             &secret_key,
         )?;
-        let signet_challenge = bitcoin::Script::builder()
-            .push_opcode(bitcoin::opcodes::all::OP_PUSHNUM_1)
-            .push_slice(cpk.to_bytes())
-            .push_opcode(bitcoin::opcodes::all::OP_PUSHNUM_1)
-            .push_opcode(bitcoin::opcodes::all::OP_CHECKMULTISIG)
-            .into_script();
-        let signet_challenge_addr =
-            bitcoin::Address::from_script(&cpk.p2wpkh_script_code(), &bitcoin::params::SIGNET)?;
+        let (signet_challenge, signet_challenge_addr) =
+            crate::signet_chain_params::signet_challenge(&cpk);
         let signet_magic = bip300301_enforcer_lib::p2p::compute_signet_magic(&signet_challenge);
         tracing::info!(
             signet_challenge = %hex::encode(signet_challenge.as_bytes()),
@@ -100,16 +94,12 @@ impl SignetSetup {
         })
     }
 
-    /// Initialize bitcoind wallet
+    /// Import the signet challenge key, so the wallet can sign blocks.
     async fn init_bitcoind_wallet(&self, bitcoin_cli: &bins::BitcoinCli) -> anyhow::Result<()> {
         tracing::debug!("Importing secret key");
         let mining_descriptor = {
             use bdk_wallet::miniscript;
             let descriptor = bdk_wallet::descriptor!(wpkh(self.secret_key))?;
-            descriptor.0.to_string_with_secret(&descriptor.1)
-        };
-        let multisig_descriptor = {
-            let descriptor = bdk_wallet::descriptor!(bare(multi(1, self.secret_key)))?;
             descriptor.0.to_string_with_secret(&descriptor.1)
         };
         let import_descriptors_output = bitcoin_cli
@@ -122,19 +112,12 @@ impl SignetSetup {
                         "timestamp": "now",
                         "active": false,
                     },
-                    {
-                        "desc": multisig_descriptor,
-                        "timestamp": "now",
-                        "active": false,
-                    },
                 ])
                 .to_string()],
             )
             .run_utf8()
             .await?;
-        let expected_import_descriptors_output = serde_json::json!([
-            { "success": true }, { "success": true }
-        ]);
+        let expected_import_descriptors_output = serde_json::json!([{ "success": true }]);
         if serde_json::from_str::<serde_json::Value>(&import_descriptors_output)?
             != expected_import_descriptors_output
         {
@@ -866,11 +849,8 @@ async fn mine_cached_signet_chain(
     bitcoin_cli.rpc_wallet = Some("integration-test".to_owned());
     let () = signet_setup.init_bitcoind_wallet(&bitcoin_cli).await?;
 
-    // Pay the coinbases to an address the wallet actually owns, so the whole
-    // point of this chain -- mature, *spendable* coins ready on startup -- is
-    // met. Note this is deliberately not `signet_challenge_addr`: that is
-    // derived from the challenge script code, so it satisfies the signet block
-    // signature but is not an output the wallet can spend from.
+    // A fresh wallet address rather than `signet_challenge_addr`, keeping the
+    // funds tests spend apart from the block-signing key.
     let mining_address = bitcoin_cli
         .command::<String, _, String, _, _>([], "getnewaddress", [])
         .run_utf8()

--- a/integration_tests/signet_chain_params.rs
+++ b/integration_tests/signet_chain_params.rs
@@ -28,3 +28,14 @@ pub const SIGNET_CHALLENGE_SECRET_KEY: [u8; 32] = [
 /// `COINBASE_MATURITY` (100) so that the earliest coinbases are spendable the
 /// moment a test starts, which is the entire point of caching it.
 pub const SIGNET_CACHED_CHAIN_BLOCKS: u32 = 110;
+
+/// The signet challenge and its address: P2WPKH to the key behind
+/// [`SIGNET_CHALLENGE_SECRET_KEY`]. Not a bare multisig like default signet,
+/// since the enforcer checks it can mine by turning the challenge into an
+/// address and asking the node wallet whether it owns it.
+pub fn signet_challenge(
+    public_key: &bitcoin::CompressedPublicKey,
+) -> (bitcoin::ScriptBuf, bitcoin::Address) {
+    let address = bitcoin::Address::p2wpkh(public_key, bitcoin::Network::Signet);
+    (address.script_pubkey(), address)
+}

--- a/integration_tests/test_no_secrets_in_logs.rs
+++ b/integration_tests/test_no_secrets_in_logs.rs
@@ -7,13 +7,12 @@
 //! the harness's `trace` log level turned on, which is where a leak is most
 //! likely to show up.
 
-use std::path::PathBuf;
-
 use bip300301_enforcer_lib::cli::SecretString;
 
 use crate::{
     integration_test::fund_enforcer,
     setup::{DummySidechain, PostSetup},
+    util::{assert_absent, enforcer_output},
 };
 
 pub const TEST_NAME: &str = "no_secrets_in_logs";
@@ -48,51 +47,6 @@ fn base64_encode(input: &[u8]) -> String {
     out
 }
 
-/// Everything the enforcer writes: both captured streams and every rolling log
-/// file. Missing files are skipped -- `stderr.txt` is empty on a healthy run.
-fn enforcer_output(post_setup: &PostSetup) -> anyhow::Result<Vec<(PathBuf, String)>> {
-    let dir = &post_setup.directories.enforcer_dir;
-    let mut paths = vec![dir.join("stdout.txt"), dir.join("stderr.txt")];
-    let log_dir = dir.join("logs");
-    if log_dir.is_dir() {
-        for entry in std::fs::read_dir(&log_dir)? {
-            let path = entry?.path();
-            if path.is_file() {
-                paths.push(path);
-            }
-        }
-    }
-
-    let mut out = Vec::new();
-    for path in paths {
-        match std::fs::read_to_string(&path) {
-            Ok(contents) => out.push((path, contents)),
-            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
-            Err(err) => return Err(anyhow::anyhow!("reading {}: {err}", path.display())),
-        }
-    }
-    anyhow::ensure!(!out.is_empty(), "the enforcer wrote no output to scan");
-    Ok(out)
-}
-
-/// Fail with the offending line rather than just a count, so a regression says
-/// where the secret escaped.
-fn assert_absent(files: &[(PathBuf, String)], needle: &str, what: &str) -> anyhow::Result<()> {
-    for (path, contents) in files {
-        if let Some(line) = contents.lines().find(|line| line.contains(needle)) {
-            // The line itself is not printed in full: it contains the secret.
-            let position = line.find(needle).unwrap_or(0);
-            anyhow::bail!(
-                "{what} leaked into {} at character {position} of a {} line starting `{}`",
-                path.display(),
-                line.len(),
-                line.chars().take(60).collect::<String>(),
-            );
-        }
-    }
-    Ok(())
-}
-
 pub async fn test_no_secrets_in_logs(mut post_setup: PostSetup) -> anyhow::Result<()> {
     // Drive real work through the enforcer first, so the logs cover node RPC
     // traffic and wallet activity rather than just startup.
@@ -111,7 +65,7 @@ pub async fn test_no_secrets_in_logs(mut post_setup: PostSetup) -> anyhow::Resul
         .clone()
         .ok_or_else(|| anyhow::anyhow!("harness has no rpc password to check for"))?;
 
-    let files = enforcer_output(&post_setup)?;
+    let files = enforcer_output(&post_setup.directories.enforcer_dir)?;
     let total_bytes: usize = files.iter().map(|(_, contents)| contents.len()).sum();
     tracing::info!(
         "scanning {} enforcer output file(s), {total_bytes} bytes",

--- a/integration_tests/test_signet_miner_rpc_cookie.rs
+++ b/integration_tests/test_signet_miner_rpc_cookie.rs
@@ -1,0 +1,186 @@
+//! The enforcer's signet miner must get the node RPC credentials through a
+//! cookie file, not through the `bitcoin-cli` invocation in its argv. Drives
+//! `GenerateToAddress` on signet, the one path that spawns the miner, and
+//! checks the logged invocation, the cookie file, and the enforcer's output.
+
+use bip300301_enforcer_lib::{
+    bins::CommandExt as _,
+    cli::RPC_COOKIE_FILENAME,
+    proto::{self, mainchain::GenerateToAddressRequest},
+};
+use futures::channel::mpsc;
+
+use crate::{
+    setup::{Mode, PostSetup, PreSetup, SetupOpts, wait_for_block_templates, wait_until},
+    util::{assert_absent, enforcer_output},
+};
+
+/// Logged with the full miner command right before it is spawned.
+const MINER_INVOCATION_MARKER: &str = "Running signet miner:";
+
+async fn block_count(
+    bitcoin_cli: &bip300301_enforcer_lib::bins::BitcoinCli,
+) -> anyhow::Result<u64> {
+    let count = bitcoin_cli
+        .command::<String, _, String, _, _>([], "getblockcount", [])
+        .run_utf8()
+        .await?;
+    Ok(count.trim().parse()?)
+}
+
+/// Polled: the rolling log can lag the RPC response.
+async fn wait_for_miner_invocation(post_setup: &PostSetup) -> anyhow::Result<String> {
+    let mut invocation = None;
+    wait_until("the enforcer to log its signet miner invocation", || {
+        let found = enforcer_output(&post_setup.directories.enforcer_dir).map(|files| {
+            files.iter().find_map(|(_, contents)| {
+                contents
+                    .lines()
+                    .find(|line| line.contains(MINER_INVOCATION_MARKER))
+                    .map(str::to_owned)
+            })
+        });
+        let result = match found {
+            Ok(Some(line)) => {
+                invocation = Some(line);
+                Ok(true)
+            }
+            Ok(None) => Ok(false),
+            Err(err) => Err(err),
+        };
+        async move { result }
+    })
+    .await?;
+    invocation.ok_or_else(|| anyhow::anyhow!("miner invocation matched but was not captured"))
+}
+
+pub async fn test_signet_miner_rpc_cookie(setup: PreSetup) -> anyhow::Result<()> {
+    let (res_tx, _res_rx) = mpsc::unbounded();
+    // Otherwise the enforcer clones the miner from GitHub and looks for the
+    // binaries on `PATH`, which CI lacks.
+    let enforcer_args = {
+        let bin_paths = &setup.bin_paths;
+        vec![
+            format!(
+                "--signet-miner-script-path={}",
+                std::path::absolute(bin_paths.signet_miner()?)?.display()
+            ),
+            format!(
+                "--signet-miner-bitcoin-cli-path={}",
+                std::path::absolute(bin_paths.bitcoin_cli()?)?.display()
+            ),
+            format!(
+                "--signet-miner-bitcoin-util-path={}",
+                std::path::absolute(bin_paths.bitcoin_util()?)?.display()
+            ),
+        ]
+    };
+    let setup_opts: SetupOpts = SetupOpts {
+        enforcer_args,
+        ..Default::default()
+    };
+    let post_setup = setup
+        .setup(Mode::GetBlockTemplate, setup_opts, res_tx)
+        .await?;
+
+    // The miner takes its template from the enforcer's own server.
+    wait_for_block_templates(&post_setup.gbt_client).await?;
+
+    let start_height = block_count(&post_setup.bitcoin_cli).await?;
+    let mining_address = post_setup.mining_address.clone();
+    let resp = post_setup
+        .mining_service_client
+        .generate_to_address(GenerateToAddressRequest {
+            blocks: proto::wrap_u32(1),
+            address: mining_address.to_string(),
+        })
+        .await?
+        .into_owned();
+    let block_hashes = resp
+        .block_hashes
+        .into_iter()
+        .map(|block_hash| {
+            block_hash.decode::<proto::mainchain::GenerateToAddressResponse, bitcoin::BlockHash>(
+                "block_hashes",
+            )
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    anyhow::ensure!(
+        block_hashes.len() == 1,
+        "expected 1 block hash, got {}",
+        block_hashes.len()
+    );
+
+    // The block landed, so `bitcoin-cli` authenticated with the cookie.
+    let end_height = block_count(&post_setup.bitcoin_cli).await?;
+    anyhow::ensure!(
+        end_height == start_height + 1,
+        "expected the chain to advance from {start_height} to {}, got {end_height}",
+        start_height + 1
+    );
+    let best_block_hash = post_setup
+        .bitcoin_cli
+        .command::<String, _, String, _, _>([], "getbestblockhash", [])
+        .run_utf8()
+        .await?
+        .trim()
+        .parse::<bitcoin::BlockHash>()?;
+    anyhow::ensure!(
+        Some(&best_block_hash) == block_hashes.first(),
+        "expected the node tip to be the generated block, got {best_block_hash}"
+    );
+
+    // The logged `--cli=` string is where the password used to show up. Never
+    // echo it into a failure message.
+    let invocation = wait_for_miner_invocation(&post_setup).await?;
+    anyhow::ensure!(
+        invocation.contains("--cli="),
+        "the logged miner invocation carries no `--cli=`"
+    );
+    for leaked in ["-rpcpassword=", "-rpcuser="] {
+        anyhow::ensure!(
+            !invocation.contains(leaked),
+            "`{leaked}` reached the miner's argv; see the enforcer log"
+        );
+    }
+    let cookie_path = post_setup
+        .directories
+        .enforcer_dir
+        .join(RPC_COOKIE_FILENAME);
+    let cookie_arg = format!("-rpccookiefile={}", cookie_path.display());
+    anyhow::ensure!(
+        invocation.contains(&cookie_arg),
+        "the miner's bitcoin-cli must be pointed at `{cookie_arg}`; see the enforcer log"
+    );
+
+    // The cookie itself.
+    let rpc_user = post_setup
+        .bitcoin_cli
+        .rpc_user
+        .clone()
+        .ok_or_else(|| anyhow::anyhow!("harness has no rpc user"))?;
+    let rpc_pass = post_setup
+        .bitcoin_cli
+        .rpc_pass
+        .clone()
+        .ok_or_else(|| anyhow::anyhow!("harness has no rpc password"))?;
+    let cookie = std::fs::read_to_string(&cookie_path)
+        .map_err(|err| anyhow::anyhow!("reading {}: {err}", cookie_path.display()))?;
+    anyhow::ensure!(
+        cookie == format!("{rpc_user}:{}", rpc_pass.expose()),
+        "the cookie does not hold the node's credentials"
+    );
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        let mode = std::fs::metadata(&cookie_path)?.permissions().mode() & 0o777;
+        anyhow::ensure!(mode == 0o600, "the cookie must be 0600, got {mode:o}");
+    }
+
+    // Nothing the enforcer wrote carries the password.
+    let files = enforcer_output(&post_setup.directories.enforcer_dir)?;
+    assert_absent(&files, rpc_pass.expose(), "the node RPC password")?;
+
+    drop(post_setup);
+    Ok(())
+}

--- a/integration_tests/util.rs
+++ b/integration_tests/util.rs
@@ -958,3 +958,49 @@ pub fn expect_block_template(
         .map(|template| *template)
         .ok_or_else(|| anyhow::anyhow!("expected a block template, got a BIP23 proposal verdict"))
 }
+
+/// Everything the enforcer wrote: captured stdout/stderr and the rolling logs
+/// under `enforcer_dir`.
+pub fn enforcer_output(enforcer_dir: &std::path::Path) -> anyhow::Result<Vec<(PathBuf, String)>> {
+    let mut paths = vec![
+        enforcer_dir.join("stdout.txt"),
+        enforcer_dir.join("stderr.txt"),
+    ];
+    let log_dir = enforcer_dir.join("logs");
+    if log_dir.is_dir() {
+        for entry in std::fs::read_dir(&log_dir)? {
+            let path = entry?.path();
+            if path.is_file() {
+                paths.push(path);
+            }
+        }
+    }
+
+    let mut out = Vec::new();
+    for path in paths {
+        match std::fs::read_to_string(&path) {
+            Ok(contents) => out.push((path, contents)),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+            Err(err) => return Err(anyhow::anyhow!("reading {}: {err}", path.display())),
+        }
+    }
+    anyhow::ensure!(!out.is_empty(), "the enforcer wrote no output to scan");
+    Ok(out)
+}
+
+/// Fail if `needle` appears in any of `files`, without printing the line: it
+/// holds the secret.
+pub fn assert_absent(files: &[(PathBuf, String)], needle: &str, what: &str) -> anyhow::Result<()> {
+    for (path, contents) in files {
+        if let Some(line) = contents.lines().find(|line| line.contains(needle)) {
+            let position = line.find(needle).unwrap_or(0);
+            anyhow::bail!(
+                "{what} leaked into {} at character {position} of a {} line starting `{}`",
+                path.display(),
+                line.len(),
+                line.chars().take(60).collect::<String>(),
+            );
+        }
+    }
+    Ok(())
+}

--- a/lib/bins.rs
+++ b/lib/bins.rs
@@ -243,3 +243,68 @@ impl SignetMiner {
         command
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser as _;
+
+    use crate::cli::Config;
+
+    fn temp_dir(tag: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "bip300301-bins-{tag}-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id(),
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn config_with_rpc_credentials(dir: &std::path::Path) -> Config {
+        Config::try_parse_from([
+            "bip300301_enforcer",
+            &format!("--data-dir={}", dir.display()),
+            "--node-rpc-user=alice",
+            "--node-rpc-pass=hunter2",
+        ])
+        .expect("should parse")
+    }
+
+    /// A failed cookie write is an error, not a fallback to arguments. A
+    /// regular file as data dir fails the write even as root.
+    #[test]
+    fn unwritable_data_dir_is_an_error() {
+        let dir = temp_dir("rpc-cookie-unwritable");
+        let not_a_dir = dir.join("data");
+        std::fs::write(&not_a_dir, b"").unwrap();
+        let config = config_with_rpc_credentials(&not_a_dir);
+
+        let err = config
+            .bitcoin_cli(bitcoin::Network::Signet)
+            .expect_err("an unwritable data dir must refuse to build a bitcoin-cli invocation");
+        assert!(!err.to_string().contains("hunter2"));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// A path the miner cannot pass on is an error, not a fallback.
+    #[test]
+    fn data_dir_with_whitespace_is_an_error() {
+        let dir = temp_dir("rpc-cookie-whitespace").join("Application Support");
+        std::fs::create_dir_all(&dir).unwrap();
+        let config = config_with_rpc_credentials(&dir);
+
+        let err = config
+            .bitcoin_cli(bitcoin::Network::Signet)
+            .expect_err("a data dir with whitespace must refuse to build a bitcoin-cli invocation");
+        assert!(
+            err.to_string().contains("whitespace"),
+            "the error must say why: {err}"
+        );
+        assert!(!err.to_string().contains("hunter2"));
+        assert!(
+            !dir.join(crate::cli::RPC_COOKIE_FILENAME).exists(),
+            "no cookie may be written to a path the miner cannot use"
+        );
+        std::fs::remove_dir_all(dir.parent().unwrap()).ok();
+    }
+}

--- a/lib/block_producer/error.rs
+++ b/lib/block_producer/error.rs
@@ -407,6 +407,8 @@ pub enum GenerateSignetBlock {
     Mine(#[from] crate::bins::CommandError),
     #[error("signet miner subprocess timed out")]
     Timeout { duration: tokio::time::Duration },
+    #[error(transparent)]
+    WriteRpcCookie(#[from] crate::cli::WriteRpcCookieError),
 }
 
 impl ToStatus for GenerateSignetBlock {
@@ -419,6 +421,7 @@ impl ToStatus for GenerateSignetBlock {
             Self::GetSignetMinerPath(err) => err.builder(),
             Self::Mine(err) => err.builder(),
             Self::Timeout { .. } => StatusBuilder::new(self),
+            Self::WriteRpcCookie(err) => StatusBuilder::new(err),
         }
     }
 }

--- a/lib/block_producer/mine.rs
+++ b/lib/block_producer/mine.rs
@@ -512,16 +512,18 @@ impl BlockProducer {
             .get_header_info(&self.validator().get_mainchain_tip()?)?;
 
         let getblocktemplate_command = Some(format!(
-            "bitcoin-cli -rpcconnect={} -rpcport={} getblocktemplate",
+            "{} -rpcconnect={} -rpcport={} getblocktemplate",
+            self.config().mining_opts.bitcoin_cli_path.display(),
             self.config().serve_rpc_addr.ip(),
             self.config().serve_rpc_addr.port()
         ));
         let target_block_interval = self.signet_challenge().map(target_block_interval);
 
         let mining_script_path = self.get_signet_miner_path().await?;
+        let bitcoin_cli = self.config().bitcoin_cli(bitcoin::Network::Signet)?;
         let miner = bins::SignetMiner {
             path: mining_script_path,
-            bitcoin_cli: self.config().bitcoin_cli(bitcoin::Network::Signet),
+            bitcoin_cli,
             bitcoin_util: self.config().mining_opts.bitcoin_util_path.clone(),
             block_interval: target_block_interval,
             nbits: None,

--- a/lib/cli.rs
+++ b/lib/cli.rs
@@ -11,6 +11,7 @@ use clap::{Args, Parser, ValueEnum};
 use thiserror::Error;
 use tracing_appender::rolling::{RollingFileAppender, Rotation};
 use tracing_subscriber::fmt::format as tracing_format;
+use zeroize::Zeroizing;
 
 use crate::types::NetworkParams;
 
@@ -71,6 +72,9 @@ const LOG_FILENAME: &str = "bip300301_enforcer.log";
 // Sub-par location for the log dir.
 // https://github.com/LayerTwo-Labs/bip300301_enforcer/issues/133
 const DEFAULT_LOG_DIRNAME: &str = "logs";
+
+/// Cookie file [`Config::bitcoin_cli`] writes under `data_dir`.
+pub const RPC_COOKIE_FILENAME: &str = "enforcer-rpc.cookie";
 
 /// Possible formats for log output.
 #[derive(Clone, Copy, Debug, Default, ValueEnum)]
@@ -719,6 +723,70 @@ fn effective_config_lines(matches: &clap::ArgMatches) -> Vec<String> {
     lines
 }
 
+#[derive(Debug, Error)]
+pub enum WriteRpcCookieError {
+    #[error(
+        "RPC cookie path `{}` contains whitespace, which the signet miner cannot pass on to \
+         bitcoin-cli; set --data-dir to a path without whitespace",
+        path.display()
+    )]
+    PathContainsWhitespace { path: PathBuf },
+    #[error("failed to write RPC cookie file `{}`", path.display())]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+}
+
+/// Write `user:pass` to a 0600 cookie file under `data_dir` and return its
+/// path. Fresh temp file plus rename, like the seed file, so a leftover or
+/// symlinked temp file can never decide the permissions.
+fn write_rpc_cookie(
+    data_dir: &Path,
+    user: &str,
+    pass: &SecretString,
+) -> Result<PathBuf, WriteRpcCookieError> {
+    let path = data_dir.join(RPC_COOKIE_FILENAME);
+    // `bitcoin-cli` resolves a relative `-rpccookiefile` against the node's
+    // datadir.
+    let path = std::path::absolute(&path).map_err(|source| WriteRpcCookieError::Io {
+        path: path.clone(),
+        source,
+    })?;
+
+    // The pinned signet miner splits `--cli=` on spaces, so a path with
+    // whitespace (macOS' default data dir, for one) cannot be passed on.
+    if path.to_string_lossy().contains(char::is_whitespace) {
+        return Err(WriteRpcCookieError::PathContainsWhitespace { path });
+    }
+    let io = |source| WriteRpcCookieError::Io {
+        path: path.clone(),
+        source,
+    };
+    let contents = Zeroizing::new(format!("{user}:{}", pass.expose()));
+    let () = std::fs::create_dir_all(data_dir).map_err(io)?;
+    let tmp_path = path.with_extension("cookie.tmp");
+    {
+        match std::fs::remove_file(&tmp_path) {
+            Ok(()) => (),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => (),
+            Err(err) => return Err(io(err)),
+        }
+        let mut options = std::fs::OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt as _;
+            options.mode(0o600);
+        }
+        let mut file = options.open(&tmp_path).map_err(io)?;
+        let () = std::io::Write::write_all(&mut file, contents.as_bytes()).map_err(io)?;
+    }
+    let () = std::fs::rename(&tmp_path, &path).map_err(io)?;
+    Ok(path)
+}
+
 impl Config {
     /// Parse the command line, keeping the raw [`clap::ArgMatches`] alongside
     /// the parsed config so that [`log_effective_config`] can report where each
@@ -739,17 +807,38 @@ impl Config {
         env!("GIT_HASH")
     }
 
-    pub fn bitcoin_cli(&self, network: bitcoin::Network) -> crate::bins::BitcoinCli {
-        crate::bins::BitcoinCli {
+    /// The `bitcoin-cli` invocation for the signet miner.
+    ///
+    /// User/password credentials go through a cookie file: the miner keeps
+    /// this invocation in its argv for the whole run, where any local user can
+    /// read it. No fallback to passing them as arguments; failing to mine
+    /// beats leaking the password.
+    pub fn bitcoin_cli(
+        &self,
+        network: bitcoin::Network,
+    ) -> Result<crate::bins::BitcoinCli, WriteRpcCookieError> {
+        let (rpc_user, rpc_pass, rpc_cookie_path) =
+            match (&self.node_rpc_opts.user, &self.node_rpc_opts.pass) {
+                (Some(user), Some(pass)) => {
+                    let cookie_path = write_rpc_cookie(&self.data_dir, user, pass)?;
+                    (None, None, Some(cookie_path.display().to_string()))
+                }
+                _ => (
+                    self.node_rpc_opts.user.clone(),
+                    self.node_rpc_opts.pass.clone(),
+                    self.node_rpc_opts.cookie_path.clone(),
+                ),
+            };
+        Ok(crate::bins::BitcoinCli {
             path: self.mining_opts.bitcoin_cli_path.clone(),
             network,
-            rpc_user: self.node_rpc_opts.user.clone(),
-            rpc_pass: self.node_rpc_opts.pass.clone(),
-            rpc_cookie_path: self.node_rpc_opts.cookie_path.clone(),
+            rpc_user,
+            rpc_pass,
+            rpc_cookie_path,
             rpc_port: self.node_rpc_opts.addr.port(),
             rpc_host: self.node_rpc_opts.addr.ip().to_string(),
             rpc_wallet: None,
-        }
+        })
     }
 
     pub fn log_formatter(&self) -> LogFormatter {


### PR DESCRIPTION
`Config::bitcoin_cli` built the `bitcoin-cli` invocation with `-rpcuser=`/`-rpcpassword=` arguments (`lib/cli.rs`). Command-line arguments are readable by every local user through `/proc/<pid>/cmdline`, and the signet miner is handed the entire `bitcoin-cli` command line as its `--cli=` argument, so the node RPC password sits in that miner's argv for the whole mining run.

The fix adds `write_rpc_cookie`, which writes the credentials to a 0600 file under `data_dir` in the `user:pass` shape Bitcoin Core's own cookie file uses (written atomically, like the seed file), and `bitcoin_cli` now passes `-rpccookiefile=<absolute path>` instead. It falls back to the old argument form when the data dir is unwritable or the path contains whitespace (which the miner's space-splitting `--cli=` cannot carry).

Tests assert no `-rpcpassword=`/`-rpcuser=` reaches argv while the cookie path does, that the `--cli=` string omits the password, and that the cookie is owner-only 0600.

This only changes the argv the node constructs for its child process, not anything it validates.