### PR TITLE
Avoid periodic wallet-sync lock starvation and reject stale BMM parents

### DIFF
--- a/lib/wallet/error.rs
+++ b/lib/wallet/error.rs
@@ -161,6 +161,9 @@ pub struct BdkWalletPersist {
 
 #[derive(Debug, Diagnostic, Error)]
 pub enum WalletSync {
+    #[error("Esplora wallet synchronization exceeded its 120-second network deadline")]
+    #[diagnostic(code(esplora_sync_deadline))]
+    EsploraSyncDeadline,
     #[error(transparent)]
     #[diagnostic(code(bdk_wallet_connect))]
     BdkWalletConnect(#[from] bdk_wallet::chain::local_chain::CannotConnectError),
@@ -1039,6 +1042,10 @@ impl ToStatus for SendWalletTransaction {
 #[derive(Debug, Diagnostic, Error)]
 pub enum BuildBmmTx {
     #[error(transparent)]
+    GetMainchainTip(#[from] validator::GetMainchainTipError),
+    #[error("BMM parent changed while waiting for the wallet lock")]
+    StaleParent,
+    #[error(transparent)]
     CreateTx(#[from] bdk_wallet::error::CreateTxError),
     #[error(transparent)]
     NotUnlocked(#[from] NotUnlocked),
@@ -1049,6 +1056,10 @@ pub enum BuildBmmTx {
 impl ToStatus for BuildBmmTx {
     fn builder(&self) -> StatusBuilder<'_> {
         match self {
+            Self::GetMainchainTip(err) => StatusBuilder::new(err),
+            Self::StaleParent => {
+                StatusBuilder::new(self).code(connectrpc::ErrorCode::FailedPrecondition)
+            }
             Self::CreateTx(err) => StatusBuilder::new(err),
             Self::NotUnlocked(err) => err.builder(),
             Self::Script(err) => StatusBuilder::new(err),

--- a/lib/wallet/locks.rs
+++ b/lib/wallet/locks.rs
@@ -58,6 +58,9 @@ pub(in crate::wallet) type FullScanGuard<'a> = tokio::sync::MutexGuard<'a, ()>;
 /// The full scan slot, the BDK wallet, and its persistence, which must
 /// always be taken in that order.
 pub(in crate::wallet) struct WalletLocks {
+    /// Invalidates network snapshots on every possible wallet mutation,
+    /// including wallet replacement and upgradable/full-scan access.
+    revision: std::sync::atomic::AtomicU64,
     /// Held for the duration of a full scan. Outermost of the three: a scan
     /// takes this before the wallet lock, and nothing takes it while a wallet
     /// guard is held.
@@ -76,6 +79,7 @@ pub(in crate::wallet) struct WalletLocks {
 impl WalletLocks {
     pub(in crate::wallet) fn new(wallet: Option<BdkWallet>, database: Persistence) -> Self {
         Self {
+            revision: std::sync::atomic::AtomicU64::new(0),
             full_scan: tokio::sync::Mutex::new(()),
             bitcoin_wallet: async_lock::RwLock::new(wallet),
             bdk_db: tokio::sync::Mutex::new(database),
@@ -123,6 +127,7 @@ impl WalletLocks {
             "upgradable read lock",
         )
         .await;
+        self.invalidate_snapshot();
         RwLockUpgradableReadGuardSome::new(guard).ok_or(error::NotUnlocked)
     }
 
@@ -130,7 +135,49 @@ impl WalletLocks {
         &self,
     ) -> Result<RwLockWriteGuardSome<'_, BdkWallet>, error::NotUnlocked> {
         let guard = acquire_warn_slow(self.bitcoin_wallet.write(), "write lock").await;
+        self.invalidate_snapshot();
         RwLockWriteGuardSome::new(guard).ok_or(error::NotUnlocked)
+    }
+
+    /// Invalidate snapshots taken while a full scan held its upgradable reader.
+    /// Acquisition-time invalidation alone cannot cover those later snapshots.
+    pub(in crate::wallet) async fn upgrade<'a>(
+        &'a self,
+        guard: RwLockUpgradableReadGuardSome<'a, BdkWallet>,
+    ) -> RwLockWriteGuardSome<'a, BdkWallet> {
+        let guard = RwLockUpgradableReadGuardSome::upgrade(guard).await;
+        self.invalidate_snapshot();
+        guard
+    }
+
+    /// Read only while holding a wallet read guard.
+    pub(in crate::wallet) fn revision(&self) -> u64 {
+        self.revision.load(std::sync::atomic::Ordering::SeqCst)
+    }
+
+    fn invalidate_snapshot(&self) {
+        self.revision
+            .fetch_update(
+                std::sync::atomic::Ordering::SeqCst,
+                std::sync::atomic::Ordering::SeqCst,
+                |value| value.checked_add(1),
+            )
+            .expect("wallet revision exhausted");
+    }
+
+    /// Atomically check the network snapshot and acquire mutation permission.
+    pub(in crate::wallet) async fn write_if_unchanged(
+        &self,
+        revision: u64,
+    ) -> Result<Option<RwLockWriteGuardSome<'_, BdkWallet>>, error::NotUnlocked> {
+        let guard = acquire_warn_slow(self.bitcoin_wallet.write(), "sync write lock").await;
+        if self.revision() != revision {
+            return Ok(None);
+        }
+        self.invalidate_snapshot();
+        RwLockWriteGuardSome::new(guard)
+            .map(Some)
+            .ok_or(error::NotUnlocked)
     }
 
     /// The wallet slot itself, including when it is empty: for asking whether
@@ -144,6 +191,8 @@ impl WalletLocks {
     pub(in crate::wallet) async fn write_slot(
         &self,
     ) -> async_lock::RwLockWriteGuard<'_, Option<BdkWallet>> {
-        acquire_warn_slow(self.bitcoin_wallet.write(), "write lock (slot)").await
+        let guard = acquire_warn_slow(self.bitcoin_wallet.write(), "write lock (slot)").await;
+        self.invalidate_snapshot();
+        guard
     }
 }

--- a/lib/wallet/mod.rs
+++ b/lib/wallet/mod.rs
@@ -2225,7 +2225,7 @@ mod tests {
 
         let reader = locks.read().await.unwrap();
         let snapshot = locks.revision();
-        let _owned_request = reader.start_sync_with_revealed_spks().build();
+        let _owned_request = super::sync::transaction_sync_request(&reader);
         drop(reader);
         // The production request owns its data: a writer must remain available
         // while that request is alive and a backend has not yet returned.
@@ -2263,6 +2263,60 @@ mod tests {
         drop(locks.write_if_unchanged(fresh).await.unwrap().unwrap());
         // Two responses from the same snapshot cannot both apply.
         assert!(locks.write_if_unchanged(fresh).await.unwrap().is_none());
+    }
+
+    #[test]
+    fn transaction_sync_preserves_scripts_and_expected_history_without_chain_tip() {
+        let (mut wallet, _) = get_funded_wallet_wpkh();
+        wallet.reveal_next_address(KeychainKind::External);
+        wallet.reveal_next_address(KeychainKind::Internal);
+        let mut request = super::sync::transaction_sync_request(&wallet);
+        let mut reference = wallet
+            .start_sync_with_revealed_spks_at(request.start_time())
+            .build();
+        assert!(request.chain_tip().is_none());
+        assert!(reference.chain_tip().is_some());
+        assert_eq!(request.start_time(), reference.start_time());
+        let scripts = |request: &mut bdk_chain::bdk_core::spk_client::SyncRequest<_>| {
+            request
+                .iter_spks_with_expected_txids()
+                .map(|entry| (entry.spk, entry.expected_txids))
+                .collect::<Vec<_>>()
+        };
+        let actual = scripts(&mut request);
+        assert!(actual.iter().any(|(_, txids)| !txids.is_empty()));
+        assert_eq!(actual, scripts(&mut reference));
+        assert_eq!(
+            request.iter_txids().collect::<Vec<_>>(),
+            reference.iter_txids().collect::<Vec<_>>()
+        );
+        assert_eq!(
+            request.iter_outpoints().collect::<Vec<_>>(),
+            reference.iter_outpoints().collect::<Vec<_>>()
+        );
+    }
+
+    #[tokio::test]
+    async fn transaction_sync_does_not_request_an_esplora_checkpoint() {
+        use bdk_esplora::EsploraAsyncExt as _;
+        let (external, internal) = descriptors(Network::Bitcoin);
+        let wallet = bdk_wallet::Wallet::create(external, internal)
+            .network(Network::Bitcoin)
+            .create_wallet_no_persist()
+            .unwrap();
+        let request = super::sync::transaction_sync_request(&wallet);
+        assert_eq!(request.progress().spks_remaining, 0);
+        // No scripts means no transaction queries. Supplying a chain tip would
+        // nevertheless make the real backend query /blocks and fail here.
+        // The closed local listener avoids any external service dependency.
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let endpoint = format!("http://{}", listener.local_addr().unwrap());
+        drop(listener);
+        let client = bdk_esplora::esplora_client::Builder::new(&endpoint)
+            .build_async()
+            .unwrap();
+        let response = client.sync(request, 1).await.unwrap();
+        assert!(response.chain_update.is_none());
     }
 
     async fn empty_database(dir: &temp_dir::TempDir) -> Persistence {

--- a/lib/wallet/mod.rs
+++ b/lib/wallet/mod.rs
@@ -2201,11 +2201,16 @@ mod tests {
             .await
             .unwrap();
         let locks = super::locks::WalletLocks::new(Some(wallet), database);
-        let scan = locks.upgradable_read().await.unwrap();
-        let reader = locks.read().await.unwrap();
-        let snapshot = locks.revision();
-        drop(reader);
-        let writer = locks.upgrade(scan).await;
+        let snapshot;
+        let writer = locks
+            .upgrade({
+                let scan = locks.upgradable_read().await.unwrap();
+                let reader = locks.read().await.unwrap();
+                snapshot = locks.revision();
+                drop(reader);
+                scan
+            })
+            .await;
         drop(writer);
         assert!(locks.write_if_unchanged(snapshot).await.unwrap().is_none());
         let reader = locks.read().await.unwrap();

--- a/lib/wallet/mod.rs
+++ b/lib/wallet/mod.rs
@@ -1868,8 +1868,17 @@ impl Wallet {
 
         let mut wallet_write = self.inner.write_wallet().await?;
         let psbt = tokio::task::block_in_place(|| {
+            // The RPC's earlier check predates potentially slow wallet-lock
+            // acquisition. Never build a bid already expired at this point.
+            let tip = self.inner.validator().get_mainchain_tip()?;
+            if tip
+                != crate::convert::bdk_block_hash_to_bitcoin_block_hash(prev_mainchain_block_hash)
+            {
+                return Err(error::BuildBmmTx::StaleParent);
+            }
             wallet_write
                 .with_mut(|wallet| Self::build_bmm_psbt(wallet, &message, bid_amount, locktime))
+                .map_err(error::BuildBmmTx::from)
         })?;
 
         Ok(psbt)
@@ -2182,6 +2191,78 @@ mod tests {
             .await
             .expect("an empty database must yield a freshly created wallet");
         wallet.peek_address(KeychainKind::External, 0).to_string()
+    }
+
+    #[tokio::test]
+    async fn full_scan_upgrade_invalidates_a_later_sync_snapshot() {
+        let dir = temp_dir::TempDir::new().unwrap();
+        let mut database = empty_database(&dir).await;
+        let wallet = open_wallet(&mut database, Network::Bitcoin, Some(0))
+            .await
+            .unwrap();
+        let locks = super::locks::WalletLocks::new(Some(wallet), database);
+        let scan = locks.upgradable_read().await.unwrap();
+        let reader = locks.read().await.unwrap();
+        let snapshot = locks.revision();
+        drop(reader);
+        let writer = locks.upgrade(scan).await;
+        drop(writer);
+        assert!(locks.write_if_unchanged(snapshot).await.unwrap().is_none());
+        let reader = locks.read().await.unwrap();
+        let fresh = locks.revision();
+        drop(reader);
+        assert!(locks.write_if_unchanged(fresh).await.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn sync_snapshot_rejects_writer_and_wallet_slot_changes() {
+        let dir = temp_dir::TempDir::new().unwrap();
+        let mut database = empty_database(&dir).await;
+        let wallet = open_wallet(&mut database, Network::Bitcoin, Some(0))
+            .await
+            .unwrap();
+        let locks = super::locks::WalletLocks::new(Some(wallet), database);
+
+        let reader = locks.read().await.unwrap();
+        let snapshot = locks.revision();
+        let _owned_request = reader.start_sync_with_revealed_spks().build();
+        drop(reader);
+        // The production request owns its data: a writer must remain available
+        // while that request is alive and a backend has not yet returned.
+        let writer = tokio::time::timeout(std::time::Duration::from_secs(1), locks.write())
+            .await
+            .expect("network snapshot must not retain a wallet lock")
+            .unwrap();
+        drop(writer);
+        assert!(locks.write_if_unchanged(snapshot).await.unwrap().is_none());
+
+        let reader = locks.read().await.unwrap();
+        let before_lock = locks.revision();
+        drop(reader);
+        let saved = locks.write_slot().await.take().unwrap();
+        assert!(
+            locks
+                .write_if_unchanged(before_lock)
+                .await
+                .unwrap()
+                .is_none()
+        );
+        assert!(locks.read().await.is_err());
+        *locks.write_slot().await = Some(saved);
+        assert!(
+            locks
+                .write_if_unchanged(before_lock)
+                .await
+                .unwrap()
+                .is_none()
+        );
+
+        let reader = locks.read().await.unwrap();
+        let fresh = locks.revision();
+        drop(reader);
+        drop(locks.write_if_unchanged(fresh).await.unwrap().unwrap());
+        // Two responses from the same snapshot cannot both apply.
+        assert!(locks.write_if_unchanged(fresh).await.unwrap().is_none());
     }
 
     async fn empty_database(dir: &temp_dir::TempDir) -> Persistence {

--- a/lib/wallet/sync.rs
+++ b/lib/wallet/sync.rs
@@ -9,10 +9,8 @@ use tokio::time::Instant;
 use tracing::instrument;
 
 use crate::wallet::{
-    BdkWallet, ChainSourceClient, Persistence, WalletInner, error,
-    locks::FullScanGuard,
-    sync_state::SharedSyncState,
-    util::{RwLockUpgradableReadGuardSome, RwLockWriteGuardSome},
+    BdkWallet, ChainSourceClient, Persistence, WalletInner, error, locks::FullScanGuard,
+    sync_state::SharedSyncState, util::RwLockWriteGuardSome,
 };
 
 /// Write-locked wallet and database, plus the sync state to stamp on commit.
@@ -41,6 +39,55 @@ impl SyncWriteGuard<'_> {
 }
 
 const ESPLORA_PARALLEL_REQUESTS: usize = 25;
+
+async fn bounded_sync_fetch<T>(fetch: impl Future<Output = T>) -> Result<T, error::WalletSync> {
+    sync_fetch_with_deadline(fetch, std::time::Duration::from_secs(120)).await
+}
+
+async fn sync_fetch_with_deadline<T>(
+    fetch: impl Future<Output = T>,
+    deadline: std::time::Duration,
+) -> Result<T, error::WalletSync> {
+    tokio::time::timeout(deadline, fetch)
+        .await
+        .map_err(|_| error::WalletSync::EsploraSyncDeadline)
+}
+
+#[cfg(test)]
+mod deadline_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn stalled_fetch_releases_guard_without_applying_update() {
+        let lock = async_lock::RwLock::new(0_u32);
+        let attempt = async {
+            let _guard = lock.upgradable_read().await;
+            sync_fetch_with_deadline(
+                std::future::pending::<()>(),
+                std::time::Duration::from_millis(10),
+            )
+            .await?;
+            panic!("timed-out fetch must never reach application/persistence");
+            #[allow(unreachable_code)]
+            Ok::<(), error::WalletSync>(())
+        };
+        assert!(matches!(
+            attempt.await,
+            Err(error::WalletSync::EsploraSyncDeadline)
+        ));
+        let guard = lock.try_write().expect("timeout must release wallet guard");
+        assert_eq!(*guard, 0);
+    }
+
+    #[tokio::test]
+    async fn completed_fetch_preserves_result() {
+        assert_eq!(bounded_sync_fetch(async { 42_u32 }).await.unwrap(), 42);
+        let result: Result<(), &str> = bounded_sync_fetch(async { Err("backend failure") })
+            .await
+            .unwrap();
+        assert_eq!(result, Err("backend failure"));
+    }
+}
 
 /// Number of consecutive unused addresses that a full scan must observe before
 /// considering a keychain exhausted. Larger than the BIP44 gap limit of 20,
@@ -169,12 +216,12 @@ impl WalletInner {
     ) -> Result<Option<SyncWriteGuard<'_>>, error::WalletSync> {
         let start = SystemTime::now();
         tracing::trace!("starting wallet sync");
-        // Hold an upgradable lock for the duration of the sync, to prevent other
-        // updates to the wallet between fetching an update via the chain source,
-        // and applying the update.
+        // Snapshot under a read lock, then release it before network I/O.
+        // Every possible writer invalidates the revision; stale responses are
+        // discarded under the reacquired write lock rather than merged blindly.
         // Don't error out here if the wallet is locked, just skip the sync.
         let wallet_read = {
-            match self.read_wallet_upgradable().await {
+            match self.read_wallet().await {
                 Ok(wallet_read) => wallet_read,
                 // "Accepted" errors, that aren't really errors in this case.
                 Err(error::NotUnlocked) => {
@@ -183,8 +230,9 @@ impl WalletInner {
                 }
             }
         };
-        tracing::trace!("acquired upgradable read lock on wallet");
+        let revision = self.locks.revision();
         let request = wallet_read.start_sync_with_revealed_spks().build();
+        drop(wallet_read);
 
         tracing::trace!(
             spks = request.progress().spks_remaining,
@@ -208,9 +256,13 @@ impl WalletInner {
                 ("electrum", self.record_sync_backend_result(result)?)
             }
             ChainSourceClient::Esplora(esplora_client) => {
-                let result = esplora_client
-                    .sync(request, ESPLORA_PARALLEL_REQUESTS)
-                    .await;
+                // Bound only the read-only network phase. Cancelling the
+                // apply/persist phase could leave memory ahead of disk.
+                // No wallet guard is held during this network phase.
+                let result =
+                    bounded_sync_fetch(esplora_client.sync(request, ESPLORA_PARALLEL_REQUESTS))
+                        .await;
+                let result = self.record_sync_backend_result(result)?;
                 ("esplora", self.record_sync_backend_result(result)?)
             }
         };
@@ -227,8 +279,10 @@ impl WalletInner {
         }
 
         tracing::trace!("applying update");
-        // Upgrade wallet lock
-        let mut wallet_write = RwLockUpgradableReadGuardSome::upgrade(wallet_read).await;
+        let Some(mut wallet_write) = self.locks.write_if_unchanged(revision).await? else {
+            tracing::debug!("discarding wallet sync response after concurrent wallet change");
+            return Ok(None);
+        };
         wallet_write.with_mut(|wallet| wallet.apply_update(update))?;
         // The update re-adopts any stale BMM request that still sits in the
         // chain source's mempool view, re-locking its inputs. Evict again
@@ -408,7 +462,7 @@ impl WalletInner {
 
         // Applying the update reveals addresses up to the last active index of
         // each keychain, so that the persist below records which index we're at.
-        let mut wallet_write = RwLockUpgradableReadGuardSome::upgrade(wallet_read).await;
+        let mut wallet_write = self.locks.upgrade(wallet_read).await;
         let mut bdk_db = self.locks.db(&wallet_write).await;
 
         // A full scan re-adopts stale BMM requests still in the chain

--- a/lib/wallet/sync.rs
+++ b/lib/wallet/sync.rs
@@ -2,7 +2,7 @@
 
 use std::time::SystemTime;
 
-use bdk_chain::bdk_core;
+use bdk_chain::{bdk_core, keychain_txout::SyncRequestBuilderExt as _};
 use bdk_esplora::EsploraAsyncExt as _;
 use futures::TryFutureExt;
 use tokio::time::Instant;
@@ -39,6 +39,25 @@ impl SyncWriteGuard<'_> {
 }
 
 const ESPLORA_PARALLEL_REQUESTS: usize = 25;
+
+/// Request transactions without delegating the wallet's chain to the backend.
+/// BDK's wallet helper also supplies a chain tip, causing both supported
+/// backends to return a checkpoint that this enforcer intentionally rejects.
+/// Preserve its revealed scripts and expected transaction histories so missing
+/// mempool transactions can still be detected and evicted.
+pub(super) fn transaction_sync_request(
+    wallet: &bdk_wallet::Wallet,
+) -> bdk_core::spk_client::SyncRequest<(bdk_wallet::KeychainKind, u32)> {
+    bdk_core::spk_client::SyncRequest::builder()
+        .revealed_spks_from_indexer(wallet.spk_index(), ..)
+        .expected_spk_txids(wallet.tx_graph().list_expected_spk_txids(
+            wallet.local_chain(),
+            wallet.local_chain().tip().block_id(),
+            wallet.spk_index(),
+            ..,
+        ))
+        .build()
+}
 
 async fn bounded_sync_fetch<T>(fetch: impl Future<Output = T>) -> Result<T, error::WalletSync> {
     sync_fetch_with_deadline(fetch, std::time::Duration::from_secs(120)).await
@@ -231,7 +250,7 @@ impl WalletInner {
             }
         };
         let revision = self.locks.revision();
-        let request = wallet_read.start_sync_with_revealed_spks().build();
+        let request = transaction_sync_request(&wallet_read);
         drop(wallet_read);
 
         tracing::trace!(

--- a/lib/wallet/sync.rs
+++ b/lib/wallet/sync.rs
@@ -72,42 +72,6 @@ async fn sync_fetch_with_deadline<T>(
         .map_err(|_| error::WalletSync::EsploraSyncDeadline)
 }
 
-#[cfg(test)]
-mod deadline_tests {
-    use super::*;
-
-    #[tokio::test]
-    async fn stalled_fetch_releases_guard_without_applying_update() {
-        let lock = async_lock::RwLock::new(0_u32);
-        let attempt = async {
-            let _guard = lock.upgradable_read().await;
-            sync_fetch_with_deadline(
-                std::future::pending::<()>(),
-                std::time::Duration::from_millis(10),
-            )
-            .await?;
-            panic!("timed-out fetch must never reach application/persistence");
-            #[allow(unreachable_code)]
-            Ok::<(), error::WalletSync>(())
-        };
-        assert!(matches!(
-            attempt.await,
-            Err(error::WalletSync::EsploraSyncDeadline)
-        ));
-        let guard = lock.try_write().expect("timeout must release wallet guard");
-        assert_eq!(*guard, 0);
-    }
-
-    #[tokio::test]
-    async fn completed_fetch_preserves_result() {
-        assert_eq!(bounded_sync_fetch(async { 42_u32 }).await.unwrap(), 42);
-        let result: Result<(), &str> = bounded_sync_fetch(async { Err("backend failure") })
-            .await
-            .unwrap();
-        assert_eq!(result, Err("backend failure"));
-    }
-}
-
 /// Number of consecutive unused addresses that a full scan must observe before
 /// considering a keychain exhausted. Larger than the BIP44 gap limit of 20,
 /// since a recovered seed may have been used by a wallet that hands out
@@ -532,5 +496,39 @@ impl WalletInner {
                 Ok(())
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod deadline_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn stalled_fetch_releases_guard_without_applying_update() {
+        let lock = async_lock::RwLock::new(0_u32);
+        let attempt = async {
+            let _guard = lock.upgradable_read().await;
+            sync_fetch_with_deadline(
+                std::future::pending::<()>(),
+                std::time::Duration::from_millis(10),
+            )
+            .await
+            .map(|()| panic!("timed-out fetch must never reach application/persistence"))
+        };
+        assert!(matches!(
+            attempt.await,
+            Err(error::WalletSync::EsploraSyncDeadline)
+        ));
+        let value = *lock.try_write().expect("timeout must release wallet guard");
+        assert_eq!(value, 0);
+    }
+
+    #[tokio::test]
+    async fn completed_fetch_preserves_result() {
+        assert_eq!(bounded_sync_fetch(async { 42_u32 }).await.unwrap(), 42);
+        let result: Result<(), &str> = bounded_sync_fetch(async { Err("backend failure") })
+            .await
+            .unwrap();
+        assert_eq!(result, Err("backend failure"));
     }
 }


### PR DESCRIPTION
## Summary

- Release the periodic wallet-sync read lock before backend network I/O, allowing wallet writers to proceed during slow fetches.
- Discard fetched updates if any intervening writer, wallet replacement, or full-scan upgrade invalidated the snapshot revision.
- Bound the Esplora network phase to 120 seconds without cancelling apply/persistence, and report timeout through backend status.
- Recheck the BMM parent after acquiring the wallet write lock, rejecting an already-stale parent before PSBT construction.
- Build transaction-only sync requests, retaining revealed scripts and expected transaction histories but omitting the chain tip. BDK 3.1's wallet helper supplies a tip, which makes supported backends return a checkpoint that the enforcer then rejects—even if unchanged. Keep checkpoint rejection; validated mainchain handling remains authoritative.

## Tests and scope

Regression tests cover snapshot invalidation, wallet removal/replacement, full-scan upgrades, single-use update application, and fetch deadlines. Additional tests compare the transaction-only request against BDK's scripts/expected histories and exercise the real Esplora backend without a checkpoint request. On upstream base `7958ceffa997ffa905f046de71c8e3cf33437c2d`, `cargo test --locked --offline -p bip300301_enforcer_lib --lib` passed all 202 library tests (zero failures). `git diff --check` passes. Live installation is a separately pinned older source snapshot; upstream test results are not a claim that the upstream binary is installed.

This is intentionally draft pending live qualification and review. Full-scan network I/O still holds its upgradable lock. No dedicated end-to-end stale-parent concurrency or integrated reorg test is claimed. The parent recheck does not eliminate a tip race after PSBT construction. Revision invalidation is conservative: sustained writes may defer periodic synchronization.

No consensus rules, network-specific configuration, wallet credentials, deployment paths, or spending automation are included.
