### PR TITLE
fix: Bind withdrawal bundles to their authoring sidechain, not the slot

### DIFF
--- a/lib/block_producer/coinbase.rs
+++ b/lib/block_producer/coinbase.rs
@@ -1,39 +1,85 @@
 use std::collections::{HashMap, HashSet};
 
-use bitcoin::{Amount, BlockHash, OutPoint, Transaction, TxOut};
+use bitcoin::{Amount, BlockHash, OutPoint, Transaction, TxOut, hashes::sha256d};
 use fallible_iterator::{FallibleIterator as _, IteratorExt as _};
 
 use crate::{
-    block_producer::{BlockProducer, BundleProposals, error},
+    block_producer::{BlockProducer, BundleProposals, db::StoredBundleProposals, error},
     messages::{CoinbaseBuilder, CoinbaseMessage, CoinbaseMessages, M4AckBundles},
     types::{
-        AmountUnderflowError, BlindedM6, Ctip, Sidechain, SidechainAck, SidechainNumber,
+        AmountUnderflowError, BlindedM6, Ctip, M6id, Sidechain, SidechainAck, SidechainNumber,
         SidechainProposal, SidechainProposalId, Thresholds,
     },
 };
 
 impl BlockProducer {
+    /// The stored bundles for `sidechain_id` that still belong to the sidechain
+    /// occupying that slot, identified by `active_description_hash`. A bundle is
+    /// bound to the sidechain that held the slot when it was accepted: once a
+    /// different sidechain holds it, proposing the bundle would pay the previous
+    /// occupant's withdrawals out of the new occupant's treasury, so it is
+    /// dropped. Rows stored before bundles were bound carry no hash, and are
+    /// judged by the slot alone as they were before.
+    fn bundles_bound_to_active_sidechain(
+        sidechain_id: SidechainNumber,
+        stored: StoredBundleProposals,
+        active_description_hash: sha256d::Hash,
+    ) -> Vec<(M6id, BlindedM6<'static>)> {
+        stored
+            .into_iter()
+            .filter_map(|(m6id, blinded_m6, description_hash)| {
+                if description_hash.is_none_or(|hash| hash == active_description_hash) {
+                    return Some((m6id, blinded_m6));
+                }
+                tracing::warn!(
+                    %sidechain_id,
+                    %m6id,
+                    "skipping a stored withdrawal bundle: another sidechain holds the slot now"
+                );
+                None
+            })
+            .collect()
+    }
+
     /// Bundle proposals we've stored, joined with the validator's view of each
     /// one. Proposals for a sidechain that isn't active are dropped: per BIP300
     /// M3, a bundle proposed for an inactive slot is just an ordinary script (a
     /// no-op), so there is nothing to gain by proposing it. Those can sneak in by
     /// activating a sidechain and then reorging it out of existence.
+    ///
+    /// A slot that is active but held by a *different* sidechain than the one
+    /// that authored a bundle drops it just the same, via
+    /// [`Self::bundles_bound_to_active_sidechain`].
     pub(crate) async fn get_bundle_proposals(
         &self,
     ) -> Result<HashMap<SidechainNumber, BundleProposals>, error::GetBundleProposals> {
         let bundle_proposals = self.db().get_bundle_proposals().await?;
-        let active_sidechain_numbers: HashSet<SidechainNumber> = self
+        let active_description_hashes: HashMap<SidechainNumber, sha256d::Hash> = self
             .validator()
             .get_active_sidechains()?
             .into_iter()
-            .map(|sidechain| sidechain.proposal.sidechain_number)
+            .map(|sidechain| {
+                (
+                    sidechain.proposal.sidechain_number,
+                    sidechain.proposal.description.sha256d_hash(),
+                )
+            })
             .collect();
         let res = bundle_proposals
             .into_iter()
             .map(Ok::<_, error::GetBundleProposals>)
             .transpose_into_fallible()
-            .filter_map(|(sidechain_id, m6ids)| {
-                if !active_sidechain_numbers.contains(&sidechain_id) {
+            .filter_map(|(sidechain_id, stored)| {
+                let Some(active_description_hash) = active_description_hashes.get(&sidechain_id)
+                else {
+                    return Ok(None);
+                };
+                let m6ids = Self::bundles_bound_to_active_sidechain(
+                    sidechain_id,
+                    stored,
+                    *active_description_hash,
+                );
+                if m6ids.is_empty() {
                     return Ok(None);
                 }
                 let pending_m6ids = self.validator().get_pending_withdrawals(&sidechain_id)?;
@@ -41,11 +87,7 @@ impl BlockProducer {
                     .into_iter()
                     .map(|(m6id, blinded_m6)| (m6id, blinded_m6, pending_m6ids.get(&m6id).copied()))
                     .collect();
-                if res.is_empty() {
-                    Ok(None)
-                } else {
-                    Ok(Some((sidechain_id, res)))
-                }
+                Ok(Some((sidechain_id, res)))
             })
             .collect()?;
         Ok(res)
@@ -470,7 +512,7 @@ mod tests {
     };
 
     use crate::{
-        block_producer::{BlockProducer, BundleProposals},
+        block_producer::{BlockProducer, BundleProposals, db::StoredBundleProposals},
         types::{
             AmountUnderflowError, BlindedM6, Ctip, PendingM6idInfo, SidechainAck,
             SidechainDescription, SidechainNumber, SidechainProposal, Thresholds,
@@ -523,6 +565,47 @@ mod tests {
             proposal_height: 1,
         };
         vec![(blinded_m6.compute_m6id(), blinded_m6, Some(info))]
+    }
+
+    /// The slot the stored bundles below were accepted for.
+    const BOUND_SLOT: SidechainNumber = SidechainNumber(7);
+
+    /// [`approved_bundle`] as it comes back out of the DB, bound to the
+    /// sidechain `bound_to` describes -- or unbound (`None`), as rows stored
+    /// before bundles were bound to a sidechain are.
+    fn stored_bundle(bound_to: Option<&SidechainProposal>) -> StoredBundleProposals {
+        let hash = bound_to.map(|proposal| proposal.description.sha256d_hash());
+        approved_bundle()
+            .into_iter()
+            .map(|(m6id, blinded_m6, _info)| (m6id, blinded_m6, hash))
+            .collect()
+    }
+
+    /// How many of `stored` are still proposable for [`BOUND_SLOT`], given that
+    /// the sidechain `active` describes holds that slot now.
+    fn bundles_kept(stored: StoredBundleProposals, active: &SidechainProposal) -> usize {
+        let hash = active.description.sha256d_hash();
+        BlockProducer::bundles_bound_to_active_sidechain(BOUND_SLOT, stored, hash).len()
+    }
+
+    /// A bundle accepted while one sidechain held a slot must not be re-proposed
+    /// once another sidechain holds it: an M3 names the slot alone, so it would
+    /// be voted on and paid out of the new occupant's treasury.
+    #[test]
+    fn stored_bundles_of_a_previous_slot_occupant_are_dropped() {
+        let previous = test_proposal(BOUND_SLOT, b"previous");
+        let current = test_proposal(BOUND_SLOT, b"current");
+        let ours = stored_bundle(Some(&current));
+        let theirs = stored_bundle(Some(&previous));
+        let legacy = stored_bundle(None);
+
+        // The sidechain that authored the bundle still holds the slot.
+        assert_eq!(bundles_kept(ours, &current), 1);
+        // A different sidechain holds it now: the bundle is not ours to propose.
+        assert_eq!(bundles_kept(theirs, &current), 0);
+        // A row stored before bundles were bound to a sidechain has no owner to
+        // compare against, and keeps the pre-existing slot-only behaviour.
+        assert_eq!(bundles_kept(legacy, &current), 1);
     }
 
     fn ctip(byte: u8) -> Ctip {

--- a/lib/block_producer/db.rs
+++ b/lib/block_producer/db.rs
@@ -14,8 +14,11 @@ use crate::{
     },
 };
 
-/// Bundle proposals for a single sidechain, as stored (no validator filtering).
-pub(crate) type StoredBundleProposals = Vec<(M6id, BlindedM6<'static>)>;
+/// Bundle proposals for a single sidechain, as stored (no validator filtering),
+/// each with the description hash of the sidechain that occupied the slot when
+/// the bundle was accepted. `None` for rows written before bundles were bound to
+/// a sidechain.
+pub(crate) type StoredBundleProposals = Vec<(M6id, BlindedM6<'static>, Option<sha256d::Hash>)>;
 
 /// Undo rows are kept for this many recently-produced blocks, so that blocks
 /// which stay on the main chain (and are therefore never disconnected) don't
@@ -112,6 +115,18 @@ impl Db {
                  INSERT INTO block_producer_settings (id, ack_all_proposals)
                  VALUES (0, TRUE);",
             ),
+            // Bind each stored bundle to the sidechain that occupied its slot
+            // when the bundle was accepted, so that a bundle is not re-proposed
+            // once a different sidechain takes the slot over. Nullable: SQLite
+            // cannot add a NOT NULL column without a default, and rows written
+            // before this migration have no known owner — those stay unbound.
+            // The `UNIQUE(sidechain_number, bundle_hash)` key above cannot be
+            // widened by `ALTER TABLE`, so the binding is filtered on read
+            // instead (see `BlockProducer::get_bundle_proposals`).
+            M::up(
+                "ALTER TABLE bundle_proposals
+                 ADD COLUMN sidechain_description_hash BLOB;",
+            ),
         ]);
 
         let path = data_dir.join("db.sqlite");
@@ -179,8 +194,10 @@ impl Db {
     ) -> Result<HashMap<SidechainNumber, StoredBundleProposals>, error::GetBundleProposals> {
         // Satisfy clippy with a single function call per lock
         let with_connection = |connection: &Connection| -> Result<_, error::GetBundleProposals> {
-            let mut statement = connection
-                .prepare("SELECT sidechain_number, bundle_hash, bundle_tx FROM bundle_proposals")?;
+            let mut statement = connection.prepare(
+                "SELECT sidechain_number, bundle_hash, bundle_tx, sidechain_description_hash \
+                 FROM bundle_proposals",
+            )?;
             let mut bundle_proposals = HashMap::<_, Vec<_>>::new();
             let () = statement
                 .query_map([], |row| {
@@ -188,18 +205,23 @@ impl Db {
                     let m6id_bytes: [u8; 32] = row.get(1)?;
                     let m6id = M6id::from(m6id_bytes);
                     let bundle_tx_bytes: Vec<u8> = row.get(2)?;
-                    Ok((sidechain_number, m6id, bundle_tx_bytes))
+                    let description_hash: Option<[u8; 32]> = row.get(3)?;
+                    Ok((sidechain_number, m6id, bundle_tx_bytes, description_hash))
                 })?
                 .transpose_into_fallible()
                 .map_err(error::GetBundleProposals::from)
-                .for_each(|(sidechain_number, m6id, bundle_tx_bytes)| {
-                    let bundle_proposal_tx = BlindedM6::deserialize(&bundle_tx_bytes)?;
-                    bundle_proposals
-                        .entry(sidechain_number)
-                        .or_default()
-                        .push((m6id, bundle_proposal_tx));
-                    Ok(())
-                })?;
+                .for_each(
+                    |(sidechain_number, m6id, bundle_tx_bytes, description_hash)| {
+                        let bundle_proposal_tx = BlindedM6::deserialize(&bundle_tx_bytes)?;
+                        let description_hash = description_hash.map(sha256d::Hash::from_byte_array);
+                        bundle_proposals.entry(sidechain_number).or_default().push((
+                            m6id,
+                            bundle_proposal_tx,
+                            description_hash,
+                        ));
+                        Ok(())
+                    },
+                )?;
             Ok(bundle_proposals)
         };
         let connection = self.conn.lock().await;
@@ -338,9 +360,15 @@ impl Db {
         with_connection(&connection)
     }
 
+    /// Store a bundle for `sidechain_number`, bound to the sidechain occupying
+    /// that slot right now, identified by `sidechain_description_hash`. A bundle
+    /// only makes sense for the sidechain that authored it, so the binding is
+    /// re-checked when the bundle is proposed (see
+    /// `BlockProducer::get_bundle_proposals`).
     pub async fn put_withdrawal_bundle(
         &self,
         sidechain_number: SidechainNumber,
+        sidechain_description_hash: sha256d::Hash,
         blinded_m6: &BlindedM6<'static>,
     ) -> Result<M6id, rusqlite::Error> {
         let m6id = blinded_m6.compute_m6id();
@@ -348,13 +376,22 @@ impl Db {
         // because `BlindedM6::deserialize` reads this encoding back, and a
         // finalized M6 has a treasury input anyway.
         let tx_bytes = blinded_m6.serialize();
-        self.conn
-            .lock()
-            .await
-            .execute(
-                "INSERT OR IGNORE INTO bundle_proposals (sidechain_number, bundle_hash, bundle_tx) VALUES (?1, ?2, ?3)",
-                (sidechain_number.0, m6id.0.as_byte_array(), tx_bytes),
-            )?;
+        // The key is `(slot, bundle)` and cannot be widened on an existing DB,
+        // so a re-broadcast re-binds the row to the sidechain broadcasting it
+        // now, rather than being ignored and left bound to a previous occupant.
+        self.conn.lock().await.execute(
+            "INSERT INTO bundle_proposals \
+                 (sidechain_number, bundle_hash, bundle_tx, sidechain_description_hash) \
+                 VALUES (?1, ?2, ?3, ?4) \
+                 ON CONFLICT (sidechain_number, bundle_hash) \
+                 DO UPDATE SET sidechain_description_hash = excluded.sidechain_description_hash",
+            (
+                sidechain_number.0,
+                m6id.0.as_byte_array(),
+                tx_bytes,
+                sidechain_description_hash.as_byte_array(),
+            ),
+        )?;
         Ok(m6id)
     }
 

--- a/lib/server/wallet/grpc.rs
+++ b/lib/server/wallet/grpc.rs
@@ -146,16 +146,19 @@ impl WalletService for crate::wallet::Wallet {
         // be a no-op. Fail fast at ingestion rather than persisting a row that can
         // never be acted on. NB: this gate cannot catch a slot that is deactivated by
         // a reorg *after* a bundle is stored, so the block builder
-        // (`get_bundle_proposals`) also skips inactive-slot bundles.
-        match self.is_sidechain_active(sidechain_id) {
-            Ok(false) => {
+        // (`get_bundle_proposals`) also skips inactive-slot bundles. For the same
+        // reason the bundle is stored bound to the sidechain occupying the slot right
+        // now: a slot that is reactivated by a *different* sidechain is still active,
+        // and the builder re-checks the binding before proposing.
+        let description_hash = match self.active_sidechain_description_hash(sidechain_id) {
+            Ok(None) => {
                 return Err(ConnectError::failed_precondition(format!(
                     "cannot accept a withdrawal bundle for sidechain {sidechain_id}: not active"
                 )));
             }
-            Ok(true) => (),
+            Ok(Some(description_hash)) => description_hash,
             Err(err) => return Err(internal_err(err)),
-        }
+        };
         // Likewise reject bundles for an active slot that has no CTIP: with no
         // treasury UTXO there is nothing for an M6 to spend, so the bundle could
         // never become a valid withdrawal. NB: as with the active-slot gate
@@ -186,7 +189,7 @@ impl WalletService for crate::wallet::Wallet {
             )
         })?;
         let _m6id = self
-            .put_withdrawal_bundle(sidechain_id, &transaction)
+            .put_withdrawal_bundle(sidechain_id, description_hash, &transaction)
             .await
             .map_err(|err| StatusBuilder::new(&err).to_connect_error())?;
         Ok(Response::new(BroadcastWithdrawalBundleResponse::default()))

--- a/lib/wallet/mod.rs
+++ b/lib/wallet/mod.rs
@@ -833,11 +833,12 @@ impl Wallet {
     pub async fn put_withdrawal_bundle(
         &self,
         sidechain_number: SidechainNumber,
+        sidechain_description_hash: sha256d::Hash,
         blinded_m6: &BlindedM6<'static>,
     ) -> Result<M6id, rusqlite::Error> {
         self.inner
             .db()
-            .put_withdrawal_bundle(sidechain_number, blinded_m6)
+            .put_withdrawal_bundle(sidechain_number, sidechain_description_hash, blinded_m6)
             .await
     }
 
@@ -1736,6 +1737,23 @@ impl Wallet {
             .any(|sc| sc.proposal.sidechain_number == sidechain_number);
 
         Ok(active)
+    }
+
+    /// The description hash of the sidechain occupying `sidechain_number` right
+    /// now, or `None` if the slot is inactive. Identifies *which* sidechain
+    /// holds the slot, which a slot number alone does not: a slot can be
+    /// reactivated by a different sidechain.
+    pub fn active_sidechain_description_hash(
+        &self,
+        sidechain_number: SidechainNumber,
+    ) -> Result<Option<sha256d::Hash>, validator::GetSidechainsError> {
+        let sidechains = self.inner.validator().get_active_sidechains()?;
+        let description_hash = sidechains
+            .iter()
+            .find(|sc| sc.proposal.sidechain_number == sidechain_number)
+            .map(|sc| sc.proposal.description.sha256d_hash());
+
+        Ok(description_hash)
     }
 
     #[instrument(skip_all, err)]


### PR DESCRIPTION
The enforcer wallet stores withdrawal bundles keyed by slot number alone, and `get_bundle_proposals` in `lib/block_producer/coinbase.rs` filtered them only by whether the slot is currently active. A slot can be deactivated and reactivated by a *different* sidechain; the stored bundle then survives and is re-proposed via M3 for the new occupant, so the previous occupant's withdrawals would be voted on and paid out of the new occupant's treasury.

The fix records, alongside each stored bundle, the description hash of the sidechain occupying the slot when the bundle was accepted (a new nullable `sidechain_description_hash` column plus migration). On read, a bundle whose bound hash does not match the current occupant is dropped and logged. Rows written before this change carry no hash and keep the prior slot-only behaviour, and a re-broadcast re-binds the row to the sidechain broadcasting it now.

`stored_bundles_of_a_previous_slot_occupant_are_dropped` covers the kept, dropped, and legacy cases.

This only changes which M3 bundle proposals the node puts in its own block templates and wallet state, not what it validates.