### PR TITLE
fix: Evict losing competing M5 deposits once their treasury exists

### DIFF
--- a/integration_tests/integration_test.rs
+++ b/integration_tests/integration_test.rs
@@ -1172,6 +1172,19 @@ pub fn tests(
         },
         crate::test_consecutive_deposits::test_consecutive_deposits,
     ));
+    // Competing deposits wedge the block producer, which only serves templates
+    // in GetBlockTemplate mode.
+    async_trials.push(new_trial_with_setup(
+        "competing_deposits".to_string(),
+        TestSetupComponents {
+            bin_paths: bin_paths.clone(),
+            network: Network::Regtest,
+            mode: Mode::GetBlockTemplate,
+            file_registry: file_registry.clone(),
+            failure_collector: failure_collector.clone(),
+        },
+        crate::test_consecutive_deposits::test_competing_deposits,
+    ));
 
     async_trials.push(new_trial_with_setup(
         "blinded_m6_roundtrip".to_string(),

--- a/integration_tests/test_consecutive_deposits.rs
+++ b/integration_tests/test_consecutive_deposits.rs
@@ -16,7 +16,8 @@ use crate::{
     integration_test::{
         activate_sidechain, fund_enforcer, propose_sidechain, wait_for_wallet_sync,
     },
-    setup::{DummySidechain, PostSetup, Sidechain as _, wait_for_tx_in_mempool},
+    mine::{mine, wait_for_tx_in_block_template},
+    setup::{DummySidechain, PostSetup, Sidechain as _, wait_for_tx_in_mempool, wait_until},
 };
 
 const DEPOSIT_AMOUNT: bitcoin::Amount = bitcoin::Amount::from_sat(21_000_000);
@@ -181,5 +182,94 @@ pub async fn test_consecutive_deposits(mut post_setup: PostSetup) -> anyhow::Res
         "second deposit {deposit_txid_2} missing from mempool: {mempool:?}"
     );
     tracing::info!("Both consecutive deposits are in the mempool");
+    Ok(())
+}
+
+/// Block until the enforcer's block template selects all of `want` and none
+/// of `not_want`. `Mode::GetBlockTemplate` only; the mempool mirror trails
+/// bitcoind's mempool, so this must gate mining on the deposits. A template
+/// that cannot be built at all is reported as the last error on timeout.
+async fn wait_for_template_txs(
+    post_setup: &PostSetup,
+    want: Vec<bitcoin::Txid>,
+    not_want: Vec<bitcoin::Txid>,
+) -> anyhow::Result<()> {
+    use cusf_enforcer_mempool::server::RpcClient as _;
+    let gbt_client = post_setup.gbt_client.clone();
+    wait_until(
+        "the enforcer's block template to settle the competing deposits",
+        move || {
+            let gbt_client = gbt_client.clone();
+            let want = want.clone();
+            let not_want = not_want.clone();
+            async move {
+                let mut gbt_request = bitcoin_jsonrpsee::client::BlockTemplateRequest::default();
+                gbt_request.capabilities.insert("coinbasetxn".to_owned());
+                let template = crate::util::expect_block_template(
+                    gbt_client.get_block_template(gbt_request).await?,
+                )?;
+                let txids: Vec<bitcoin::Txid> =
+                    template.transactions.iter().map(|tx| tx.txid).collect();
+                Ok(want.iter().all(|txid| txids.contains(txid))
+                    && not_want.iter().all(|txid| !txids.contains(txid)))
+            }
+        },
+    )
+    .await
+}
+
+/// Two first deposits into the same empty treasury do not spend a treasury
+/// UTXO, so they are not double-spends of each other and both sit in the
+/// mempool at once. Only one of them can ever be connected, so a block
+/// producer that cannot tell them apart offers a template containing both and
+/// then fails to finalize it -- for this block, and for every block after the
+/// winner confirms, because nothing evicts the loser.
+pub async fn test_competing_deposits(mut post_setup: PostSetup) -> anyhow::Result<()> {
+    let (res_tx, _res_rx) = mpsc::unbounded();
+    let sidechain = DummySidechain::setup((), &post_setup, res_tx).await?;
+    let () = propose_sidechain::<DummySidechain>(&mut post_setup).await?;
+    let () = activate_sidechain::<DummySidechain>(&mut post_setup).await?;
+    let () = fund_enforcer::<DummySidechain>(&mut post_setup).await?;
+    tracing::info!("Activated sidechain and funded enforcer successfully");
+    drop(sidechain);
+
+    // As in `test_consecutive_deposits`: a single UTXO forces the second
+    // deposit to be funded from the first deposit's change.
+    let () = consolidate_to_single_utxo(&mut post_setup).await?;
+
+    let deposit_txid_1 = create_deposit(&mut post_setup, "sidechain address 1").await?;
+    let () = wait_for_tx_in_mempool(&post_setup.bitcoin_cli, &deposit_txid_1).await?;
+    // The mirror has to hold the first deposit before the second is created,
+    // so that it is the second that is seen to compete with the first.
+    let () = wait_for_tx_in_block_template(&post_setup, &deposit_txid_1).await?;
+
+    let deposit_txid_2 = create_deposit(&mut post_setup, "sidechain address 2").await?;
+    let () = wait_for_tx_in_mempool(&post_setup.bitcoin_cli, &deposit_txid_2).await?;
+    tracing::info!(%deposit_txid_1, %deposit_txid_2, "Both competing deposits are in the mempool");
+
+    // The second deposit spends the first's change, so the only block either
+    // can appear in is one holding the first alone.
+    let () = wait_for_template_txs(&post_setup, vec![deposit_txid_1], vec![deposit_txid_2]).await?;
+
+    let () = mine::<DummySidechain>(&mut post_setup, 1, None).await?;
+
+    // The block was mined from that template, so it took the first deposit
+    // alone, and the second is still an unconfirmed transaction that can never
+    // be connected now that the treasury it would have created exists.
+    let mempool = raw_mempool(&mut post_setup).await?;
+    anyhow::ensure!(
+        !mempool.contains(&deposit_txid_1.to_string()),
+        "expected the winning deposit {deposit_txid_1} to be mined: {mempool:?}"
+    );
+    anyhow::ensure!(
+        mempool.contains(&deposit_txid_2.to_string()),
+        "expected the losing deposit {deposit_txid_2} to stay in bitcoind's mempool: {mempool:?}"
+    );
+
+    // Unless connecting the block evicted the loser from the enforcer's own
+    // mempool mirror, every later template fails to finalize the same way the
+    // first one would have.
+    let () = wait_for_template_txs(&post_setup, vec![], vec![deposit_txid_2]).await?;
+    tracing::info!("The losing deposit was evicted, and templates are still served");
     Ok(())
 }

--- a/lib/validator/cusf_enforcer.rs
+++ b/lib/validator/cusf_enforcer.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use async_broadcast::TrySendError;
-use bitcoin::{Block, BlockHash, Transaction, Txid, hashes::Hash as _};
+use bitcoin::{Block, BlockHash, OutPoint, Transaction, Txid, hashes::Hash as _};
 use cusf_enforcer_mempool::cusf_enforcer::{
     ConnectBlockAction, CusfEnforcer, DisconnectBlockAction, SyncToTipError, TxAcceptAction,
 };
@@ -20,11 +20,12 @@ use tokio_util::sync::CancellationToken;
 
 use crate::{
     errors::ErrorChain,
-    messages::parse_m8_tx,
+    messages::{parse_m8_tx, parse_op_drivechain},
     proto::mainchain::HeaderSyncProgress,
     types::{Ctip, Event, SidechainNumber},
     validator::{
         Validator,
+        dbs::SeenDeposits,
         task::{self, BlockHandler, error::ValidateTransaction as ValidateTransactionError},
     },
 };
@@ -46,6 +47,8 @@ enum ConnectBlockErrorInner {
     #[error(transparent)]
     ConnectBlock(#[from] Box<<task::error::ConnectBlock as Split>::Fatal>),
     #[error(transparent)]
+    Db(Box<db::Error>),
+    #[error(transparent)]
     DbPut(#[from] db::error::Put),
     #[error(transparent)]
     DbTryGet(#[from] db::error::TryGet),
@@ -55,6 +58,12 @@ enum ConnectBlockErrorInner {
     NestedWriteTxn(#[from] env::error::NestedWriteTxn),
     #[error(transparent)]
     WriteTxn(#[from] env::error::WriteTxn),
+}
+
+impl From<db::Error> for ConnectBlockErrorInner {
+    fn from(err: db::Error) -> Self {
+        Self::Db(Box::new(err))
+    }
 }
 
 impl From<db::error::Range> for ConnectBlockErrorInner {
@@ -236,7 +245,7 @@ fn connect_block_no_commit<'validator>(
         .into_nested()?
     {
         Ok(event) => {
-            let remove_mempool_txs = parent_child_rwtxn
+            let mut remove_mempool_txs: HashSet<Txid> = parent_child_rwtxn
                 .with_child(|child_rotxn| {
                     validator
                         .dbs
@@ -246,6 +255,17 @@ fn connect_block_no_commit<'validator>(
                 .into_values()
                 .flat_map(|bmm_requests| bmm_requests.into_values().flatten())
                 .collect();
+            // The competing deposits that this block did not connect can never
+            // be connected either, as they do not spend the treasury UTXO that
+            // it created. Nothing else evicts them, and block production wedges
+            // on them for as long as they are mirrored.
+            let obsolete_seen_deposits = parent_child_rwtxn.with_child_mut(|child_rwtxn| {
+                validator.dbs.take_obsolete_seen_deposits(child_rwtxn)
+            })?;
+            for (ctip, seen_deposits) in obsolete_seen_deposits {
+                let first_deposit = seen_deposits.get(&ctip.outpoint).copied();
+                remove_mempool_txs.extend(competing_deposits(&seen_deposits, first_deposit));
+            }
             Ok(ConnectBlockRwTxnAction::Accept {
                 event,
                 remove_mempool_txs,
@@ -354,6 +374,31 @@ where
     }
 }
 
+/// An M5 deposit into an empty treasury does not spend a treasury UTXO, so
+/// competing first deposits for the same slot are not double-spends of each
+/// other, and all of them enter the mempool. Only the deposits of a single
+/// chain can ever be connected, so the deposits of the other chains must be
+/// reported as conflicts, and evicted once the treasury exists.
+///
+/// Returns the first deposit of the chain that `tx` extends, which is `txid`
+/// itself if `tx` starts a new chain.
+fn deposit_chain_root(seen_deposits: &SeenDeposits, tx: &Transaction, txid: Txid) -> Txid {
+    tx.input
+        .iter()
+        .find_map(|input| seen_deposits.get(&input.previous_output).copied())
+        .unwrap_or(txid)
+}
+
+/// Txids of the seen deposits that are not part of the chain rooted at
+/// `first_deposit`. See [`deposit_chain_root`].
+fn competing_deposits(seen_deposits: &SeenDeposits, first_deposit: Option<Txid>) -> HashSet<Txid> {
+    seen_deposits
+        .iter()
+        .filter(|(_, root)| Some(**root) != first_deposit)
+        .map(|(outpoint, _)| outpoint.txid)
+        .collect()
+}
+
 impl CusfEnforcer for Validator {
     type InvalidBlockReason = InvalidBlockReason;
     type SyncError = SyncError;
@@ -448,7 +493,7 @@ impl CusfEnforcer for Validator {
         // the transaction will not be accepted into the mempool.
         let handler = BlockHandler::new(&self.dbs, self.network, self.network_params);
         let res = if handler.validate_tx(&mut rwtxn, tx)? {
-            let (conflicts_with, weight_tweak) = if let Some(bmm_request) = parse_m8_tx(tx) {
+            let (mut conflicts_with, weight_tweak) = if let Some(bmm_request) = parse_m8_tx(tx) {
                 let txid = tx.compute_txid();
                 let conflicts_with = {
                     let mut seen_bmm_request_txs = self
@@ -476,7 +521,6 @@ impl CusfEnforcer for Validator {
                         bmm_request.sidechain_block_hash,
                     )
                     .map_err(db::Error::from)?;
-                rwtxn.commit()?;
 
                 /// Weight, in wu, of the BMM accept (M7) coinbase output that block
                 /// production appends for an accepted BMM request (M8).
@@ -492,6 +536,48 @@ impl CusfEnforcer for Validator {
             } else {
                 (HashSet::new(), 0)
             };
+            // Treasury outputs that this tx creates for slots whose treasury
+            // does not exist yet, ie. the M5 deposits that
+            // `deposit_chain_root` must reconcile. A deposit into a slot that
+            // already has a ctip must spend it, so competing deposits there
+            // are ordinary double-spends that never coexist in the mempool,
+            // and an inactive slot has no treasury at all.
+            let active_sidechains = &self.dbs.active_sidechains;
+            let mut new_treasury_vouts = Vec::new();
+            for (vout, output) in tx.output.iter().enumerate() {
+                let Ok((_input, sidechain_number)) =
+                    parse_op_drivechain(output.script_pubkey.as_bytes())
+                else {
+                    continue;
+                };
+                if !active_sidechains
+                    .sidechain()
+                    .contains_key(&rwtxn, &sidechain_number)
+                    .map_err(db::Error::from)?
+                    || active_sidechains
+                        .ctip()
+                        .contains_key(&rwtxn, &sidechain_number)
+                        .map_err(db::Error::from)?
+                {
+                    continue;
+                }
+                new_treasury_vouts.push((sidechain_number, vout as u32));
+            }
+            if !new_treasury_vouts.is_empty() {
+                let txid = tx.compute_txid();
+                for (sidechain_number, vout) in new_treasury_vouts {
+                    let seen_deposits = self.dbs.get_seen_deposits(&rwtxn, sidechain_number)?;
+                    let first_deposit = deposit_chain_root(&seen_deposits, tx, txid);
+                    conflicts_with.extend(competing_deposits(&seen_deposits, Some(first_deposit)));
+                    let () = self.dbs.put_seen_deposit(
+                        &mut rwtxn,
+                        sidechain_number,
+                        OutPoint { txid, vout },
+                        first_deposit,
+                    )?;
+                }
+            }
+            rwtxn.commit()?;
             TxAcceptAction::Accept {
                 conflicts_with,
                 weight_tweak,
@@ -545,11 +631,16 @@ pub(crate) fn get_ctips_after(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
+
+    use bitcoin::{Amount, OutPoint, Transaction, Txid, hashes::Hash as _};
     use miette::IntoDiagnostic as _;
 
+    use super::{SeenDeposits, competing_deposits, deposit_chain_root};
     use crate::{
         messages::CoinbaseBuilder,
-        types::{BmmCommitment, SidechainNumber},
+        types::{BmmCommitment, Ctip, SidechainNumber},
+        validator::test_utils::create_test_dbs,
     };
 
     /// `TxAcceptAction::weight_tweak` is specified in weight units, so the
@@ -570,6 +661,138 @@ mod tests {
             ));
         };
         assert_eq!(192, bmm_accept_txout.weight().to_wu() as i64);
+        Ok(())
+    }
+
+    fn dummy_txid(byte: u8) -> Txid {
+        Txid::from_byte_array([byte; 32])
+    }
+
+    /// Spend the treasury outpoints (`txid`, 0) of the provided txids.
+    fn tx_spending(txids: &[Txid]) -> Transaction {
+        Transaction {
+            version: bitcoin::transaction::Version::TWO,
+            lock_time: bitcoin::locktime::absolute::LockTime::ZERO,
+            input: txids
+                .iter()
+                .map(|txid| bitcoin::TxIn {
+                    previous_output: OutPoint {
+                        txid: *txid,
+                        vout: 0,
+                    },
+                    script_sig: bitcoin::ScriptBuf::new(),
+                    sequence: bitcoin::Sequence::MAX,
+                    witness: bitcoin::Witness::new(),
+                })
+                .collect(),
+            output: Vec::new(),
+        }
+    }
+
+    /// Seen deposits for a chain `a0 -> a1 -> a2` into an empty treasury, and
+    /// a competing first deposit `b0`.
+    fn competing_seen_deposits() -> (SeenDeposits, [Txid; 4]) {
+        let [a0, a1, a2, b0] = [0xa0, 0xa1, 0xa2, 0xb0].map(dummy_txid);
+        let seen_deposits = [(a0, a0), (a1, a0), (a2, a0), (b0, b0)]
+            .into_iter()
+            .map(|(txid, first_deposit)| (OutPoint { txid, vout: 0 }, first_deposit))
+            .collect();
+        (seen_deposits, [a0, a1, a2, b0])
+    }
+
+    /// A deposit that extends a seen chain of deposits into an empty treasury
+    /// is compatible with every other deposit in that chain, however deep it
+    /// is, and conflicts only with the deposits of competing chains.
+    #[test]
+    fn deposit_conflicts_are_limited_to_competing_chains() {
+        let (seen_deposits, [a0, a1, a2, b0]) = competing_seen_deposits();
+        // A deposit extending the tip of the `a0` chain is itself part of that
+        // chain, and conflicts with `b0` only.
+        let a3 = dummy_txid(0xa3);
+        let first_deposit = deposit_chain_root(&seen_deposits, &tx_spending(&[a2]), a3);
+        assert_eq!(first_deposit, a0);
+        assert_eq!(
+            competing_deposits(&seen_deposits, Some(first_deposit)),
+            HashSet::from_iter([b0])
+        );
+        // A deposit that starts a new chain conflicts with every deposit of
+        // both seen chains.
+        let c0 = dummy_txid(0xc0);
+        let first_deposit = deposit_chain_root(&seen_deposits, &tx_spending(&[]), c0);
+        assert_eq!(first_deposit, c0);
+        assert_eq!(
+            competing_deposits(&seen_deposits, Some(first_deposit)),
+            HashSet::from_iter([a0, a1, a2, b0])
+        );
+    }
+
+    /// Competing deposits into the same empty treasury must all be retained,
+    /// per slot, until a block creates the treasury. The deposits that lost
+    /// are then evicted, and the slot is no longer tracked.
+    #[test]
+    fn obsolete_seen_deposits_are_taken_once_the_treasury_exists() -> miette::Result<()> {
+        let (_dir, dbs) = create_test_dbs()?;
+        let mut rwtxn = dbs.write_txn().into_diagnostic()?;
+        let sidechain_number = SidechainNumber(1);
+        let (seen_deposits, [a0, a1, _a2, b0]) = competing_seen_deposits();
+        for (outpoint, first_deposit) in &seen_deposits {
+            let () = dbs
+                .put_seen_deposit(&mut rwtxn, sidechain_number, *outpoint, *first_deposit)
+                .into_diagnostic()?;
+        }
+        assert_eq!(
+            dbs.get_seen_deposits(&rwtxn, sidechain_number)
+                .into_diagnostic()?,
+            seen_deposits
+        );
+        // Deposits are not reported for other slots.
+        assert!(
+            dbs.get_seen_deposits(&rwtxn, SidechainNumber(2))
+                .into_diagnostic()?
+                .is_empty()
+        );
+        // While the treasury does not exist, the seen deposits are still
+        // needed to reconcile further deposits.
+        assert!(
+            dbs.take_obsolete_seen_deposits(&mut rwtxn)
+                .into_diagnostic()?
+                .is_empty()
+        );
+        // Connecting `a1` creates the treasury, so the losers of the race are
+        // reported for eviction, and the slot is dropped.
+        let ctip = Ctip {
+            outpoint: OutPoint { txid: a1, vout: 0 },
+            value: Amount::ONE_BTC,
+        };
+        let _seq: u64 = dbs
+            .active_sidechains
+            .put_ctip(&mut rwtxn, sidechain_number, &ctip)
+            .into_diagnostic()?;
+        let obsolete = dbs
+            .take_obsolete_seen_deposits(&mut rwtxn)
+            .into_diagnostic()?;
+        let [(obsolete_ctip, obsolete_seen_deposits)] = obsolete.as_slice() else {
+            return Err(miette::miette!(
+                "expected exactly one slot's seen deposits, got {}",
+                obsolete.len()
+            ));
+        };
+        assert_eq!(obsolete_ctip.outpoint, ctip.outpoint);
+        assert_eq!(
+            competing_deposits(
+                obsolete_seen_deposits,
+                obsolete_seen_deposits.get(&ctip.outpoint).copied()
+            ),
+            // Only the `b0` chain lost: `a0` and `a2` belong to the chain that
+            // `a1` extends, and remain connectable.
+            HashSet::from_iter([b0])
+        );
+        assert_eq!(a0, obsolete_seen_deposits[&ctip.outpoint]);
+        assert!(
+            dbs.get_seen_deposits(&rwtxn, sidechain_number)
+                .into_diagnostic()?
+                .is_empty()
+        );
         Ok(())
     }
 }

--- a/lib/validator/dbs/mod.rs
+++ b/lib/validator/dbs/mod.rs
@@ -1,9 +1,10 @@
 use std::{
+    collections::HashMap,
     num::NonZeroU64,
     path::{Path, PathBuf},
 };
 
-use bitcoin::{Amount, OutPoint};
+use bitcoin::{Amount, OutPoint, Txid};
 use fallible_iterator::FallibleIterator;
 use heed_types::SerdeBincode;
 use ordermap::OrderMap;
@@ -320,6 +321,11 @@ pub enum CreateDbsError {
 pub type ProposalIdToSidechain =
     DatabaseUnique<SerdeBincode<SidechainProposalId>, SerdeBincode<Sidechain>>;
 
+/// Unconfirmed M5 deposits into the empty treasury of a single sidechain slot.
+/// Maps the treasury outpoint that each deposit creates to the txid of the
+/// first deposit in its chain.
+pub type SeenDeposits = HashMap<OutPoint, Txid>;
+
 #[derive(Clone)]
 pub(super) struct Dbs {
     env: Env,
@@ -330,10 +336,14 @@ pub(super) struct Dbs {
     pub _leading_by_50: DatabaseUnique<UnitKey, SerdeBincode<Vec<[u8; 32]>>>,
     pub _previous_votes: DatabaseUnique<UnitKey, SerdeBincode<Vec<[u8; 32]>>>,
     pub proposal_id_to_sidechain: ProposalIdToSidechain,
+    /// Mempool state rather than chain state: used for determining conflicts
+    /// between unconfirmed M5 deposits into an empty treasury. Only ever
+    /// populated for slots whose treasury does not exist yet.
+    seen_deposits: DatabaseUnique<SerdeBincode<SidechainNumber>, SerdeBincode<SeenDeposits>>,
 }
 
 impl Dbs {
-    const NUM_DBS: u32 = ActiveSidechainDbs::NUM_DBS + BlockHashDbs::NUM_DBS + 4;
+    const NUM_DBS: u32 = ActiveSidechainDbs::NUM_DBS + BlockHashDbs::NUM_DBS + 5;
 
     pub fn new(data_dir: &Path, network: bitcoin::Network) -> Result<Self, CreateDbsError> {
         let db_dir = data_dir.join(format!("{network}.mdb"));
@@ -361,6 +371,8 @@ impl Dbs {
         let previous_votes = DatabaseUnique::create(&env, &mut rwtxn, "previous_votes")?;
         let proposal_id_to_sidechain =
             DatabaseUnique::create(&env, &mut rwtxn, "proposal_id_to_sidechain")?;
+        let seen_deposits =
+            DatabaseUnique::create(&env, &mut rwtxn, "sidechain_number_to_seen_deposits")?;
         let () = rwtxn.commit()?;
 
         tracing::info!("Created validator DBs in {}", db_dir.display());
@@ -372,7 +384,59 @@ impl Dbs {
             _leading_by_50: leading_by_50,
             _previous_votes: previous_votes,
             proposal_id_to_sidechain,
+            seen_deposits,
         })
+    }
+
+    /// Seen unconfirmed deposits into the empty treasury of a sidechain slot.
+    pub fn get_seen_deposits(
+        &self,
+        rotxn: &RoTxn,
+        sidechain_number: SidechainNumber,
+    ) -> Result<SeenDeposits, db::Error> {
+        Ok(self
+            .seen_deposits
+            .try_get(rotxn, &sidechain_number)?
+            .unwrap_or_default())
+    }
+
+    pub fn put_seen_deposit(
+        &self,
+        rwtxn: &mut RwTxn,
+        sidechain_number: SidechainNumber,
+        outpoint: OutPoint,
+        first_deposit: Txid,
+    ) -> Result<(), db::Error> {
+        let mut seen_deposits = self.get_seen_deposits(rwtxn, sidechain_number)?;
+        let _ = seen_deposits.insert(outpoint, first_deposit);
+        self.seen_deposits
+            .put(rwtxn, &sidechain_number, &seen_deposits)?;
+        Ok(())
+    }
+
+    /// Seen deposits are only tracked while the treasury for a slot does not
+    /// exist yet, so once a block has created it, they are obsolete. Delete
+    /// and return the seen deposits for every such slot, paired with the ctip
+    /// that now exists.
+    pub fn take_obsolete_seen_deposits(
+        &self,
+        rwtxn: &mut RwTxn,
+    ) -> Result<Vec<(Ctip, SeenDeposits)>, db::Error> {
+        let seen_deposits: Vec<(SidechainNumber, SeenDeposits)> =
+            self.seen_deposits.iter(rwtxn)?.collect()?;
+        let mut res = Vec::new();
+        for (sidechain_number, seen_deposits) in seen_deposits {
+            let Some(ctip) = self
+                .active_sidechains
+                .ctip()
+                .try_get(rwtxn, &sidechain_number)?
+            else {
+                continue;
+            };
+            let _ = self.seen_deposits.delete(rwtxn, &sidechain_number)?;
+            res.push((ctip, seen_deposits));
+        }
+        Ok(res)
     }
 
     pub fn read_txn(&self) -> Result<RoTxn<'_, heed::WithTls>, env::error::ReadTxn> {


### PR DESCRIPTION
Two first deposits into the same empty treasury do not spend a treasury UTXO, so they are not double-spends of each other and both sit in the mempool at once. Only one can ever connect. In `Validator::connect_block` (`lib/validator/cusf_enforcer.rs`) the producer that mirrors both keeps offering a template containing both and then cannot finalize it — for that block, and for every block after the winner confirms, because nothing evicts the loser. In GetBlockTemplate mode this wedges block production.

The fix tracks unconfirmed first-deposits per empty-treasury slot in a new `SeenDeposits` mempool-state map, reconciles competing deposit chains on `accept_tx`, and once a block creates the treasury evicts the losing chains' deposits from the mirror via `take_obsolete_seen_deposits`.

Tests: adds a `test_competing_deposits` integration test plus unit tests for `deposit_chain_root`/`competing_deposits` and the obsolete-deposit sweep.

This only affects the enforcer's own mempool mirror and the templates it produces, not what blocks it validates.